### PR TITLE
fix(mcp): report related-graph count from the returned page

### DIFF
--- a/packages/mcp/src/registry-handlers-lib.js
+++ b/packages/mcp/src/registry-handlers-lib.js
@@ -154,12 +154,15 @@ export function mapRecentUpdateEntries(
 }
 
 export function buildRelatedEntriesGraphResponse({ target, entries, limit }) {
+  // The graph path receives the full related list (its caller does not
+  // pre-slice), so count must reflect the returned page, not the input length.
+  const page = entries.slice(0, limit);
   return {
     ok: true,
     key: `${target.category}:${target.slug}`,
     relationGraph: true,
-    count: entries.length,
-    entries: entries.slice(0, limit),
+    count: page.length,
+    entries: page,
   };
 }
 

--- a/tests/mcp-registry-handlers-lib.test.ts
+++ b/tests/mcp-registry-handlers-lib.test.ts
@@ -531,6 +531,15 @@ describe("registry-handlers-lib response builders", () => {
     });
     expect(response.relationGraph).toBe(true);
   });
+  it("buildRelatedEntriesGraphResponse count matches the returned page", () => {
+    const response = buildRelatedEntriesGraphResponse({
+      target: { category: "mcp", slug: "demo" },
+      entries: Array.from({ length: 8 }, (_, index) => ({ id: index })),
+      limit: 5,
+    });
+    expect(response.entries).toHaveLength(5);
+    expect(response.count).toBe(response.entries.length);
+  });
   it("buildTrendingResourceResponse matrix 0", () => {
     const response = buildTrendingResourceResponse({
       payload: { schemaVersion: 1 },


### PR DESCRIPTION
## Summary

`buildRelatedEntriesGraphResponse` reported `count` from the **input** length but returned only a **sliced** page:

```js
count: entries.length,
entries: entries.slice(0, limit),
```

Unlike the scored path (`buildRelatedEntriesScoredResponse`), whose caller already `.slice(0, limit)`-es its input, the graph path is fed the **full** related list (`resolveGraphRelatedEntries` maps every `graphRow.related` with no slice). So an entry with more than `limit` graph relations advertises a `count` larger than the `entries` array it returns:

```js
buildRelatedEntriesGraphResponse({ target:{category:"mcp",slug:"x"},
  entries: /* 8 items */, limit: 5 })
// before: count = 8, entries.length = 5   (mismatch)
// after:  count = 5, entries.length = 5
```

With the `entry.related` default `limit = 8`, any graph row with >8 relations (common for popular entries) triggers this — the MCP `entry.related` response then advertises a total that doesn't match its payload.

## Fix

Slice once into a `page` and report `count` from that page, so the graph response's `count` always agrees with the returned `entries`. This matches the `count: page.length` convention already used by the paginated `buildCategoryEntriesPageResponse`.

## Changed files

- `packages/mcp/src/registry-handlers-lib.js` — count from the sliced page.
- `tests/mcp-registry-handlers-lib.test.ts` — regression test that `count === entries.length` for a >limit graph list.

## Quality evidence

- **No visual impact** — pure library change.
- Verified (harness): 8 entries with `limit: 5` now returns `count: 5` with 5 entries; an entry count ≤ limit is unchanged.
- Backward compatibility: `count` now equals the returned page length in all cases; entries returned are unchanged. The scored path (already pre-sliced) is unaffected.

## Validation

```
pnpm exec vitest run tests/mcp-registry-handlers-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
