### PR TITLE
fix(mcp): keep entry.compare sharedTags cased and deduped like the row tags

### DIFF
--- a/packages/mcp/src/registry-compare-lib.js
+++ b/packages/mcp/src/registry-compare-lib.js
@@ -67,12 +67,25 @@ export function buildCompareEntryRow(entry, platform, deps) {
  */
 export function sharedCompareTags(comparedEntries) {
   if (!comparedEntries.length) return [];
-  return comparedEntries
-    .slice(1)
-    .reduce(
-      (tags, entry) => intersection(tags, entry.tags || []),
-      comparedEntries[0].tags || [],
-    );
+  const [first, ...rest] = comparedEntries;
+  const firstTags = first.tags || [];
+  // Intersect case-insensitively across every entry to find the shared keys...
+  const sharedKeys = new Set(
+    rest.reduce(
+      (keys, entry) => intersection(keys, entry.tags || []),
+      firstTags.map((tag) => String(tag).trim().toLowerCase()),
+    ),
+  );
+  // ...but emit the first entry's original-cased tags (matching each row's
+  // `tags`), deduped. This keeps sharedTags consistent with the displayed tags
+  // and identical in shape for one vs. many entries.
+  const seen = new Set();
+  return firstTags.filter((tag) => {
+    const key = String(tag).trim().toLowerCase();
+    if (!key || !sharedKeys.has(key) || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }
 
 /**

--- a/tests/mcp-registry-compare-lib.test.ts
+++ b/tests/mcp-registry-compare-lib.test.ts
@@ -6588,6 +6588,19 @@ describe("registry-compare-lib sharedCompareTags", () => {
     ];
     expect(sharedCompareTags(compared)).toEqual(["b", "c"]);
   });
+  it("intersects case-insensitively but keeps the first entry's casing", () => {
+    const compared = [
+      { tags: ["Code-Review", "Testing"] },
+      { tags: ["code-review", "  Testing  "] },
+    ];
+    expect(sharedCompareTags(compared)).toEqual(["Code-Review", "Testing"]);
+  });
+  it("dedupes a single entry's tags without lowercasing", () => {
+    expect(sharedCompareTags([{ tags: ["Alpha", "Beta", "Alpha"] }])).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+  });
   it("sharedCompareTags matrix 0", () => {
     const shared = ["shared-0", "common"];
     const compared = [


### PR DESCRIPTION
## Summary

`sharedCompareTags` (the `sharedTags` field of the `entry.compare` MCP response) was inconsistent with the per-entry `tags` it sits beside:

- **Two or more entries:** the reduce folded tags through `intersection()`, which normalizes via `normalizeText` (trim + lowercase). So the shared tags came back **lowercased** (e.g. `["code-review"]`) while each compare row still shows `entry.tags` in original case (`["Code-Review"]`).
- **A single entry:** the `.slice(1)` reduce ran zero times and returned the raw first-entry tags — **original case with duplicates preserved** — yet another shape.

```js
sharedCompareTags([{ tags: ["Code-Review", "Testing"] }, { tags: ["code-review", "  Testing  "] }])
// before: ["code-review", "testing"]     after: ["Code-Review", "Testing"]
sharedCompareTags([{ tags: ["Alpha", "Beta", "Alpha"] }])
// before: ["Alpha", "Beta", "Alpha"]     after: ["Alpha", "Beta"]
```

## Fix

Intersect case-insensitively to find the shared keys, then emit the **first entry's original-cased tags** (deduped) — so `sharedTags` matches the displayed row `tags` and has one consistent shape whether there is one entry or many. First-entry order is preserved.

## Changed files

- `packages/mcp/src/registry-compare-lib.js` — case-preserving, deduped `sharedCompareTags`.
- `tests/mcp-registry-compare-lib.test.ts` — mixed-case and single-entry regression tests.

## Quality evidence

- **No visual impact** — pure library change.
- Verified: mixed-case multi-entry keeps `["Code-Review","Testing"]`; single entry dedupes to `["Alpha","Beta"]`; the existing lowercase matrix/intersection cases (`["a","b","c"] ∩ … = ["b","c"]`, `["shared-0","common"]`) are unchanged because their casing already equals the output.
- Backward compatibility: identical output for the already-lowercase, unique-tag inputs the tool produces today; only the previously-inconsistent casing/dedup is corrected.

## Validation

```
pnpm exec vitest run tests/mcp-registry-compare-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
