### PR TITLE
fix(scripts): render impact-card stats near a million as M, not 1000k

### DIFF
--- a/scripts/lib/impact-card-core.mjs
+++ b/scripts/lib/impact-card-core.mjs
@@ -8,7 +8,10 @@ export const WEEKS = 12;
 
 /** Compact number formatting for the card's stat values (1.2M / 34k / 900). */
 export function compact(n) {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  // Use the millions branch once the value would round to 1000k: n >= 999_500
+  // rounds to "1.0M". Without this, 999_500..999_999 rendered "1000k" because
+  // (n / 1000).toFixed(0) carried past the thousands magnitude.
+  if (n >= 999_500) return (n / 1_000_000).toFixed(1) + "M";
   if (n >= 1000) return (n / 1000).toFixed(0) + "k";
   return String(n);
 }

--- a/tests/impact-card-core.test.ts
+++ b/tests/impact-card-core.test.ts
@@ -32,6 +32,12 @@ describe("compact", () => {
     expect(compact(999)).toBe("999");
     expect(compact(0)).toBe("0");
   });
+
+  it("rolls the just-under-a-million boundary up to millions, not 1000k", () => {
+    expect(compact(999_499)).toBe("999k");
+    expect(compact(999_500)).toBe("1.0M");
+    expect(compact(999_999)).toBe("1.0M");
+  });
 });
 
 describe("escapeXml", () => {


### PR DESCRIPTION
## Summary

`compact()` (the stat formatter behind the Gittensor impact-card SVG) chose the thousands branch for any `n >= 1000`:

```js
if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
if (n >= 1000) return (n / 1000).toFixed(0) + "k";
```

For `n` in `[999_500, 999_999]`, `(n / 1000).toFixed(0)` rounds to `1000`, so the card rendered a malformed **`"1000k"`** instead of `"1.0M"`:

```js
compact(999_999) // before: "1000k"   after: "1.0M"
compact(999_500) // before: "1000k"   after: "1.0M"
compact(999_499) //         "999k"    (unchanged)
```

So a PR / lines-of-code / contributor total just under a million shows up as `1000k` on the impact card.

## Fix

Enter the millions branch once the value rounds to `1000k` (`n >= 999_500`). Values below still format as thousands; a million and above are unchanged.

## Changed files

- `scripts/lib/impact-card-core.mjs` — millions-branch threshold accounts for rounding.
- `tests/impact-card-core.test.ts` — boundary regression test.

## Quality evidence

- **No visual impact on the tool's code** — output-formatting fix; the rendered card now shows `1.0M` instead of `1000k` near a million.
- Verified: `999_499 → "999k"`, `999_500 → "1.0M"`, `999_999 → "1.0M"`, `1_000_000 → "1.0M"`, `1_500_000 → "1.5M"`; the existing cases (`2.5M`, `1.0M`, `34k`, `1k`, `999`, `0`) are unchanged.
- Backward compatibility: only the previously-malformed `[999_500, 999_999]` band changes; every other value formats exactly as before.

## Validation

```
pnpm exec vitest run tests/impact-card-core.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
