### PR TITLE
fix(registry): read packageVerified from trustSignals in saferInstallReasons

### DIFF
--- a/packages/registry/src/weekly-brief-lib.js
+++ b/packages/registry/src/weekly-brief-lib.js
@@ -243,7 +243,12 @@ export function saferInstallReasons(entry) {
   const reasons = [];
   if (entry.downloadTrust === "first-party")
     reasons.push("first-party package");
-  if (entry.packageVerified === true) reasons.push("package verified");
+  if (
+    entry.packageVerified === true ||
+    entry.trustSignals?.packageVerified === true
+  ) {
+    reasons.push("package verified");
+  }
   if (entry.downloadSha256 || entry.trustSignals?.checksumPresent) {
     reasons.push("checksum present");
   }

--- a/tests/weekly-brief-lib.test.ts
+++ b/tests/weekly-brief-lib.test.ts
@@ -383,6 +383,12 @@ describe("reason builders and selection", () => {
     ]);
   });
 
+  it("reads packageVerified from trustSignals as well as the top level", () => {
+    expect(
+      saferInstallReasons(entry({ trustSignals: { packageVerified: true } })),
+    ).toContain("package verified");
+  });
+
   it("materializes items and selects unique entries up to a limit", () => {
     const item = itemFromEntry(
       entry({


### PR DESCRIPTION
## Summary

The weekly brief's "safer installs" section is inconsistent about where it reads the `packageVerified` signal:

- **Selection** — `hasSaferInstallSignal` accepts either surface: `entry.packageVerified === true || entry.trustSignals?.packageVerified === true`.
- **Checksum reason** — already reads both: `entry.downloadSha256 || entry.trustSignals?.checksumPresent`.
- **`packageVerified` reason** — checked **only** the top level: `if (entry.packageVerified === true)`.

So an entry selected into the section via `trustSignals.packageVerified` fell through to the generic fallback reason:

```js
saferInstallReasons({ installCommand: "npx x", trustSignals: { packageVerified: true } })
// before: ["reviewable install metadata"]
// after:  ["package verified"]
```

## Fix

Read `packageVerified` from both surfaces, matching the selection predicate and the sibling checksum reason.

## Changed files

- `packages/registry/src/weekly-brief-lib.js` — `saferInstallReasons` reads `entry.trustSignals?.packageVerified` too.
- `tests/weekly-brief-lib.test.ts` — regression test for the `trustSignals.packageVerified` surface.

## Quality evidence

- **No visual impact** — pure library change.
- Verified: `{ trustSignals: { packageVerified: true } }` now yields `["package verified"]`; the top-level `{ packageVerified: true }` case is unchanged; an entry with no trust signals still returns the `["reviewable install metadata"]` fallback.
- Backward compatibility: only the previously-missed `trustSignals.packageVerified` case changes; every other reason is unaffected.

## Validation

```
pnpm exec vitest run tests/weekly-brief-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
