### PR TITLE
fix(mcp): accept markdown-bullet retrieval_sources in submission validation

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -378,7 +378,11 @@ function validateAgainstSpec(spec, fields = {}) {
       }
     }
     if (retrievalSources) {
-      for (const url of splitList(retrievalSources)) {
+      for (const item of splitList(retrievalSources)) {
+        // Contributors often paste retrieval_sources as a markdown list — which
+        // is exactly what this field's own example teaches ("- https://…") — so
+        // strip a leading list marker before validating the URL.
+        const url = item.replace(/^\s*(?:[-*+]|\d+[.)])\s+/, "");
         if (!isHttpsUrl(url)) {
           errors.push(`retrieval_sources must use https URLs: ${url}`);
         }

--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -222,6 +222,42 @@ describe("submissions-lib spec validation", () => {
       "capability-pack skills must use skill_level=expert.",
     );
   });
+
+  it("accepts retrieval_sources pasted as a markdown bullet list", () => {
+    const baseSkill = {
+      category: "skills",
+      name: "Capability Pack",
+      description:
+        "Capability pack skill used to validate retrieval source formatting during review.",
+      github_url: "https://github.com/example/repo/tree/main/skills/demo",
+      usage_snippet: "Use this capability pack during code review workflows.",
+      skill_type: "capability-pack",
+      skill_level: "expert",
+      verified_at: "2026-01-01",
+      safety_notes: "Runs user-configured scripts in the local workspace.",
+      privacy_notes:
+        "Does not persist user data outside the configured workspace.",
+    };
+
+    const bulletResult = validateSubmissionDraftFromSpec(submissionSpec, {
+      fields: {
+        ...baseSkill,
+        retrieval_sources:
+          "- https://example.com/docs\n- https://docs.foo.com/guide",
+      },
+    });
+    expect(bulletResult.errors.join("\n")).not.toContain(
+      "retrieval_sources must use https URLs",
+    );
+
+    // A genuinely non-https source is still rejected, marker or not.
+    const insecureResult = validateSubmissionDraftFromSpec(submissionSpec, {
+      fields: { ...baseSkill, retrieval_sources: "- http://insecure.example" },
+    });
+    expect(insecureResult.errors.join("\n")).toContain(
+      "retrieval_sources must use https URLs: http://insecure.example",
+    );
+  });
 });
 
 describe("submissions-lib draft builders", () => {


### PR DESCRIPTION
## Summary

`validateAgainstSpec` splits `retrieval_sources` on `,` / newline and passes each raw item straight to `isHttpsUrl`. But the field's **own example generator** returns a markdown bullet, and contributors naturally paste a markdown list:

```js
exampleValueForField("retrieval_sources") // => "- https://example.com/docs"
```

`splitList` only splits on `,` / `\n`, so each item keeps its leading `"- "`, and `new URL("- https://example.com/docs")` fails to parse — so valid https sources are rejected:

```
retrieval_sources: "- https://example.com/docs\n- https://docs.foo.com/guide"
// before: "retrieval_sources must use https URLs: - https://example.com/docs" (x2)
// after:  valid
```

This blocks capability-pack skills specifically, since they **require** `retrieval_sources`.

## Fix

Strip a leading list marker (`-`, `*`, `+`, or `1.` / `1)`) from each item before the https check. Genuinely non-https sources are still rejected (the marker is stripped, then the URL is validated).

## Changed files

- `packages/mcp/src/submissions-lib.js` — strip list markers before validating each `retrieval_sources` URL.
- `tests/mcp-submissions-lib.test.ts` — regression test for bullet-formatted (accepted) and non-https (still rejected) sources.

## Quality evidence

- **No visual impact** — pure validation-logic change.
- Verified end-to-end (splitList → strip → isHttpsUrl): `"- https://a\n- https://b"` validates clean; `"- http://insecure.example"` still errors as `retrieval_sources must use https URLs: http://insecure.example`; plain comma/newline URL lists are unchanged.
- Backward compatibility: previously-accepted plain URL lists behave identically; only the previously-rejected markdown-bullet form (which the tool's own example teaches) is now accepted.

## Validation

```
pnpm exec vitest run tests/mcp-submissions-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
