### PR TITLE
fix(mcp): compare duplicate-search category case-insensitively

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -899,7 +899,7 @@ export function searchDuplicateEntries(entries = [], args = {}) {
   const matches = [];
   for (const entry of entries) {
     const reasons = [];
-    if (category && entry.category !== category) continue;
+    if (category && normalizeLower(entry.category) !== category) continue;
     if (slug && normalizeLower(entry.slug) === slug) reasons.push("slug");
     if (title && normalizeLower(entry.title) === title) reasons.push("title");
     if (brandDomain && normalizeDomain(entry.brandDomain) === brandDomain) {

--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -354,6 +354,15 @@ describe("submissions-lib duplicate review", () => {
     ).toBe(1);
   });
 
+  it("matches duplicates when the indexed category casing differs", () => {
+    expect(
+      searchDuplicateEntries([indexedEntry({ category: "MCP" })], {
+        category: "mcp",
+        slug: "airtable-mcp-server",
+      }).count,
+    ).toBe(1);
+  });
+
   it("reviews drafts and recommends duplicate review when matches exist", () => {
     expect(
       reviewSubmissionDraftFromSpec(


### PR DESCRIPTION
## Summary

`searchDuplicateEntries` (the registry duplicate-detection helper) compared the category case-inconsistently. The requested category is lowercased via `normalizeLower`, but it was compared against the **raw** `entry.category`:

```js
const category = normalizeLower(args.category);
...
if (category && entry.category !== category) continue;   // entry side not normalized
```

Every other signal in the same loop normalizes both sides (`normalizeLower(entry.slug) === slug`, `normalizeLower(entry.title) === title`, `normalizeDomain(entry.brandDomain) === brandDomain`). So an indexed entry whose stored `category` casing differs from the normalized argument is skipped, and a real duplicate slips past the check:

```js
searchDuplicateEntries([{ category: "MCP", slug: "airtable-mcp-server", ... }],
                       { category: "mcp", slug: "airtable-mcp-server" })
// before: { count: 0, matches: [] }     after: { count: 1, reasons: ["slug"] }
```

## Fix

Normalize `entry.category` before comparing, matching the other duplicate signals. One line.

## Changed files

- `packages/mcp/src/submissions-lib.js` — case-insensitive category comparison.
- `tests/mcp-submissions-lib.test.ts` — regression test with a mixed-case indexed category.

## Quality evidence

- **No visual impact** — pure library change.
- Verified: a `category: "MCP"` indexed entry now matches a `category: "mcp"` query (via the `slug` reason); the existing lowercase-category matches are unchanged.
- Backward compatibility: registry categories are lowercase by convention, so today's behavior is unchanged for canonical data; the fix only closes the gap for any entry whose stored category casing differs, making category consistent with slug/title/brandDomain matching.

## Validation

```
pnpm exec vitest run tests/mcp-submissions-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
