### PR TITLE
fix(registry): use aliases when primary source URL fields are empty strings

### DIFF
--- a/packages/registry/src/llms-lib.js
+++ b/packages/registry/src/llms-lib.js
@@ -72,9 +72,12 @@ export function bulletList(values) {
 
 export function entrySourceUrls(entry) {
   return [
-    entry.documentationUrl ?? entry.docsUrl,
+    // Use `||`, not `??`: normalized entries default missing URLs to "" rather
+    // than undefined, and `??` would let an empty-string primary swallow a real
+    // docsUrl/sourceUrl alias. The array is clean()+filter(Boolean) guarded.
+    entry.documentationUrl || entry.docsUrl,
     entry.repoUrl,
-    entry.githubUrl ?? entry.sourceUrl,
+    entry.githubUrl || entry.sourceUrl,
     entry.websiteUrl,
   ]
     .map(clean)

--- a/tests/llms-lib.test.ts
+++ b/tests/llms-lib.test.ts
@@ -84,6 +84,20 @@ describe("entrySourceUrls", () => {
       "https://github.com/example/source",
     ]);
   });
+
+  it("uses aliases when the primary url fields are empty strings", () => {
+    expect(
+      entrySourceUrls({
+        documentationUrl: "",
+        docsUrl: "https://docs.example.com/guide",
+        githubUrl: "",
+        sourceUrl: "https://github.com/example/source",
+      }),
+    ).toEqual([
+      "https://docs.example.com/guide",
+      "https://github.com/example/source",
+    ]);
+  });
 });
 
 describe("entryLastVerified", () => {


### PR DESCRIPTION
## Summary

`entrySourceUrls` resolved the `docsUrl` / `sourceUrl` aliases with nullish coalescing:

```js
entry.documentationUrl ?? entry.docsUrl,
entry.githubUrl ?? entry.sourceUrl,
```

`??` only falls through on `null` / `undefined`. But normalized registry entries default missing URLs to an **empty string** (`documentationUrl: entry.documentationUrl || ""`, etc.). So an entry whose real URLs live only in the `docsUrl` / `sourceUrl` aliases — with `documentationUrl` / `githubUrl` set to `""` — had those aliases swallowed:

```js
entrySourceUrls({ documentationUrl: "", docsUrl: "https://docs.example.com/guide" })
// before: []            after: ["https://docs.example.com/guide"]
```

Downstream, `entryCitationFacts` / `renderEntryLlms` then emitted **no "Source URLs" fact at all** for such entries, dropping valid source/repo links from the LLMS export and the per-entry citation block (hurting citability/SEO).

## Fix

Switch those two fallbacks to `||`, so an empty-string primary yields the alias. The array is already `clean()` + `filter(Boolean)` guarded, so `||` stays safe when both primary and alias are empty.

## Changed files

- `packages/registry/src/llms-lib.js` — `??` -> `||` on the two aliased fields.
- `tests/llms-lib.test.ts` — add a regression test for empty-string primaries with valid aliases.

## Quality evidence

- **No visual impact** — pure library change.
- Verified against the built module: `{ documentationUrl:"", docsUrl:... , githubUrl:"", sourceUrl:... }` now returns both alias URLs; the existing cases (populated primary, undefined-primary alias fallback, dedup) are unchanged.
- Backward compatibility: only the previously-dropped empty-string-primary + alias case changes; every other input resolves exactly as before.

## Validation

```
pnpm exec vitest run tests/llms-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
