### PR TITLE
fix(registry): normalize repo URLs with a .git suffix and trailing slash

### DIFF
--- a/packages/registry/src/relationships-lib.js
+++ b/packages/registry/src/relationships-lib.js
@@ -102,9 +102,12 @@ export function normalizeUrl(value) {
       }
     }
     url.hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+    // Strip trailing slashes before the terminal ".git" so a URL like
+    // ".../repo.git/" collapses to the same value as ".../repo.git"; otherwise
+    // the ".git$" anchor misses and the two forms produce different repo keys.
     url.pathname = url.pathname
-      .replace(/\.git$/, "")
       .replace(/\/+$/, "")
+      .replace(/\.git$/, "")
       .toLowerCase();
     url.searchParams.sort();
     return url.toString().replace(/\/$/, "");

--- a/tests/relationships-lib.test.ts
+++ b/tests/relationships-lib.test.ts
@@ -106,6 +106,15 @@ describe("normalizeUrl", () => {
     );
   });
 
+  it("strips a terminal .git suffix even when a trailing slash follows it", () => {
+    expect(normalizeUrl("https://github.com/Acme/Widget.git/")).toBe(
+      "https://github.com/acme/widget",
+    );
+    expect(normalizeUrl("https://github.com/Acme/Widget.git//")).toBe(
+      "https://github.com/acme/widget",
+    );
+  });
+
   it("sorts remaining query params for stability", () => {
     expect(normalizeUrl("https://example.com/path?b=2&a=1")).toBe(
       "https://example.com/path?a=1&b=2",
@@ -210,6 +219,12 @@ describe("githubRepoKey", () => {
   it("returns owner/repo for a github repository", () => {
     expect(
       githubRepoKey(entry({ repoUrl: "https://github.com/Acme/Widget.git" })),
+    ).toBe("acme/widget");
+  });
+
+  it("keys a .git url with a trailing slash the same as without", () => {
+    expect(
+      githubRepoKey(entry({ repoUrl: "https://github.com/Acme/Widget.git/" })),
     ).toBe("acme/widget");
   });
 });


### PR DESCRIPTION
## Summary

`normalizeUrl` (which backs `githubRepoKey` and the normalized `sourceUrls` used for relationship matching) stripped the terminal `.git` **before** trailing slashes:

```js
url.pathname = url.pathname
  .replace(/\.git$/, "")   // misses when the path ends in "/"
  .replace(/\/+$/, "")
  .toLowerCase();
```

For a URL like `https://github.com/acme/widget.git/`, the `\.git$` anchor doesn't match (the string ends in `/`), so `.git` survives and the trailing slash is only removed afterward — leaving `.../widget.git`.

Result: the same repo produces **different keys** depending on a trailing slash:

```
githubRepoKey(".../widget.git")   -> "acme/widget"
githubRepoKey(".../widget.git/")  -> "acme/widget.git"   // bug
```

So `sameProject` / shared-source relationship matching silently misses genuine same-repo links whenever one entry's `repoUrl` carries a trailing slash after `.git`.

## Fix

Strip trailing slashes **before** the `.git` suffix, so `.../repo.git/` and `.../repo.git` collapse to the same value. One-line reorder.

## Changed files

- `packages/registry/src/relationships-lib.js` — reorder the pathname normalization.
- `tests/relationships-lib.test.ts` — add `normalizeUrl` (`.git/`, `.git//`) and `githubRepoKey` (trailing-slash parity) regression tests.

## Quality evidence

- **No visual impact** — pure normalization/library change.
- Verified against the built module (10 cases): `.git/` and `.git//` now normalize to `https://github.com/acme/widget` and key `acme/widget`, matching the no-slash form; existing behavior (tracking-param stripping, `www.` removal, query sorting, root-path `?id=9`, plain `.git`) is unchanged.
- Backward compatibility: only the previously-inconsistent `.git` + trailing-slash form changes; every other input normalizes exactly as before.

## Validation

```
pnpm exec vitest run tests/relationships-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
