### PR TITLE
fix(registry): stop stale-but-sourced entries polluting the missingSource queue

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -839,7 +839,11 @@ export function buildRegistryTrustReport(entries) {
         .slice(0, 50),
       missingSource: needsAttention
         .filter((entry) =>
-          entry.recommendations.some((item) => item.includes("source")),
+          // Match the "Add source, …" recommendation specifically. A plain
+          // "source" substring also matches the stale-verification text
+          // ("…from current source facts."), which pulled entries that already
+          // have a source into this queue, contradicting missingSourceCount.
+          entry.recommendations.some((item) => item.includes("Add source")),
         )
         .slice(0, 50),
       missingChecksum: needsAttention

--- a/tests/artifacts-lib.test.ts
+++ b/tests/artifacts-lib.test.ts
@@ -1149,6 +1149,24 @@ describe("buildRegistryTrustReport", () => {
     expect(report.queues.missingSource.length).toBeGreaterThan(0);
   });
 
+  it("keeps stale-but-sourced entries out of the missingSource queue", () => {
+    const report = buildRegistryTrustReport([
+      {
+        category: "agents",
+        slug: "stale-one",
+        title: "Stale One",
+        repoUrl: "https://github.com/example/repo",
+        verifiedAt: "2020-01-01",
+        dateAdded: "2026-07-01",
+      },
+    ]);
+    expect(report.summary.missingSourceCount).toBe(0);
+    expect(report.queues.missingSource).toHaveLength(0);
+    expect(report.queues.staleVerification.map((entry) => entry.key)).toContain(
+      "agents:stale-one",
+    );
+  });
+
   it.each([
     ["branded", BRANDED_ENTRY, true],
     ["sparse mcp", SPARSE_ENTRY, false],


### PR DESCRIPTION
## Summary

`buildRegistryTrustReport` built its `missingSource` remediation queue by matching any recommendation containing the substring `"source"`:

```js
missingSource: needsAttention.filter((entry) =>
  entry.recommendations.some((item) => item.includes("source")),
)
```

But two recommendations contain the word "source":

- `"Add source, docs, repository, or editorial provenance."` (the genuine missing-source case)
- `"Refresh verification date from current source facts."` (the **stale-verification** case)

So an entry that already has a source and is merely overdue for re-verification was pulled into `missingSource` — directly contradicting the report's own `summary.missingSourceCount` and the row's `sourceStatus: "available"`:

```js
buildRegistryTrustReport([{ category:"agents", slug:"stale-one",
  repoUrl:"https://github.com/example/repo", verifiedAt:"2020-01-01", dateAdded:"2026-07-01" }])
// before: summary.missingSourceCount = 0, but queues.missingSource = ["agents:stale-one"]
// after:  queues.missingSource = []  (entry stays in staleVerification only)
```

## Fix

Match the `"Add source, …"` recommendation specifically (`item.includes("Add source")`) — consistent with the other queue filters, which key off distinctive recommendation phrases. No recommendation other than the genuine missing-source one contains `"Add source"`.

## Changed files

- `packages/registry/src/artifacts-lib.js` — tighten the `missingSource` queue filter.
- `tests/artifacts-lib.test.ts` — regression test that a stale-but-sourced entry stays out of `missingSource`.

## Quality evidence

- **No visual impact** — pure library change.
- Verified: a stale-but-sourced entry now has `missingSource = []` (and remains in `staleVerification`), while a genuinely source-missing entry still yields `missingSource = ["agents:no-src"]` with `missingSourceCount = 1`.
- Backward compatibility: the `missingSource` queue now agrees with `summary.missingSourceCount`; genuine missing-source entries are unaffected.

## Validation

```
pnpm exec vitest run tests/artifacts-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
