### PR TITLE
feat(web): hub highlight trending and ranking entry egress

### DIFF
--- a/apps/web/src/components/category-ranking-table.tsx
+++ b/apps/web/src/components/category-ranking-table.tsx
@@ -1,5 +1,10 @@
 import { Link } from "@tanstack/react-router";
 import { PlatformChip, InstallRiskBadge, NotesPresenceChips } from "@/components/badges";
+import { trackEvent } from "@/lib/analytics";
+import {
+  hubCategoryRankingEntryAnalyticsData,
+  hubCategoryRankingEntryAnalyticsEvent,
+} from "@/lib/hub-entry-cta-events";
 import type { Entry } from "@/types/registry";
 
 /**
@@ -46,6 +51,12 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                   <Link
                     to="/entry/$category/$slug"
                     params={{ category: e.category, slug: e.slug }}
+                    onClick={() =>
+                      trackEvent(
+                        hubCategoryRankingEntryAnalyticsEvent(),
+                        hubCategoryRankingEntryAnalyticsData(e.category, e.slug, i, entries.length),
+                      )
+                    }
                     className="story-link text-sm font-medium text-ink"
                   >
                     {e.title}

--- a/apps/web/src/components/hub-highlights.tsx
+++ b/apps/web/src/components/hub-highlights.tsx
@@ -10,6 +10,11 @@ import {
 } from "lucide-react";
 import { TrustBadge, SourceBadge } from "@/components/badges";
 import type { Highlight, HighlightKind, HubStat } from "@/lib/hub-highlights";
+import { trackEvent } from "@/lib/analytics";
+import {
+  hubHighlightEntryAnalyticsData,
+  hubHighlightEntryAnalyticsEvent,
+} from "@/lib/hub-entry-cta-events";
 
 const HIGHLIGHT_ICON: Record<HighlightKind, LucideIcon> = {
   trusted: ShieldCheck,
@@ -47,6 +52,17 @@ export function HubHighlights({
               <Link
                 to="/entry/$category/$slug"
                 params={{ category: h.entry.category, slug: h.entry.slug }}
+                onClick={() =>
+                  trackEvent(
+                    hubHighlightEntryAnalyticsEvent(),
+                    hubHighlightEntryAnalyticsData(
+                      h.entry.category,
+                      h.entry.slug,
+                      h.kind,
+                      highlights.length,
+                    ),
+                  )
+                }
                 className="group flex h-full flex-col rounded-xl border border-border bg-surface p-4 transition-colors hover:border-ink/20 hover:bg-surface-2"
               >
                 <div className="flex items-center gap-1.5 eyebrow">

--- a/apps/web/src/components/trending-podium.tsx
+++ b/apps/web/src/components/trending-podium.tsx
@@ -3,6 +3,11 @@ import { Link } from "@tanstack/react-router";
 import { Star, ArrowUpRight, TrendingUp } from "lucide-react";
 import { CategoryPill, TrustBadge, SourceBadge } from "@/components/badges";
 import { formatCompact } from "@/lib/format";
+import { trackEvent } from "@/lib/analytics";
+import {
+  hubTrendingPodiumEntryAnalyticsData,
+  hubTrendingPodiumEntryAnalyticsEvent,
+} from "@/lib/hub-entry-cta-events";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 
@@ -20,6 +25,16 @@ const RANK_STYLES = [
 export function TrendingPodium({ entries }: { entries: TrendingEntry[] }) {
   const top = entries.slice(0, 3);
   if (top.length === 0) return null;
+
+  const trackPodiumClick = React.useCallback(
+    (entry: TrendingEntry, rank: number) => {
+      trackEvent(
+        hubTrendingPodiumEntryAnalyticsEvent(),
+        hubTrendingPodiumEntryAnalyticsData(entry.category, entry.slug, rank, top.length),
+      );
+    },
+    [top.length],
+  );
 
   return (
     <div className="mt-8 grid gap-3 stagger-children sm:grid-cols-3">
@@ -58,6 +73,7 @@ export function TrendingPodium({ entries }: { entries: TrendingEntry[] }) {
             <Link
               to="/entry/$category/$slug"
               params={{ category: e.category, slug: e.slug }}
+              onClick={() => trackPodiumClick(e, i + 1)}
               className="mt-3 min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
             >
               <div className="flex flex-wrap items-center gap-1.5">
@@ -90,6 +106,7 @@ export function TrendingPodium({ entries }: { entries: TrendingEntry[] }) {
             <Link
               to="/entry/$category/$slug"
               params={{ category: e.category, slug: e.slug }}
+              onClick={() => trackPodiumClick(e, i + 1)}
               className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-ink-muted hover:text-ink"
             >
               Inspect <ArrowUpRight className="h-3 w-3" />

--- a/apps/web/src/lib/hub-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/hub-entry-cta-events-lib.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure hub entry egress analytics helpers.
+ *
+ * Maps highlight, trending podium, and category ranking entry navigation to
+ * privacy-light event names without embedding entry titles or hub copy.
+ */
+
+import type { HighlightKind } from "@/lib/hub-highlights-lib";
+
+export const HUB_HIGHLIGHTS_SURFACE = "hub-highlights";
+export const HUB_TRENDING_PODIUM_SURFACE = "hub-trending-podium";
+export const HUB_CATEGORY_RANKING_SURFACE = "hub-category-ranking";
+
+export function hubEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function hubHighlightEntryAnalyticsEvent(): string {
+  return "hub_highlight_entry_click";
+}
+
+export function hubHighlightEntryAnalyticsData(
+  category: string,
+  slug: string,
+  kind: HighlightKind,
+  highlightCount: number,
+) {
+  return {
+    entry: hubEntryKey(category, slug),
+    surface: HUB_HIGHLIGHTS_SURFACE,
+    kind,
+    highlightCount,
+  };
+}
+
+export function hubTrendingPodiumEntryAnalyticsEvent(): string {
+  return "hub_trending_podium_entry_click";
+}
+
+export function hubTrendingPodiumEntryAnalyticsData(
+  category: string,
+  slug: string,
+  rank: number,
+  podiumCount: number,
+) {
+  return {
+    entry: hubEntryKey(category, slug),
+    surface: HUB_TRENDING_PODIUM_SURFACE,
+    rank,
+    podiumCount,
+  };
+}
+
+export function hubCategoryRankingEntryAnalyticsEvent(): string {
+  return "hub_category_ranking_entry_click";
+}
+
+export function hubCategoryRankingEntryAnalyticsData(
+  category: string,
+  slug: string,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    entry: hubEntryKey(category, slug),
+    surface: HUB_CATEGORY_RANKING_SURFACE,
+    rowIndex,
+    rowCount,
+  };
+}

--- a/apps/web/src/lib/hub-entry-cta-events.ts
+++ b/apps/web/src/lib/hub-entry-cta-events.ts
@@ -1,0 +1,15 @@
+/**
+ * Hub entry egress CTA event surface.
+ */
+export {
+  HUB_CATEGORY_RANKING_SURFACE,
+  HUB_HIGHLIGHTS_SURFACE,
+  HUB_TRENDING_PODIUM_SURFACE,
+  hubCategoryRankingEntryAnalyticsData,
+  hubCategoryRankingEntryAnalyticsEvent,
+  hubEntryKey,
+  hubHighlightEntryAnalyticsData,
+  hubHighlightEntryAnalyticsEvent,
+  hubTrendingPodiumEntryAnalyticsData,
+  hubTrendingPodiumEntryAnalyticsEvent,
+} from "@/lib/hub-entry-cta-events-lib";

--- a/tests/hub-entry-cta-events-lib.test.ts
+++ b/tests/hub-entry-cta-events-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  HUB_CATEGORY_RANKING_SURFACE,
+  HUB_HIGHLIGHTS_SURFACE,
+  HUB_TRENDING_PODIUM_SURFACE,
+  hubCategoryRankingEntryAnalyticsData,
+  hubCategoryRankingEntryAnalyticsEvent,
+  hubHighlightEntryAnalyticsData,
+  hubHighlightEntryAnalyticsEvent,
+  hubTrendingPodiumEntryAnalyticsData,
+  hubTrendingPodiumEntryAnalyticsEvent,
+} from "@/lib/hub-entry-cta-events-lib";
+
+describe("hub entry cta events lib", () => {
+  it("builds privacy-light hub entry egress analytics", () => {
+    expect(hubHighlightEntryAnalyticsEvent()).toBe("hub_highlight_entry_click");
+    expect(
+      hubHighlightEntryAnalyticsData("mcp", "browser", "trusted", 4),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: HUB_HIGHLIGHTS_SURFACE,
+      kind: "trusted",
+      highlightCount: 4,
+    });
+    expect(hubTrendingPodiumEntryAnalyticsEvent()).toBe(
+      "hub_trending_podium_entry_click",
+    );
+    expect(hubTrendingPodiumEntryAnalyticsData("skills", "demo", 1, 3)).toEqual(
+      {
+        entry: "skills/demo",
+        surface: HUB_TRENDING_PODIUM_SURFACE,
+        rank: 1,
+        podiumCount: 3,
+      },
+    );
+    expect(hubCategoryRankingEntryAnalyticsEvent()).toBe(
+      "hub_category_ranking_entry_click",
+    );
+    expect(
+      hubCategoryRankingEntryAnalyticsData("agents", "foo", 2, 12),
+    ).toEqual({
+      entry: "agents/foo",
+      surface: HUB_CATEGORY_RANKING_SURFACE,
+      rowIndex: 2,
+      rowCount: 12,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add privacy-light hub entry egress analytics for highlights, trending podium, and category ranking table
- New events: `hub_highlight_entry_click`, `hub_trending_podium_entry_click`, `hub_category_ranking_entry_click`
- Hub CTA lib + wrapper + vitest coverage

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build pass locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)
- [ ] Manual: click highlight/podium/ranking links on category, tag, platform, trending pages