### PR TITLE
fix(scripts): handle single-value and empty sparkline series

### DIFF
--- a/scripts/lib/impact-card-svg.mjs
+++ b/scripts/lib/impact-card-svg.mjs
@@ -13,7 +13,10 @@ export function sparkline(x, y, w, h, values, mutedColor, accentColor, cardBg) {
   const min = Math.min(...values, 0);
   const range = max - min || 1;
   const n = values.length;
-  const stepX = w / (n - 1);
+  if (n === 0) return "";
+  // With a single point there is no horizontal step; keep stepX at 0 so the
+  // point lands at x instead of x + 0 * (w / 0) === NaN.
+  const stepX = n > 1 ? w / (n - 1) : 0;
   const pts = values.map((v, i) => [
     x + i * stepX,
     y + h - ((v - min) / range) * h,

--- a/tests/impact-card-svg.test.ts
+++ b/tests/impact-card-svg.test.ts
@@ -23,6 +23,17 @@ describe("sparkline", () => {
     // p0: y = 10 - ((-3 - -3)/4)*10 = 10 ; p1: y = 10 - ((0.5 - -3)/4)*10 = 1.25 -> "1.3"
     expect(svg).toContain('d="M0.0,10.0 L4.0,1.3"');
   });
+
+  it("places a single-value series at x without NaN coordinates", () => {
+    const svg = sparkline(0, 0, 100, 20, [5], "#mut", "#acc", "#bg");
+    expect(svg).not.toContain("NaN");
+    expect(svg).toContain('d="M0.0,0.0"');
+    expect(svg).toContain('<circle cx="0.0" cy="0.0" r="4" fill="#acc"/>');
+  });
+
+  it("returns empty markup for an empty series instead of throwing", () => {
+    expect(sparkline(0, 0, 100, 20, [], "#mut", "#acc", "#bg")).toBe("");
+  });
 });
 
 describe("meter", () => {


### PR DESCRIPTION
## Summary

`sparkline` (a standalone-unit-tested SVG helper) computed `stepX = w / (n - 1)`, which breaks on degenerate series:

- **Single value** — `stepX = w / 0 = Infinity`, so the point's x becomes `0 * Infinity = NaN`, and the emitted SVG contains `d="MNaN,0.0"` / `cx="NaN"` (broken markup):
  ```js
  sparkline(0, 0, 100, 20, [5], "#mut", "#acc", "#bg")
  // before: <path d="MNaN,0.0" .../> <circle cx="NaN" .../>
  // after:  <path d="M0.0,0.0" .../> <circle cx="0.0" .../>
  ```
- **Empty series** — `values.map` yields an empty points array and `pts[pts.length - 1]` (`pts[-1]`) is `undefined`, so destructuring it **throws** `TypeError: undefined is not iterable`.

## Fix

Guard both degenerate cases: return `""` for an empty series, and use `stepX = 0` for a single point so it lands at `x` with no NaN. Multi-point series are unchanged.

## Changed files

- `scripts/lib/impact-card-svg.mjs` — guard the empty and single-value cases.
- `tests/impact-card-svg.test.ts` — regression tests for single-value (no NaN) and empty (no throw).

## Quality evidence

- **No visual impact on real cards** — the current caller always feeds 12 weekly buckets; this hardens the standalone helper (which the suite unit-tests in isolation) against edge inputs.
- Verified: single value → `d="M0.0,0.0"` with no `NaN`; empty → `""` (no throw); the existing 3-point and 2-point series render byte-identically.
- Backward compatibility: only the previously-broken 0- and 1-length inputs change; every multi-point series is unchanged.

## Validation

```
pnpm exec vitest run tests/impact-card-svg.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
