### PR TITLE
fix(registry): reject GitHub reserved product surfaces in repo URL parser

### DIFF
--- a/packages/registry/src/source-repo-lib.js
+++ b/packages/registry/src/source-repo-lib.js
@@ -19,19 +19,50 @@ const OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
 const REPO_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 // First path segments that are GitHub product surfaces, never repo owners.
-// GitHub reserves these, so "github.com/sponsors/x" is never a repository.
+// GitHub reserves these names, so "github.com/sponsors/x" or
+// "github.com/features/copilot" is a product/marketing/auth page, not a
+// repository. Two-segment marketing URLs (features/*, enterprise/*,
+// customer-stories/*) otherwise slip through as bogus owner/repo pairs, which
+// inflates source-provenance scoring and makes the source-repo signal refresher
+// query repos that cannot exist. Keep lowercase; membership is case-folded.
 const RESERVED_OWNERS = new Set([
   "about",
+  "account",
   "apps",
+  "business",
+  "codespaces",
   "collections",
+  "contact",
+  "customer-stories",
+  "dashboard",
+  "education",
+  "enterprise",
   "explore",
+  "features",
+  "issues",
+  "join",
+  "login",
+  "logout",
   "marketplace",
+  "new",
+  "nonprofits",
   "notifications",
+  "organizations",
   "orgs",
+  "pricing",
   "pulls",
+  "readme",
+  "search",
+  "security",
+  "sessions",
   "settings",
+  "signup",
   "sponsors",
+  "stars",
+  "team",
   "topics",
+  "trending",
+  "watching",
 ]);
 
 // Strip a single leading "www." so the www alias resolves to the bare host,

--- a/tests/source-repo-lib.test.ts
+++ b/tests/source-repo-lib.test.ts
@@ -11,16 +11,42 @@ const whisper = {
 
 const RESERVED_OWNERS = [
   "about",
+  "account",
   "apps",
+  "business",
+  "codespaces",
   "collections",
+  "contact",
+  "customer-stories",
+  "dashboard",
+  "education",
+  "enterprise",
   "explore",
+  "features",
+  "issues",
+  "join",
+  "login",
+  "logout",
   "marketplace",
+  "new",
+  "nonprofits",
   "notifications",
+  "organizations",
   "orgs",
+  "pricing",
   "pulls",
+  "readme",
+  "search",
+  "security",
+  "sessions",
   "settings",
+  "signup",
   "sponsors",
+  "stars",
+  "team",
   "topics",
+  "trending",
+  "watching",
 ];
 
 describe("parseGitHubRepoUrl https forms", () => {
@@ -101,6 +127,25 @@ describe("parseGitHubRepoUrl reserved GitHub product roots", () => {
         `https://github.com/${owner.toUpperCase()}/SomeProject`,
       ),
     ).toBeNull();
+  });
+});
+
+describe("parseGitHubRepoUrl reserved two-segment product surfaces", () => {
+  // Regression: these GitHub marketing/product/auth pages used to parse as
+  // bogus owner/repo pairs because the second path segment made them look like
+  // real repositories.
+  it.each([
+    "https://github.com/features/copilot",
+    "https://github.com/enterprise/contact",
+    "https://github.com/security/advisories",
+    "https://github.com/customer-stories/duolingo",
+    "https://github.com/login/oauth",
+    "https://github.com/pricing/team",
+    "https://github.com/readme/guides",
+    "https://github.com/stars/anthropics",
+    "git@github.com:features/copilot.git",
+  ])("rejects reserved product surface %s", (input) => {
+    expect(parseGitHubRepoUrl(input)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

`parseGitHubRepoUrl` (the shared canonical parser in `packages/registry/src/source-repo-lib.js`) only rejected 11 reserved GitHub roots. Two-segment GitHub **product / marketing / auth** URLs therefore parsed as bogus `owner/repo` repositories:

```
parseGitHubRepoUrl("https://github.com/features/copilot")
// before => { owner: "features", repo: "copilot", url: ".../features/copilot" }
// after  => null

github.com/enterprise/contact        // before: parsed as a repo → now null
github.com/security/advisories       // before: parsed as a repo → now null
github.com/customer-stories/<name>   // before: parsed as a repo → now null
github.com/login/oauth               // before: parsed as a repo → now null
```

Because the parser feeds both the build-time source-provenance signal and the scheduled `source-repo-signals` refresher, a marketing page pasted into `repoUrl` (a) over-counts the `source` sub-score in `buildEntryQuality` (repo present → +35) and (b) makes the refresher issue GitHub API calls for repositories that cannot exist.

## Fix

Expand `RESERVED_OWNERS` to cover GitHub's reserved product, marketing, and auth roots using **exact, case-folded segment matching**. Owners that merely *start with* a reserved word (e.g. `security-onion-solutions/securityonion`) still parse correctly — only the exact reserved segment is rejected. `owner/.` and `owner/..` were already safe via WHATWG `URL` path normalization, so no change was needed there.

This is a `Set` expansion only — no regex changes, so it stays clear of the existing CodeQL ReDoS / userinfo hardening in this module.

## Changed files

- `packages/registry/src/source-repo-lib.js` — expand `RESERVED_OWNERS`; document the class.
- `tests/source-repo-lib.test.ts` — mirror the reserved list in the exhaustive table and add a focused two-segment-surface regression block.

## Quality evidence

- **No visual impact** — pure library/parser change, no routes/components/UI.
- Behavior verified against the built module (15 cases): all reserved product surfaces (incl. uppercase and scp form) return `null`; real repos (`OpenAI/whisper`, `JSONbored/awesome-claude`, `vercel/ai`, deep-path links, and the prefix-collision `security-onion-solutions/securityonion`) parse unchanged.
- Backward compatibility: return shape, casing, and canonical-URL output are unchanged; only previously-misparsed reserved surfaces now correctly return `null`.

## Validation

```
pnpm exec vitest run tests/source-repo-lib.test.ts tests/registry-source-repo.test.ts
git diff --check
```

## Notes

Filed as a direct PR: this repository restricts issue creation to collaborators, so the tracking-issue form was not available to me — the full rationale is inline above in lieu of a `Closes #` reference. Happy to split, rename, or adjust the reserved list if any entry is undesirable.
