### PR TITLE
fix(registry): stop rejecting valid brandColors that repeat or exceed six

### DIFF
--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -13,7 +13,6 @@ import { isPublicHttpUrl, isPublicHttpsUrl } from "./source-url-lib.js";
 import {
   BRAND_ASSET_SOURCES,
   isAllowedBrandAssetUrl,
-  normalizeBrandColors,
   normalizeBrandDomain,
 } from "./brand-assets.js";
 
@@ -784,16 +783,19 @@ export function validateEntry(category, data, inferred = {}) {
   if (brandVerifiedAt && !/^\d{4}-\d{2}-\d{2}$/.test(brandVerifiedAt)) {
     semanticErrors.push("brandVerifiedAt must be ISO date format YYYY-MM-DD");
   }
-  if (
-    merged.brandColors !== undefined &&
-    normalizeBrandColors(merged.brandColors).length !==
-      (Array.isArray(merged.brandColors)
-        ? merged.brandColors.length
-        : String(merged.brandColors || "")
-            .split(",")
-            .filter((value) => value.trim()).length)
-  ) {
-    semanticErrors.push("brandColors must be hex colors such as #796eff");
+  if (merged.brandColors !== undefined) {
+    // Validate each supplied color independently. normalizeBrandColors dedups
+    // and caps at 6, so comparing its length to the raw count wrongly rejected
+    // valid input that merely repeated a color or listed more than six.
+    const rawBrandColors = Array.isArray(merged.brandColors)
+      ? merged.brandColors
+      : String(merged.brandColors ?? "").split(",");
+    const providedBrandColors = rawBrandColors
+      .map((value) => String(value ?? "").trim())
+      .filter(Boolean);
+    if (providedBrandColors.some((value) => !/^#[0-9a-f]{6}$/i.test(value))) {
+      semanticErrors.push("brandColors must be hex colors such as #796eff");
+    }
   }
 
   for (const field of [

--- a/tests/content-schema.test.ts
+++ b/tests/content-schema.test.ts
@@ -279,6 +279,50 @@ describe("inferStructuredFields", () => {
     );
   });
 
+  it("accepts valid brandColors that repeat or exceed six entries", () => {
+    const base = {
+      title: "T",
+      slug: "t",
+      description: "d",
+      cardDescription: "c",
+    };
+    const brandColorError = "brandColors must be hex colors such as #796eff";
+
+    // Duplicates and >6 valid colors are normalized downstream, not invalid.
+    const duplicate = validateEntry("agents", {
+      ...base,
+      brandColors: ["#796eff", "#796eff"],
+    });
+    expect(duplicate.semanticErrors).not.toContain(brandColorError);
+
+    const overSix = validateEntry("agents", {
+      ...base,
+      brandColors: [
+        "#111111",
+        "#222222",
+        "#333333",
+        "#444444",
+        "#555555",
+        "#666666",
+        "#777777",
+      ],
+    });
+    expect(overSix.semanticErrors).not.toContain(brandColorError);
+
+    const commaString = validateEntry("agents", {
+      ...base,
+      brandColors: "#796eff,#123456",
+    });
+    expect(commaString.semanticErrors).not.toContain(brandColorError);
+
+    // A genuinely invalid color is still rejected.
+    const invalid = validateEntry("agents", {
+      ...base,
+      brandColors: ["#796eff", "not-a-color"],
+    });
+    expect(invalid.semanticErrors).toContain(brandColorError);
+  });
+
   it("does not recommend package fields for non-installable skills", () => {
     const result = validateEntry("skills", {
       slug: "copy-only-capability-pack",


### PR DESCRIPTION
## Summary

`validateEntry` rejected valid `brandColors` submissions. The guard compared the **normalized** length against the **raw** input length:

```js
normalizeBrandColors(merged.brandColors).length !== rawCount
```

But `normalizeBrandColors` deduplicates, lowercases, and caps the list at 6. So any of these valid inputs produced a false `"brandColors must be hex colors such as #796eff"` error:

- `["#796eff", "#796eff"]` — a repeated color (normalized length 1 ≠ raw 2)
- 7+ distinct valid hex colors (normalized length 6 ≠ raw 7)
- `"#796eff,#123456"` — comma-string shape: `normalizeBrandColors` returns `[]` for non-arrays, so string input **always** failed, even though the raw-count branch explicitly handles the string shape

## Fix

Validate each supplied color independently against the hex pattern (`/^#[0-9a-f]{6}$/i`), rather than comparing normalized length to raw length. Duplicates and >6 colors are still normalized away downstream (unchanged); genuinely invalid values are still rejected. The now-unused `normalizeBrandColors` import is dropped.

## Changed files

- `packages/registry/src/content-schema-lib.js` — per-color validation; remove unused import.
- `tests/content-schema.test.ts` — add a regression test (duplicate, >6, comma-string, and invalid cases).

## Quality evidence

- **No visual impact** — pure validation-logic change.
- Verified against the built module: `["#796eff","#796eff"]`, 7 distinct valid colors, and `"#796eff,#123456"` no longer error; `["#796eff","not-a-color"]` and `["#fff"]` still error (`#fff` is not a 6-digit hex, matching existing behavior).
- The existing negative test (`["#fff", "not-a-color"]` → error) still passes unchanged.
- Backward compatibility: valid single/multi-distinct-color entries behave identically; only the false-rejection of duplicate/overflow/string input is removed.

## Validation

```
pnpm exec vitest run tests/content-schema.test.ts
git diff --check
```

## Notes

Filed as a direct PR — this repository restricts issue creation to non-collaborators, so the rationale is inline here rather than a `Closes #` reference.
