### PR TITLE
feat(web): resource card and compare table entry egress

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -22,6 +22,10 @@ import { compareTableActionsForEntry } from "@/lib/compare-table-actions-interac
 import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
+import {
+  compareTableEntryAnalyticsData,
+  compareTableEntryAnalyticsEvent,
+} from "@/lib/compare-table-entry-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
@@ -313,6 +317,22 @@ export function ComparisonTable({
   const { divergingDecisionLabels, renderNextActions, actionRowDiverges, actionCells } =
     compareTableInteractiveUiState(entries, showNextActions);
 
+  const trackTableEntryClick = React.useCallback(
+    (entry: Entry, linkKind: "title" | "dossier", columnIndex: number) => {
+      trackEvent(
+        compareTableEntryAnalyticsEvent(),
+        compareTableEntryAnalyticsData(
+          entry.category,
+          entry.slug,
+          linkKind,
+          columnIndex,
+          entries.length,
+        ),
+      );
+    },
+    [entries.length],
+  );
+
   return (
     <div className="overflow-auto rounded-xl border border-border">
       <table className="w-full border-collapse text-sm">
@@ -324,7 +344,7 @@ export function ComparisonTable({
             >
               Field
             </th>
-            {entries.map((e) => (
+            {entries.map((e, columnIndex) => (
               <th
                 scope="col"
                 key={`${e.category}/${e.slug}`}
@@ -335,6 +355,7 @@ export function ComparisonTable({
                   <Link
                     to="/entry/$category/$slug"
                     params={{ category: e.category, slug: e.slug }}
+                    onClick={() => trackTableEntryClick(e, "title", columnIndex)}
                     className="min-w-0 font-display text-sm font-semibold text-ink hover:underline"
                   >
                     {e.title}
@@ -344,6 +365,7 @@ export function ComparisonTable({
                 <Link
                   to="/entry/$category/$slug"
                   params={{ category: e.category, slug: e.slug }}
+                  onClick={() => trackTableEntryClick(e, "dossier", columnIndex)}
                   className="mt-2 inline-flex items-center gap-1 text-[11px] text-ink-muted hover:text-ink"
                 >
                   Open dossier <ArrowRight className="h-3 w-3" />

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -24,6 +24,8 @@ import {
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
   resourceCardCompareToastOpenAnalyticsEvent,
+  resourceCardEntryAnalyticsData,
+  resourceCardEntryAnalyticsEvent,
   resourceCardSourceAnalyticsData,
   resourceCardSourceAnalyticsEvent,
   resourceCardInstallAnalyticsData,
@@ -93,6 +95,19 @@ function ResourceCardInner({
 
   const installPayload = entry.installCommand ?? entry.configSnippet ?? entry.fullCopy ?? "";
 
+  const onEntryClick = () => {
+    trackEvent(
+      resourceCardEntryAnalyticsEvent(),
+      resourceCardEntryAnalyticsData(
+        entry.category,
+        entry.slug,
+        variant,
+        typeof rank === "number" ? rank : null,
+        compareItems.length,
+      ),
+    );
+  };
+
   const onCompareToggle = () => {
     const wasIn = inCompare;
     const changed = toggle(entry);
@@ -138,6 +153,7 @@ function ResourceCardInner({
         <Link
           to="/entry/$category/$slug"
           params={{ category: entry.category, slug: entry.slug }}
+          onClick={onEntryClick}
           className="flex min-w-0 flex-1 items-center gap-3 focus-visible:outline-none"
         >
           {typeof rank === "number" && (
@@ -183,6 +199,7 @@ function ResourceCardInner({
           <Link
             to="/entry/$category/$slug"
             params={{ category: entry.category, slug: entry.slug }}
+            onClick={onEntryClick}
             className="flex flex-1 flex-col gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60 rounded-lg"
           >
             <div className="flex items-start justify-between gap-2">
@@ -288,6 +305,7 @@ function ResourceCardInner({
             <Link
               to="/entry/$category/$slug"
               params={{ category: entry.category, slug: entry.slug }}
+              onClick={onEntryClick}
               className="font-display text-[15px] font-semibold tracking-tight text-ink group-hover:underline"
             >
               {entry.title}

--- a/apps/web/src/lib/compare-table-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-table-entry-cta-events-lib.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure comparison table entry egress analytics helpers.
+ *
+ * Maps comparison table header entry navigation to privacy-light event names
+ * without embedding entry titles or comparison copy.
+ */
+
+import { COMPARE_TABLE_SURFACE } from "@/lib/compare-table-actions-lib";
+
+export type CompareTableEntryLinkKind = "title" | "dossier";
+
+export function compareTableEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function compareTableEntryAnalyticsEvent(): string {
+  return "compare_table_entry_click";
+}
+
+export function compareTableEntryAnalyticsData(
+  category: string,
+  slug: string,
+  linkKind: CompareTableEntryLinkKind,
+  columnIndex: number,
+  comparedCount: number,
+) {
+  return {
+    entry: compareTableEntryKey(category, slug),
+    surface: COMPARE_TABLE_SURFACE,
+    linkKind,
+    columnIndex,
+    comparedCount,
+  };
+}

--- a/apps/web/src/lib/compare-table-entry-cta-events.ts
+++ b/apps/web/src/lib/compare-table-entry-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Comparison table entry egress CTA event surface.
+ */
+export {
+  compareTableEntryAnalyticsData,
+  compareTableEntryAnalyticsEvent,
+  compareTableEntryKey,
+  type CompareTableEntryLinkKind,
+} from "@/lib/compare-table-entry-cta-events-lib";

--- a/apps/web/src/lib/resource-card-cta-events-lib.ts
+++ b/apps/web/src/lib/resource-card-cta-events-lib.ts
@@ -10,6 +10,8 @@ import type { IntentEventClientType } from "@/lib/intent-event-client-lib";
 
 export const RESOURCE_CARD_SURFACE = "browse-card";
 
+export type ResourceCardVariant = "row" | "grid" | "compact";
+
 export function resourceCardEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;
 }
@@ -67,5 +69,25 @@ export function resourceCardSourceAnalyticsData(category: string, slug: string, 
     entry: resourceCardEntryKey(category, slug),
     surface: RESOURCE_CARD_SURFACE,
     host,
+  };
+}
+
+export function resourceCardEntryAnalyticsEvent(): string {
+  return "browse_card_entry_click";
+}
+
+export function resourceCardEntryAnalyticsData(
+  category: string,
+  slug: string,
+  variant: ResourceCardVariant,
+  rank: number | null,
+  compareCount: number,
+) {
+  return {
+    entry: resourceCardEntryKey(category, slug),
+    surface: RESOURCE_CARD_SURFACE,
+    variant,
+    rank,
+    compareCount,
   };
 }

--- a/apps/web/src/lib/resource-card-cta-events.ts
+++ b/apps/web/src/lib/resource-card-cta-events.ts
@@ -7,10 +7,13 @@ export {
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
   resourceCardCompareToastOpenAnalyticsEvent,
+  resourceCardEntryAnalyticsData,
+  resourceCardEntryAnalyticsEvent,
   resourceCardSourceAnalyticsData,
   resourceCardSourceAnalyticsEvent,
   resourceCardEntryKey,
   resourceCardInstallAnalyticsData,
   resourceCardInstallAnalyticsEvent,
   resourceCardInstallIntentType,
+  type ResourceCardVariant,
 } from "@/lib/resource-card-cta-events-lib";

--- a/tests/compare-table-entry-cta-events-lib.test.ts
+++ b/tests/compare-table-entry-cta-events-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareTableEntryAnalyticsData,
+  compareTableEntryAnalyticsEvent,
+} from "@/lib/compare-table-entry-cta-events-lib";
+
+describe("compare table entry cta events lib", () => {
+  it("builds privacy-light comparison table entry egress analytics", () => {
+    expect(compareTableEntryAnalyticsEvent()).toBe("compare_table_entry_click");
+    expect(
+      compareTableEntryAnalyticsData("mcp", "browser", "title", 0, 3),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "compare-table",
+      linkKind: "title",
+      columnIndex: 0,
+      comparedCount: 3,
+    });
+    expect(
+      compareTableEntryAnalyticsData("skills", "demo", "dossier", 2, 4),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "compare-table",
+      linkKind: "dossier",
+      columnIndex: 2,
+      comparedCount: 4,
+    });
+  });
+});

--- a/tests/resource-card-cta-events-lib.test.ts
+++ b/tests/resource-card-cta-events-lib.test.ts
@@ -4,6 +4,8 @@ import {
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
   resourceCardCompareToastOpenAnalyticsEvent,
+  resourceCardEntryAnalyticsData,
+  resourceCardEntryAnalyticsEvent,
   resourceCardSourceAnalyticsData,
   resourceCardSourceAnalyticsEvent,
   resourceCardInstallAnalyticsData,
@@ -54,6 +56,25 @@ describe("resource card cta events lib", () => {
       entry: "skills/demo",
       surface: "browse-card",
       host: "github.com",
+    });
+    expect(resourceCardEntryAnalyticsEvent()).toBe("browse_card_entry_click");
+    expect(
+      resourceCardEntryAnalyticsData("mcp", "browser", "compact", 3, 2),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "browse-card",
+      variant: "compact",
+      rank: 3,
+      compareCount: 2,
+    });
+    expect(
+      resourceCardEntryAnalyticsData("skills", "demo", "grid", null, 0),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "browse-card",
+      variant: "grid",
+      rank: null,
+      compareCount: 0,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `browse_card_entry_click` analytics when users open entry detail from resource cards (row/grid/compact variants)
- Add `compare_table_entry_click` analytics for comparison table header title and dossier links
- Extend resource-card CTA lib and new compare-table entry CTA lib + vitest coverage

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build pass locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)
- [ ] Manual: click resource card titles on browse; click compare table header links