### PR TITLE
fix(mcp): treat empty array/object content as an absent copyable asset

### DIFF
--- a/packages/mcp/src/registry-asset-lib.js
+++ b/packages/mcp/src/registry-asset-lib.js
@@ -5,10 +5,21 @@
  * complexity scoring live here. Runtime registry handlers stay in `registry.js`.
  */
 export function contentAsset(type, label, content, format = "markdown") {
-  const text =
-    content && typeof content === "object"
-      ? JSON.stringify(content, null, 2)
-      : String(content || "").trim();
+  const isObject = content && typeof content === "object";
+  // An empty array/object serializes to "[]"/"{}" (truthy), which would slip
+  // past the emptiness guard below and surface a bogus copyable asset (e.g. a
+  // collection with items: [] producing a "Collection items" asset of "[]").
+  if (
+    isObject &&
+    (Array.isArray(content)
+      ? content.length === 0
+      : Object.keys(content).length === 0)
+  ) {
+    return null;
+  }
+  const text = isObject
+    ? JSON.stringify(content, null, 2)
+    : String(content || "").trim();
   if (!text) return null;
   return {
     type,

--- a/tests/mcp-registry-asset-lib.test.ts
+++ b/tests/mcp-registry-asset-lib.test.ts
@@ -18,6 +18,21 @@ describe("registry-asset-lib content assets", () => {
     expect(contentAsset("items", "Collection items", null)).toBeNull();
     expect(contentAsset("usage", "Usage snippet", "   ")).toBeNull();
   });
+
+  it("treats empty arrays and objects as absent content", () => {
+    expect(contentAsset("items", "Collection items", [], "json")).toBeNull();
+    expect(contentAsset("items", "Collection items", {}, "json")).toBeNull();
+  });
+
+  it("still serializes non-empty array and object content", () => {
+    expect(
+      contentAsset("items", "Collection items", ["a", "b"], "json"),
+    ).toMatchObject({
+      type: "items",
+      format: "json",
+      content: '[\n  "a",\n  "b"\n]',
+    });
+  });
 });
 
 describe("registry-asset-lib category primary asset", () => {


### PR DESCRIPTION
## Summary

`contentAsset` guards empty content with `String(content || "").trim()` — but only for scalars. For array/object content it takes the `JSON.stringify(content, null, 2)` branch, and `JSON.stringify([])` is `"[]"` (and `{}` -> `"{}"`), which is truthy. So the emptiness guard never fires for empty collections:

```js
contentAsset("items", "Collection items", [], "json")
// before: { type:"items", content:"[]", length:2 }   after: null
```

A `collections` entry with `items: []` (or `{}`) therefore surfaced a bogus **"Collection items"** copyable asset containing just `"[]"`. Because `categoryPrimaryAsset` prefers `items` first for collections, that empty literal even became the entry's *primary* copyable asset — so a user copying the collection got `[]`.

## Fix

Return `null` when array/object content is empty (checked before serialization). Scalars, non-empty arrays, and non-empty objects are unchanged. The fix lives in the shared `contentAsset`, so every caller (`buildEntryContentAssets`, `categoryPrimaryAsset`) benefits; only `items` passes object-typed content, so only empty collections are affected.

## Changed files

- `packages/mcp/src/registry-asset-lib.js` — empty array/object guard in `contentAsset`.
- `tests/mcp-registry-asset-lib.test.ts` — tests for empty (`[]`, `{}`) and non-empty array/object content.

## Quality evidence

- **No visual impact** — pure library change.
- Verified: `[]` and `{}` -> `null`; `["a","b"]` still serializes to the pretty-printed JSON asset; scalar strings, `null`, and whitespace behave exactly as before.
- Backward compatibility: the only behavior change is that empty-collection content no longer produces a fake asset; all non-empty content is untouched.

## Validation

```
pnpm exec vitest run tests/mcp-registry-asset-lib.test.ts tests/mcp-registry-copyable-asset-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
