### PR TITLE
fix(registry): detect bundled base64 decode flags in shell safety scan

### DIFF
--- a/packages/registry/src/command-safety-lib.js
+++ b/packages/registry/src/command-safety-lib.js
@@ -244,7 +244,10 @@ export function segmentHasDecodeFlag(line, lowerLine, start, end) {
       let flagEnd = index;
       while (flagEnd < end && !/\s/.test(line[flagEnd] || "")) flagEnd += 1;
       const flag = lowerLine.slice(index, flagEnd);
-      if (flag === "-d" || flag === "--decode") return true;
+      // GNU base64 lets short flags bundle, so `-di` (decode + ignore-garbage)
+      // still means `--decode`. Treat any single-dash short-flag group that
+      // contains `d` as a decode flag; keep the explicit long `--decode` form.
+      if (flag === "--decode" || /^-[a-z]*d[a-z]*$/.test(flag)) return true;
       index = flagEnd;
     } else {
       while (index < end && !/\s/.test(line[index] || "")) index += 1;

--- a/tests/command-safety-lib.test.ts
+++ b/tests/command-safety-lib.test.ts
@@ -295,6 +295,19 @@ describe("segmentHasDecodeFlag", () => {
     ).toBe(true);
   });
 
+  it("detects bundled short flags that include decode", () => {
+    for (const line of [
+      "base64 -di payload",
+      "base64 -id payload",
+      "base64 -wd payload",
+      "base64 -diw payload",
+    ]) {
+      expect(segmentHasDecodeFlag(line, lower(line), 0, line.length)).toBe(
+        true,
+      );
+    }
+  });
+
   it("returns false when decode flags are absent", () => {
     const line = "base64 payload";
     expect(segmentHasDecodeFlag(line, lower(line), 0, line.length)).toBe(false);
@@ -304,6 +317,23 @@ describe("segmentHasDecodeFlag", () => {
     expect(
       segmentHasDecodeFlag(otherFlags, lower(otherFlags), 0, otherFlags.length),
     ).toBe(false);
+    const wrapOnly = "base64 -i payload";
+    expect(
+      segmentHasDecodeFlag(wrapOnly, lower(wrapOnly), 0, wrapOnly.length),
+    ).toBe(false);
+  });
+});
+
+describe("hasBase64DecodedShell bundled flags", () => {
+  it("flags a bundled base64 decode piped to a shell", () => {
+    for (const line of [
+      "echo cGF5 | base64 -di | bash",
+      "echo cGF5 | base64 -id | sh",
+    ]) {
+      expect(scanDangerousShellPatterns(line)).toContain(
+        "base64-decoded shell",
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The shell safety scanner missed a common base64-decode obfuscation. `segmentHasDecodeFlag` only matched the exact flag tokens `-d` and `--decode`:

```js
if (flag === "-d" || flag === "--decode") return true;
```

GNU `base64` lets short flags bundle, so `-di` (`--decode` + `--ignore-garbage`) is a single token that equals neither. As a result an obfuscated install snippet slipped past the scanner:

```
echo cGF5 | base64 -di | bash    // before: NOT flagged
echo cGF5 | base64 -d  | bash    // flagged
echo cGF5 | base64 --decode | sh // flagged
```

Since `hasBase64DecodedShell` -> `scanDangerousShellPatterns` feed the deterministic command-safety triage, the bundled-flag form evaded detection purely by appending a second short option.

## Fix

Treat any **single-dash short-flag group that contains `d`** as a decode flag (`/^-[a-z]*d[a-z]*$/`), keeping the explicit long `--decode`. This mirrors how the existing recursive-remove check already tolerates bundled short flags (`rm -rf`, `-fr`, ...). `segmentHasDecodeFlag` is only invoked when the segment's lead command is `base64` (see `hasBase64DecodedShell`), so non-base64 commands that happen to carry a `-d`-style flag are unaffected.

## Changed files

- `packages/registry/src/command-safety-lib.js` — broaden decode-flag matching.
- `tests/command-safety-lib.test.ts` — add bundled-flag cases (`-di`, `-id`, `-wd`, `-diw`), a `-i`-only negative, and a `base64 -di | bash` chain test.

## Quality evidence

- **No visual impact** — pure library/scanner change.
- Verified against the built module (14 cases): `-d`, `--decode`, `-di`, `-id`, `-wd`, `-diw` -> decode; `-i`, `-w 0`, `-w0`, no-flag -> not decode; `base64 -di | bash` and `-id | sh` now flag `base64-decoded shell`; existing `-d`/`--decode` chains still flag.
- Backward compatibility: previously-detected forms are unchanged; only the bundled-decode gap is closed. No false positives introduced for non-base64 segments (the check is gated on the `base64` lead command).

## Validation

```
pnpm exec vitest run tests/command-safety-lib.test.ts
git diff --check
```

## Notes

Resubmission of #4921, which the automated maintenance bot closed on a transient CI failure (a prettier line-wrap in the test file, now fixed). The bot review itself assessed the change as "a narrowly-scoped fix ... closing a real detection gap" and invited a new PR with the issue resolved; validate-ci is green on this branch. Filed as a direct PR since this repo restricts issue creation to non-collaborators.
