### PR TITLE
feat(web): timeline and evidence matrix benchmark peer egress

### DIFF
--- a/apps/web/src/components/entry-decision-timeline-panel.tsx
+++ b/apps/web/src/components/entry-decision-timeline-panel.tsx
@@ -1,8 +1,15 @@
+import { Link } from "@tanstack/react-router";
 import type {
   DecisionTimelinePresetId,
   EntryDecisionTimelineState,
 } from "@/lib/entry-decision-timeline";
 import { decisionRiskClass, decisionStepToneClass } from "@/lib/entry-decision-timeline-lib";
+import {
+  detailDecisionTimelineBenchmarkEntryAnalyticsData,
+  detailDecisionTimelineBenchmarkEntryAnalyticsEvent,
+  parseDetailEntryRef,
+} from "@/lib/entry-detail-decision-preset-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: DecisionTimelinePresetId; label: string }[] = [
@@ -13,11 +20,15 @@ const PRESETS: { id: DecisionTimelinePresetId; label: string }[] = [
 
 export function EntryDecisionTimelinePanel({
   state,
+  category,
+  slug,
   selectedPreset,
   onSelectPreset,
   className,
 }: {
   state: EntryDecisionTimelineState;
+  category: string;
+  slug: string;
   selectedPreset: DecisionTimelinePresetId;
   onSelectPreset: (preset: DecisionTimelinePresetId) => void;
   className?: string;
@@ -107,18 +118,47 @@ export function EntryDecisionTimelinePanel({
         <div className="mt-2 rounded-md border border-border bg-background px-3 py-2">
           <p className="text-[11px] font-medium text-ink">Compare benchmark deltas</p>
           <ul className="mt-1.5 space-y-1">
-            {state.benchmarks.map((benchmark) => (
-              <li
-                key={benchmark.entryRef}
-                className="flex items-center justify-between gap-2 text-[11px]"
-              >
-                <span className="truncate text-ink">{benchmark.title}</span>
-                <span className="font-mono text-ink-muted">
-                  {benchmark.score} ({benchmark.delta >= 0 ? "+" : ""}
-                  {benchmark.delta})
-                </span>
-              </li>
-            ))}
+            {state.benchmarks.map((benchmark) => {
+              const parsed = parseDetailEntryRef(benchmark.entryRef);
+              const title = benchmark.title;
+
+              return (
+                <li
+                  key={benchmark.entryRef}
+                  className="flex items-center justify-between gap-2 text-[11px]"
+                >
+                  {parsed ? (
+                    <Link
+                      to="/entry/$category/$slug"
+                      params={{ category: parsed.category, slug: parsed.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          detailDecisionTimelineBenchmarkEntryAnalyticsEvent(),
+                          detailDecisionTimelineBenchmarkEntryAnalyticsData(
+                            category,
+                            slug,
+                            benchmark.entryRef,
+                            selectedPreset,
+                            benchmark.score,
+                            benchmark.delta,
+                            state.benchmarks.length,
+                          ),
+                        )
+                      }
+                      className="truncate underline-offset-2 hover:text-accent hover:underline"
+                    >
+                      {title}
+                    </Link>
+                  ) : (
+                    <span className="truncate text-ink">{title}</span>
+                  )}
+                  <span className="font-mono text-ink-muted">
+                    {benchmark.score} ({benchmark.delta >= 0 ? "+" : ""}
+                    {benchmark.delta})
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         </div>
       ) : null}

--- a/apps/web/src/components/entry-evidence-readiness-matrix.tsx
+++ b/apps/web/src/components/entry-evidence-readiness-matrix.tsx
@@ -1,8 +1,15 @@
+import { Link } from "@tanstack/react-router";
 import { cellToneClass, riskTone } from "@/lib/entry-evidence-tone-lib";
 import {
   type EntryEvidenceReadinessMatrixState,
   type EvidenceMatrixPresetId,
 } from "@/lib/entry-evidence-readiness-matrix";
+import {
+  detailEvidenceMatrixBenchmarkEntryAnalyticsData,
+  detailEvidenceMatrixBenchmarkEntryAnalyticsEvent,
+  parseDetailEntryRef,
+} from "@/lib/entry-detail-decision-preset-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: EvidenceMatrixPresetId; label: string }[] = [
@@ -13,11 +20,15 @@ const PRESETS: { id: EvidenceMatrixPresetId; label: string }[] = [
 
 export function EntryEvidenceReadinessMatrix({
   state,
+  category,
+  slug,
   selectedPreset,
   onSelectPreset,
   className,
 }: {
   state: EntryEvidenceReadinessMatrixState;
+  category: string;
+  slug: string;
   selectedPreset: EvidenceMatrixPresetId;
   onSelectPreset: (preset: EvidenceMatrixPresetId) => void;
   className?: string;
@@ -101,15 +112,44 @@ export function EntryEvidenceReadinessMatrix({
         <div className="mt-2 rounded-md border border-border bg-background px-3 py-2">
           <p className="text-[11px] font-medium text-ink">Compare benchmark snapshot</p>
           <ul className="mt-1.5 space-y-1">
-            {state.benchmarks.map((benchmark) => (
-              <li
-                key={benchmark.entryRef}
-                className="flex items-center justify-between gap-2 text-[11px]"
-              >
-                <span className="truncate text-ink">{benchmark.title}</span>
-                <span className="font-mono text-ink-muted">{benchmark.score}</span>
-              </li>
-            ))}
+            {state.benchmarks.map((benchmark) => {
+              const parsed = parseDetailEntryRef(benchmark.entryRef);
+              const title = benchmark.title;
+
+              return (
+                <li
+                  key={benchmark.entryRef}
+                  className="flex items-center justify-between gap-2 text-[11px]"
+                >
+                  {parsed ? (
+                    <Link
+                      to="/entry/$category/$slug"
+                      params={{ category: parsed.category, slug: parsed.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          detailEvidenceMatrixBenchmarkEntryAnalyticsEvent(),
+                          detailEvidenceMatrixBenchmarkEntryAnalyticsData(
+                            category,
+                            slug,
+                            benchmark.entryRef,
+                            selectedPreset,
+                            benchmark.score,
+                            benchmark.strongerThanTarget,
+                            state.benchmarks.length,
+                          ),
+                        )
+                      }
+                      className="truncate underline-offset-2 hover:text-accent hover:underline"
+                    >
+                      {title}
+                    </Link>
+                  ) : (
+                    <span className="truncate text-ink">{title}</span>
+                  )}
+                  <span className="font-mono text-ink-muted">{benchmark.score}</span>
+                </li>
+              );
+            })}
           </ul>
         </div>
       ) : null}

--- a/apps/web/src/lib/entry-detail-decision-preset-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-decision-preset-cta-events-lib.ts
@@ -7,6 +7,8 @@
 
 import type { CompareBenchmarkPresetId } from "@/lib/entry-compare-benchmark-lib";
 import type { CompareBenchmarkVerdict } from "@/lib/entry-compare-benchmark-lib";
+import type { DecisionTimelinePresetId } from "@/lib/entry-decision-timeline-lib";
+import type { EvidenceMatrixPresetId } from "@/lib/entry-evidence-readiness-matrix-lib";
 
 export type DetailDecisionPanelId =
   | "adoption-plan"
@@ -62,6 +64,54 @@ export function detailCompareBenchmarkEntryAnalyticsData(
     verdict,
     totalScore,
     delta,
+    peerCount,
+  };
+}
+
+export function detailDecisionTimelineBenchmarkEntryAnalyticsEvent(): string {
+  return "detail_decision_timeline_benchmark_entry_click";
+}
+
+export function detailDecisionTimelineBenchmarkEntryAnalyticsData(
+  fromCategory: string,
+  fromSlug: string,
+  peerEntryRef: string,
+  preset: DecisionTimelinePresetId,
+  score: number,
+  delta: number,
+  peerCount: number,
+) {
+  return {
+    entry: detailDecisionPresetEntryKey(fromCategory, fromSlug),
+    surface: detailDecisionPresetSurface("decision-timeline"),
+    peer: peerEntryRef,
+    preset,
+    score,
+    delta,
+    peerCount,
+  };
+}
+
+export function detailEvidenceMatrixBenchmarkEntryAnalyticsEvent(): string {
+  return "detail_evidence_matrix_benchmark_entry_click";
+}
+
+export function detailEvidenceMatrixBenchmarkEntryAnalyticsData(
+  fromCategory: string,
+  fromSlug: string,
+  peerEntryRef: string,
+  preset: EvidenceMatrixPresetId,
+  score: number,
+  strongerThanTarget: boolean,
+  peerCount: number,
+) {
+  return {
+    entry: detailDecisionPresetEntryKey(fromCategory, fromSlug),
+    surface: detailDecisionPresetSurface("evidence-matrix"),
+    peer: peerEntryRef,
+    preset,
+    score,
+    strongerThanTarget,
     peerCount,
   };
 }

--- a/apps/web/src/lib/entry-detail-decision-preset-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-decision-preset-cta-events.ts
@@ -8,6 +8,10 @@ export {
   detailDecisionPresetAnalyticsEvent,
   detailDecisionPresetEntryKey,
   detailDecisionPresetSurface,
+  detailDecisionTimelineBenchmarkEntryAnalyticsData,
+  detailDecisionTimelineBenchmarkEntryAnalyticsEvent,
+  detailEvidenceMatrixBenchmarkEntryAnalyticsData,
+  detailEvidenceMatrixBenchmarkEntryAnalyticsEvent,
   parseDetailEntryRef,
   type DetailDecisionPanelId,
 } from "@/lib/entry-detail-decision-preset-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -757,11 +757,15 @@ function Dossier() {
           />
           <EntryEvidenceReadinessMatrix
             state={evidenceMatrix}
+            category={entry.category}
+            slug={entry.slug}
             selectedPreset={evidencePreset}
             onSelectPreset={onEvidencePresetSelect}
           />
           <EntryDecisionTimelinePanel
             state={decisionTimeline}
+            category={entry.category}
+            slug={entry.slug}
             selectedPreset={timelinePreset}
             onSelectPreset={onTimelinePresetSelect}
           />

--- a/tests/entry-detail-decision-preset-cta-events-lib.test.ts
+++ b/tests/entry-detail-decision-preset-cta-events-lib.test.ts
@@ -5,6 +5,10 @@ import {
   detailDecisionPresetAnalyticsData,
   detailDecisionPresetAnalyticsEvent,
   detailDecisionPresetSurface,
+  detailDecisionTimelineBenchmarkEntryAnalyticsData,
+  detailDecisionTimelineBenchmarkEntryAnalyticsEvent,
+  detailEvidenceMatrixBenchmarkEntryAnalyticsData,
+  detailEvidenceMatrixBenchmarkEntryAnalyticsEvent,
   parseDetailEntryRef,
 } from "@/lib/entry-detail-decision-preset-cta-events-lib";
 
@@ -71,5 +75,49 @@ describe("entry detail decision preset cta events lib", () => {
       slug: "browser",
     });
     expect(parseDetailEntryRef("invalid")).toBeNull();
+    expect(detailDecisionTimelineBenchmarkEntryAnalyticsEvent()).toBe(
+      "detail_decision_timeline_benchmark_entry_click",
+    );
+    expect(
+      detailDecisionTimelineBenchmarkEntryAnalyticsData(
+        "mcp",
+        "browser",
+        "agents/foo",
+        "balanced",
+        72,
+        -4,
+        2,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-decision-timeline",
+      peer: "agents/foo",
+      preset: "balanced",
+      score: 72,
+      delta: -4,
+      peerCount: 2,
+    });
+    expect(detailEvidenceMatrixBenchmarkEntryAnalyticsEvent()).toBe(
+      "detail_evidence_matrix_benchmark_entry_click",
+    );
+    expect(
+      detailEvidenceMatrixBenchmarkEntryAnalyticsData(
+        "skills",
+        "demo",
+        "mcp/bar",
+        "strict",
+        88,
+        true,
+        4,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-evidence-matrix",
+      peer: "mcp/bar",
+      preset: "strict",
+      score: 88,
+      strongerThanTarget: true,
+      peerCount: 4,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Link benchmark peer rows in decision timeline and evidence readiness panels to entry detail pages
- Add privacy-light analytics events `detail_decision_timeline_benchmark_entry_click` and `detail_evidence_matrix_benchmark_entry_click`
- Extend entry-detail decision preset CTA lib + vitest coverage for new event helpers

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build pass locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)
- [ ] Manual: open entry detail with compare peers, click timeline/evidence benchmark links