### PR TITLE
feat(web): trending list entry egress analytics

### DIFF
--- a/apps/web/src/lib/trending-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/trending-entry-cta-events-lib.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure trending page entry egress analytics helpers.
+ *
+ * Maps trending list navigation below the podium to privacy-light event names
+ * without embedding entry titles or signal reason copy.
+ */
+
+export const TRENDING_LIST_SURFACE = "trending-list";
+
+export type TrendingListWindow = "7d" | "30d" | "all";
+export type TrendingListMode = "live" | "fallback" | "unavailable";
+
+export function trendingListEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function trendingListEntryAnalyticsEvent(): string {
+  return "trending_list_entry_click";
+}
+
+export function trendingListEntryAnalyticsData(
+  category: string,
+  slug: string,
+  rank: number,
+  listCount: number,
+  window: TrendingListWindow,
+  categoryFilter: string,
+  mode: TrendingListMode,
+) {
+  return {
+    entry: trendingListEntryKey(category, slug),
+    surface: TRENDING_LIST_SURFACE,
+    rank,
+    listCount,
+    window,
+    categoryFilter,
+    mode,
+  };
+}

--- a/apps/web/src/lib/trending-entry-cta-events.ts
+++ b/apps/web/src/lib/trending-entry-cta-events.ts
@@ -1,0 +1,11 @@
+/**
+ * Trending page entry egress CTA event surface.
+ */
+export {
+  TRENDING_LIST_SURFACE,
+  trendingListEntryAnalyticsData,
+  trendingListEntryAnalyticsEvent,
+  trendingListEntryKey,
+  type TrendingListMode,
+  type TrendingListWindow,
+} from "@/lib/trending-entry-cta-events-lib";

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -16,6 +16,11 @@ import { formatCompact } from "@/lib/format";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { trackEvent } from "@/lib/analytics";
+import {
+  trendingListEntryAnalyticsData,
+  trendingListEntryAnalyticsEvent,
+} from "@/lib/trending-entry-cta-events";
 import { cn } from "@/lib/utils";
 
 const defaultSearch = {
@@ -207,6 +212,24 @@ function TrendingPage() {
   const set = (patch: Partial<typeof sp>) =>
     navigate({ search: (prev: typeof sp) => ({ ...prev, ...patch }) });
 
+  const onTrendingListEntryClick = React.useCallback(
+    (entry: TrendingEntry, rank: number) => {
+      trackEvent(
+        trendingListEntryAnalyticsEvent(),
+        trendingListEntryAnalyticsData(
+          entry.category,
+          entry.slug,
+          rank,
+          list.length,
+          sp.window,
+          sp.category,
+          mode,
+        ),
+      );
+    },
+    [list.length, mode, sp.category, sp.window],
+  );
+
   const shareUrl = `/trending${sp.category ? `?category=${sp.category}` : ""}`;
 
   return (
@@ -342,6 +365,7 @@ function TrendingPage() {
               <Link
                 to="/entry/$category/$slug"
                 params={{ category: entry.category, slug: entry.slug }}
+                onClick={() => onTrendingListEntryClick(entry, index + 4)}
                 className="min-w-0 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
               >
                 <div className="flex flex-wrap items-center gap-2">

--- a/tests/trending-entry-cta-events-lib.test.ts
+++ b/tests/trending-entry-cta-events-lib.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  TRENDING_LIST_SURFACE,
+  trendingListEntryAnalyticsData,
+  trendingListEntryAnalyticsEvent,
+} from "@/lib/trending-entry-cta-events-lib";
+
+describe("trending entry cta events lib", () => {
+  it("builds privacy-light trending list entry egress analytics", () => {
+    expect(trendingListEntryAnalyticsEvent()).toBe("trending_list_entry_click");
+    expect(
+      trendingListEntryAnalyticsData(
+        "mcp",
+        "browser",
+        4,
+        12,
+        "7d",
+        "mcp",
+        "live",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: TRENDING_LIST_SURFACE,
+      rank: 4,
+      listCount: 12,
+      window: "7d",
+      categoryFilter: "mcp",
+      mode: "live",
+    });
+    expect(
+      trendingListEntryAnalyticsData(
+        "skills",
+        "demo",
+        8,
+        20,
+        "all",
+        "",
+        "fallback",
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: TRENDING_LIST_SURFACE,
+      rank: 8,
+      listCount: 20,
+      window: "all",
+      categoryFilter: "",
+      mode: "fallback",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `trending_list_entry_click` when users open entry detail from the trending ranked list (ranks 4+)
- Privacy-light payload: surface, rank, listCount, window, categoryFilter, mode
- New trending-entry CTA lib + wrapper + vitest coverage

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build pass locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)
- [ ] Manual: click trending list entries below podium with category filter active