### PR TITLE
fix(scripts): match the prod worker label exactly when resolving PR previews

### DIFF
--- a/scripts/resolve-pr-preview-url.mjs
+++ b/scripts/resolve-pr-preview-url.mjs
@@ -33,10 +33,15 @@ const nonDeploymentSourcePattern =
 // dev.heyclau.de).
 function isHeyClaudePreviewHost(hostname) {
   const host = String(hostname || "").toLowerCase();
+  if (host === "heyclau.de" || host === "www.heyclau.de") return true;
+  if (!host.endsWith(".workers.dev")) return false;
+  // The worker name is the first dot-label of the host: "heyclaude-prod" or a
+  // Workers Builds preview alias "<version>-heyclaude-prod". Match the label
+  // exactly so a sibling worker whose name merely CONTAINS the substring (e.g.
+  // "heyclaude-prod-next") or a "…heyclaude-prod…" subdomain is not selected.
+  const workerLabel = host.split(".")[0];
   return (
-    host === "heyclau.de" ||
-    host === "www.heyclau.de" ||
-    (host.endsWith(".workers.dev") && host.includes("heyclaude-prod"))
+    workerLabel === "heyclaude-prod" || workerLabel.endsWith("-heyclaude-prod")
   );
 }
 

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -46,6 +46,11 @@ describe("PR preview artifact validation flow", () => {
       "https://gittensory.aethereal.dev",
       "https://heyclaude-dev.zeronode.workers.dev",
       "https://dev.heyclau.de",
+      // Sibling workers whose name/subdomain merely contains the substring
+      // "heyclaude-prod" must not be mistaken for the prod worker.
+      "https://heyclaude-prod-next.zeronode.workers.dev",
+      "https://v1-heyclaude-prod-staging.zeronode.workers.dev",
+      "https://preview.heyclaude-prod.otheracct.workers.dev",
     ]) {
       expect(
         selectPreviewUrl([{ url, source: "github-deployment:x" }]),


### PR DESCRIPTION
## Summary

`isHeyClaudePreviewHost` (which decides whether a GitHub deployment/status/comment URL is the HeyClaude PR preview) accepted **any** `*.workers.dev` host that merely *contained* the substring `heyclaude-prod`:

```js
host.endsWith(".workers.dev") && host.includes("heyclaude-prod")
```

This Cloudflare account hosts several unrelated projects, and the file's whole purpose is to avoid selecting a sibling project's URL. But a sibling worker whose name or subdomain contains that substring slipped through:

```
heyclaude-prod-next.zeronode.workers.dev        // sibling worker  -> wrongly accepted
v1-heyclaude-prod-staging.zeronode.workers.dev  // sibling alias   -> wrongly accepted
preview.heyclaude-prod.otheracct.workers.dev    // other account   -> wrongly accepted
```

so the deployment artifact contract could run against the wrong site — exactly the mis-selection this file exists to prevent.

## Fix

Match the worker **name label** (the first dot-segment of the host) exactly, per the file's documented contract: `heyclaude-prod`, or a Workers Builds preview alias `<version>-heyclaude-prod`. The production site (`heyclau.de` / `www.heyclau.de`) and real version aliases still resolve; retired dev workers and substring siblings do not.

## Changed files

- `scripts/resolve-pr-preview-url.mjs` — exact worker-label match.
- `tests/deployment-preview-url.test.ts` — regression cases for the substring siblings.

## Quality evidence

- **No visual impact** — preview-URL resolution logic only.
- Verified (10 cases): `heyclaude-prod.*` and `abc123-heyclaude-prod.*` accepted; `heyclaude-prod-next.*`, `v1-heyclaude-prod-staging.*`, `preview.heyclaude-prod.otheracct.*`, `heyclaude-dev.*`, `dev.heyclau.de`, `gittensory.aethereal.dev` rejected; `heyclau.de` accepted.
- Backward compatibility: every case the existing tests assert (prod site + `abc123-heyclaude-prod` alias accepted; dev worker + sibling project rejected) is unchanged; only the substring-sibling gap is closed.

## Validation

```
pnpm exec vitest run tests/deployment-preview-url.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
