### PR TITLE
test(scripts): extract download-package url helpers and cover them

### DIFF
--- a/scripts/lib/download-package-url.mjs
+++ b/scripts/lib/download-package-url.mjs
@@ -1,0 +1,20 @@
+// Pure download-URL classification behind scripts/validate-download-packages.mjs:
+// deciding whether a content entry declares a first-party (maintainer-verified)
+// package and whether its download URL points at a local /downloads/ artifact.
+// Split out so these checks can be unit-tested without the filesystem / unzip /
+// checksum layers the validator runs around them.
+
+/** True only when the entry is explicitly marked as a verified first-party package. */
+export function isFirstPartyPackage(data = {}) {
+  return data.packageVerified === true;
+}
+
+/** Coerce a download URL to a trimmed string (null/undefined become ""). */
+export function normalizeDownloadUrl(downloadUrl) {
+  return String(downloadUrl ?? "").trim();
+}
+
+/** True when the (normalized) download URL is a local /downloads/ artifact path. */
+export function isLocalDownloadUrl(downloadUrl) {
+  return normalizeDownloadUrl(downloadUrl).startsWith("/downloads/");
+}

--- a/scripts/validate-download-packages.mjs
+++ b/scripts/validate-download-packages.mjs
@@ -4,22 +4,16 @@ import { execFileSync } from "node:child_process";
 
 import { parseSafeFrontmatter } from "@heyclaude/registry/frontmatter";
 
+import {
+  isFirstPartyPackage,
+  isLocalDownloadUrl,
+  normalizeDownloadUrl,
+} from "./lib/download-package-url.mjs";
+
 const repoRoot = process.cwd();
 const contentRoot = path.join(repoRoot, "content");
 const failures = [];
 const warnings = [];
-
-function isFirstPartyPackage(data = {}) {
-  return data.packageVerified === true;
-}
-
-function normalizeDownloadUrl(downloadUrl) {
-  return String(downloadUrl ?? "").trim();
-}
-
-function isLocalDownloadUrl(downloadUrl) {
-  return normalizeDownloadUrl(downloadUrl).startsWith("/downloads/");
-}
 
 function unzipList(archivePath) {
   try {

--- a/tests/download-package-url.test.ts
+++ b/tests/download-package-url.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isFirstPartyPackage,
+  isLocalDownloadUrl,
+  normalizeDownloadUrl,
+} from "../scripts/lib/download-package-url.mjs";
+
+describe("isFirstPartyPackage", () => {
+  it("is true only when packageVerified is strictly true", () => {
+    expect(isFirstPartyPackage({ packageVerified: true })).toBe(true);
+  });
+
+  it("is false for missing, false, or truthy-but-not-true values", () => {
+    expect(isFirstPartyPackage()).toBe(false);
+    expect(isFirstPartyPackage({})).toBe(false);
+    expect(isFirstPartyPackage({ packageVerified: false })).toBe(false);
+    expect(isFirstPartyPackage({ packageVerified: "true" })).toBe(false);
+    expect(isFirstPartyPackage({ packageVerified: 1 })).toBe(false);
+  });
+});
+
+describe("normalizeDownloadUrl", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeDownloadUrl("  /downloads/a.zip  ")).toBe(
+      "/downloads/a.zip",
+    );
+  });
+
+  it("coerces null and undefined to an empty string", () => {
+    expect(normalizeDownloadUrl(null)).toBe("");
+    expect(normalizeDownloadUrl(undefined)).toBe("");
+    expect(normalizeDownloadUrl()).toBe("");
+  });
+
+  it("stringifies non-string values", () => {
+    expect(normalizeDownloadUrl(123)).toBe("123");
+  });
+});
+
+describe("isLocalDownloadUrl", () => {
+  it("is true for a /downloads/ path, including one needing trimming", () => {
+    expect(isLocalDownloadUrl("/downloads/pkg.zip")).toBe(true);
+    expect(isLocalDownloadUrl("  /downloads/pkg.zip")).toBe(true);
+  });
+
+  it("is false for remote URLs, other paths, and empty input", () => {
+    expect(isLocalDownloadUrl("https://example.com/downloads/pkg.zip")).toBe(
+      false,
+    );
+    expect(isLocalDownloadUrl("/assets/pkg.zip")).toBe(false);
+    expect(isLocalDownloadUrl("")).toBe(false);
+    expect(isLocalDownloadUrl(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Behavior-preserving refactor + test coverage. The pure download-URL checks in `scripts/validate-download-packages.mjs` were defined inline and untested; this splits them into `scripts/lib/download-package-url.mjs` and covers them, mirroring the recent `test(scripts): extract … and cover it` refactors.

Extracted (unchanged logic):
- `isFirstPartyPackage(data)` — true only when `packageVerified === true`
- `normalizeDownloadUrl(downloadUrl)` — trimmed string, null/undefined → `""`
- `isLocalDownloadUrl(downloadUrl)` — whether the normalized URL is a local `/downloads/` artifact

The validator now imports them; no runtime behavior changes.

## Files

- `scripts/lib/download-package-url.mjs` — the three pure helpers (new)
- `scripts/validate-download-packages.mjs` — imports the helpers instead of defining them inline
- `tests/download-package-url.test.ts` — 7 cases covering all three (first/false, trimming, coercion, local vs remote)

No content, registry, generated-artifact, or `apps/web` changes.

## Validation

```
pnpm exec prettier --check <changed files>                       # clean
pnpm exec vitest run tests/download-package-url.test.ts          # 7 passed
node scripts/validate-download-packages.mjs                      # "Package download validation passed." (behavior unchanged)
```

The extracted helpers live in the coverage-scoped `scripts/lib/**` and are fully exercised by the new test, so `codecov/patch` is satisfied.
