### PR TITLE
fix(registry): reject GitHub product surfaces in profile URL classifier

### DIFF
--- a/packages/registry/src/source-repo-lib.js
+++ b/packages/registry/src/source-repo-lib.js
@@ -25,7 +25,9 @@ const REPO_PATTERN = /^[A-Za-z0-9._-]+$/;
 // customer-stories/*) otherwise slip through as bogus owner/repo pairs, which
 // inflates source-provenance scoring and makes the source-repo signal refresher
 // query repos that cannot exist. Keep lowercase; membership is case-folded.
-const RESERVED_OWNERS = new Set([
+// Exported so the GitHub profile-URL classifier in `source-url-lib.js` rejects
+// the same product surfaces and the two checkers cannot drift apart.
+export const RESERVED_OWNERS = new Set([
   "about",
   "account",
   "apps",

--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -9,6 +9,8 @@
  * re-exports everything below so existing imports stay unchanged.
  */
 
+import { RESERVED_OWNERS } from "./source-repo-lib.js";
+
 const AFFILIATE_PARAMS = new Set([
   "aff",
   "affiliate",
@@ -129,18 +131,25 @@ export function publicHttpUrlHref(value) {
 /**
  * Return true for a single-segment GitHub profile URL without embedded userinfo.
  *
+ * The single path segment must be a real account name, not a GitHub product
+ * surface: `github.com/features`, `github.com/sponsors`, and `github.com/about`
+ * are reserved pages, never user profiles. The reserved set is shared with the
+ * repo-URL parser (`RESERVED_OWNERS`) so the two classifiers stay in sync.
+ *
  * @param {unknown} value
  * @returns {boolean}
  */
 export function isPublicGitHubProfileUrl(value) {
   const url = parseUrl(value);
   if (!url) return false;
+  const segments = url.pathname.split("/").filter(Boolean);
   return (
     url.protocol === "https:" &&
     url.username === "" &&
     url.password === "" &&
     url.hostname === "github.com" &&
-    url.pathname.split("/").filter(Boolean).length === 1
+    segments.length === 1 &&
+    !RESERVED_OWNERS.has(segments[0].toLowerCase())
   );
 }
 

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -14,6 +14,7 @@ import {
   publicUrlHostname,
   stripTrackingParams,
 } from "../packages/registry/src/source-url-lib.js";
+import { RESERVED_OWNERS } from "../packages/registry/src/source-repo-lib.js";
 
 const AFFILIATE_PARAMS = [
   "aff",
@@ -113,6 +114,48 @@ describe("public URL userinfo helpers", () => {
       false,
     );
     expect(isPublicGitHubHostUrl("https://gist.github.com/octocat")).toBe(true);
+  });
+
+  it("rejects reserved GitHub product surfaces as profiles", () => {
+    // A single path segment that is a reserved GitHub page is not a user
+    // profile, mirroring how the repo-URL parser rejects reserved owners.
+    for (const surface of [
+      "features",
+      "sponsors",
+      "about",
+      "pricing",
+      "settings",
+      "marketplace",
+      "explore",
+      "security",
+    ]) {
+      expect(isPublicGitHubProfileUrl(`https://github.com/${surface}`)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("matches reserved surfaces case-insensitively", () => {
+    expect(isPublicGitHubProfileUrl("https://github.com/Sponsors")).toBe(false);
+    expect(isPublicGitHubProfileUrl("https://github.com/FEATURES")).toBe(false);
+  });
+
+  it("still accepts an ordinary account whose name is not reserved", () => {
+    expect(isPublicGitHubProfileUrl("https://github.com/octocat")).toBe(true);
+    // A name that merely contains a reserved word is a real account.
+    expect(isPublicGitHubProfileUrl("https://github.com/features-bot")).toBe(
+      true,
+    );
+  });
+
+  it("rejects every reserved owner the repo parser knows about", () => {
+    // Shared source of truth: the profile checker must not drift from the
+    // repo-URL parser's reserved list.
+    for (const owner of RESERVED_OWNERS) {
+      expect(isPublicGitHubProfileUrl(`https://github.com/${owner}`)).toBe(
+        false,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## The bug

`isPublicGitHubProfileUrl` accepted **any** single-segment `github.com` path as a user profile:

```js
url.pathname.split("/").filter(Boolean).length === 1   // "features" passes
```

So all of these classified as profiles:

| URL | before | after |
|---|---|---|
| `github.com/octocat` | ✅ profile | ✅ profile |
| `github.com/features` | ✅ profile | ❌ |
| `github.com/sponsors` | ✅ profile | ❌ |
| `github.com/about` | ✅ profile | ❌ |
| `github.com/settings` | ✅ profile | ❌ |
| `github.com/features-bot` | ✅ profile | ✅ profile (real account) |

This is the same class of bug the **repo-URL parser already guards against** with `RESERVED_OWNERS` — see #4920, "reject GitHub reserved product surfaces in repo URL parser." The profile classifier simply never got the same treatment.

## Why it matters

`isPublicGitHubProfileUrl` gates real behavior:
- **contributor attribution** — `apps/web/src/data/contributors.ts` returns no profile link for a non-profile URL;
- **submission risk scoring** — `submission-risk.js`;
- **contact validation** — `submission-lib.js`, and the MCP submission path.

A submission listing `https://github.com/sponsors` as its author profile would read as a valid GitHub identity.

## The fix

Export the already-curated `RESERVED_OWNERS` set from `source-repo-lib.js` and reuse it in `source-url-lib.js`, so the two classifiers share **one source of truth** and can't drift apart again — that drift is exactly how this gap opened.

The existing `source-repo → source-url` import becomes mutual. It's ESM-safe: every use of `RESERVED_OWNERS` / `hasEmbeddedUrlUserinfo` is inside a function, so the live bindings resolve by call time regardless of which module loads first. I verified both evaluation orders.

## Tests

Extends `tests/source-url-lib.test.ts`: a representative set of reserved surfaces rejected, case-insensitive matching (`/Sponsors`, `/FEATURES`), a `-bot` suffixed account still accepted, and a **cross-module invariant** — `isPublicGitHubProfileUrl` rejects *every* member of `RESERVED_OWNERS`, which will fail if the two lists ever diverge.

```
pnpm exec vitest run tests/source-url-lib.test.ts tests/source-repo-lib.test.ts   # 486 passed
pnpm test    # 63 failed / 38 failing files — identical to main's baseline (artifact-dependent suites); zero new failures
pnpm exec prettier --check <changed files>   # clean
```

Guard verified: reverting the reserved-set check fails exactly the 3 new assertions.

Refs #4920