### PR TITLE
test(scripts): extract growth-dashboard arg parser and cover it

### DIFF
--- a/scripts/growth-dashboard.mjs
+++ b/scripts/growth-dashboard.mjs
@@ -17,7 +17,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { parseGscImpressions } from "./audit-seo-snippets.mjs";
-import { buildWorklist } from "./lib/growth-dashboard.mjs";
+import {
+  buildWorklist,
+  parseGrowthDashboardArgs,
+} from "./lib/growth-dashboard.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -34,16 +37,6 @@ function loadEntries() {
   return atlas.entries ?? [];
 }
 
-function parseArgs(argv) {
-  const args = { json: false, gsc: "", limit: 50 };
-  for (let i = 0; i < argv.length; i += 1) {
-    if (argv[i] === "--json") args.json = true;
-    else if (argv[i] === "--gsc") args.gsc = argv[++i] || "";
-    else if (argv[i] === "--limit") args.limit = Number(argv[++i]) || 50;
-  }
-  return args;
-}
-
 function loadGsc(file) {
   if (!file) return new Map();
   const absolute = path.isAbsolute(file) ? file : path.join(repoRoot, file);
@@ -51,7 +44,7 @@ function loadGsc(file) {
 }
 
 function main(argv = process.argv.slice(2)) {
-  const args = parseArgs(argv);
+  const args = parseGrowthDashboardArgs(argv);
   const report = buildWorklist(loadEntries(), loadGsc(args.gsc), {
     limit: args.limit,
   });

--- a/scripts/lib/growth-dashboard.mjs
+++ b/scripts/lib/growth-dashboard.mjs
@@ -17,6 +17,20 @@ function hasText(value) {
   return String(value ?? "").trim().length > 0;
 }
 
+/**
+ * Parse the growth-dashboard CLI flags (--json, --gsc <path>, --limit <n>) into
+ * an options object. A non-numeric or zero --limit falls back to 50.
+ */
+export function parseGrowthDashboardArgs(argv) {
+  const args = { json: false, gsc: "", limit: 50 };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--json") args.json = true;
+    else if (argv[i] === "--gsc") args.gsc = argv[++i] || "";
+    else if (argv[i] === "--limit") args.limit = Number(argv[++i]) || 50;
+  }
+  return args;
+}
+
 /** Trust/coverage gaps for an entry (missing safety/privacy/source signals). */
 export function trustGaps(entry) {
   const gaps = [];

--- a/tests/growth-dashboard.test.ts
+++ b/tests/growth-dashboard.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { buildWorklist, trustGaps } from "../scripts/lib/growth-dashboard.mjs";
+import {
+  buildWorklist,
+  parseGrowthDashboardArgs,
+  trustGaps,
+} from "../scripts/lib/growth-dashboard.mjs";
 
 function entry(partial: Record<string, unknown>) {
   return {
@@ -75,5 +79,35 @@ describe("buildWorklist", () => {
     const first = buildWorklist(entries, new Map(), { limit: 2 });
     expect(first.items).toHaveLength(2);
     expect(first).toEqual(buildWorklist(entries, new Map(), { limit: 2 }));
+  });
+});
+
+describe("parseGrowthDashboardArgs", () => {
+  it("defaults to json off, no gsc, and limit 50", () => {
+    expect(parseGrowthDashboardArgs([])).toEqual({
+      json: false,
+      gsc: "",
+      limit: 50,
+    });
+  });
+
+  it("reads --json, --gsc and --limit", () => {
+    expect(
+      parseGrowthDashboardArgs(["--json", "--gsc", "gsc.csv", "--limit", "10"]),
+    ).toEqual({ json: true, gsc: "gsc.csv", limit: 10 });
+  });
+
+  it("falls back to '' for --gsc and 50 for a non-numeric/zero --limit", () => {
+    expect(parseGrowthDashboardArgs(["--gsc"]).gsc).toBe("");
+    expect(parseGrowthDashboardArgs(["--limit", "nope"]).limit).toBe(50);
+    expect(parseGrowthDashboardArgs(["--limit", "0"]).limit).toBe(50);
+  });
+
+  it("ignores unrecognized tokens", () => {
+    expect(parseGrowthDashboardArgs(["--nope", "stray"])).toEqual({
+      json: false,
+      gsc: "",
+      limit: 50,
+    });
   });
 });


### PR DESCRIPTION
### What & why

`scripts/growth-dashboard.mjs` parsed its `--json`/`--gsc`/`--limit` flags with a local `parseArgs` that had no tests. This hoists it into the existing `scripts/lib/growth-dashboard.mjs` (which the script already imports for `buildWorklist`) as `parseGrowthDashboardArgs` and uses it from the script.

### Changes

- `scripts/lib/growth-dashboard.mjs` - add `parseGrowthDashboardArgs`.
- `scripts/growth-dashboard.mjs` - import the shared parser; drop the local copy.
- `tests/growth-dashboard.test.ts` - add cases for the flag defaults, `--json` plus `--gsc` and `--limit`, the `''` / `50` fallbacks for a valueless `--gsc` and a non-numeric or zero `--limit`, and ignored tokens.

### Validation

- `node --check scripts/growth-dashboard.mjs` and `scripts/lib/growth-dashboard.mjs` - clean; the parser is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the CLI arguments parse identically. Build scripts are inside the coverage scope, so this adds real covered lines.
