### PR TITLE
fix(mcp): include shared keywords in related-entry reasons

### DIFF
--- a/packages/mcp/src/registry-projection-lib.js
+++ b/packages/mcp/src/registry-projection-lib.js
@@ -89,6 +89,7 @@ export function scoreRelatedEntry(target, candidate) {
     reasons: [
       ...(target.category === candidate.category ? ["same_category"] : []),
       ...sharedTags.map((tag) => `tag:${tag}`),
+      ...sharedKeywords.map((keyword) => `keyword:${keyword}`),
       ...sharedPlatforms.map((platform) => `platform:${platform}`),
       ...sharedHosts.map((host) => `source:${host}`),
     ],

--- a/tests/mcp-registry-projection-lib.test.ts
+++ b/tests/mcp-registry-projection-lib.test.ts
@@ -1035,8 +1035,32 @@ describe("registry-projection-lib scoreRelatedEntry", () => {
     expect(related!.score).toBeGreaterThan(4);
     expect(related!.reasons).toContain("same_category");
     expect(related!.reasons.some((r) => r.startsWith("tag:"))).toBe(true);
+    expect(related!.reasons.some((r) => r.startsWith("keyword:"))).toBe(true);
     expect(related!.reasons.some((r) => r.startsWith("platform:"))).toBe(true);
     expect(related!.reasons.some((r) => r.startsWith("source:"))).toBe(true);
+  });
+
+  it("explains a keyword-only match with keyword reasons", () => {
+    const target = makeEntry({
+      category: "mcp",
+      slug: "kw-target",
+      tags: [],
+      keywords: ["playwright", "browser"],
+      platforms: [],
+      repoUrl: "",
+    });
+    const candidate = makeEntry({
+      category: "guides",
+      slug: "kw-candidate",
+      tags: [],
+      keywords: ["playwright", "browser"],
+      platforms: [],
+      repoUrl: "",
+    });
+    const related = scoreRelatedEntry(target, candidate);
+    expect(related).not.toBeNull();
+    expect(related!.score).toBeGreaterThan(0);
+    expect(related!.reasons).toEqual(["keyword:playwright", "keyword:browser"]);
   });
 
   it("caps keyword contribution at six points", () => {


### PR DESCRIPTION
## Summary

`scoreRelatedEntry` adds `Math.min(sharedKeywords.length, 6)` to the relatedness score, but the `reasons` array only spreads `sharedTags`, `sharedPlatforms`, and `sharedHosts` — **`sharedKeywords` is never included**. So a pair related purely by shared keywords is returned with a positive score and an **empty** `reasons` list:

```js
scoreRelatedEntry(
  { category:"mcp",    slug:"a", tags:[], keywords:["playwright","browser"], platforms:[] },
  { category:"guides", slug:"b", tags:[], keywords:["playwright","browser"], platforms:[] },
)
// before: { score: 2, reasons: [] }
// after:  { score: 2, reasons: ["keyword:playwright","keyword:browser"] }
```

Any "why is this related" explanation (UI or agent) renders blank for a real keyword-driven match.

## Fix

Add the shared keywords to `reasons` as `keyword:<value>`, positioned to match their score-contribution order (after tags, before platforms/hosts).

## Changed files

- `packages/mcp/src/registry-projection-lib.js` — add `keyword:` reasons.
- `tests/mcp-registry-projection-lib.test.ts` — assert a `keyword:` reason in the existing multi-signal test and add a keyword-only regression test.

## Quality evidence

- **No visual impact** — pure library change.
- Verified: a keyword-only cross-category pair now returns `["keyword:playwright","keyword:browser"]`; a tag-only pair is unchanged (`["tag:browser"]`); scores are unchanged (only `reasons` gains the previously-missing keyword entries).
- Backward compatibility: `score` is untouched; `reasons` only gains the keyword entries that were already being counted, so no existing reason is removed or reordered relative to tags/platforms/hosts.

## Validation

```
pnpm exec vitest run tests/mcp-registry-projection-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
