### PR TITLE
fix(registry): rescue job compensation ranges the shared-k magnitude inverts

### DIFF
--- a/packages/registry/src/seo-lib.js
+++ b/packages/registry/src/seo-lib.js
@@ -455,8 +455,21 @@ export function parseJobCompensation(value) {
   const maxHasK = amounts[1].toLowerCase().endsWith("k");
   // A "k" suffix on either endpoint sets the magnitude for the whole range.
   const sharedSuffix = minHasK || maxHasK ? "k" : "";
-  const minValue = parseAmount(amounts[0], sharedSuffix);
-  const maxValue = parseAmount(amounts[1], sharedSuffix);
+  let minValue = parseAmount(amounts[0], sharedSuffix);
+  let maxValue = parseAmount(amounts[1], sharedSuffix);
+  // If the shared-k magnitude inverts the range — e.g. "$500-$2k" promotes 500
+  // to 500000 while the max is 2000 — fall back to the endpoints' literal values
+  // so a valid range still resolves instead of being dropped. This only rescues
+  // ranges that would otherwise return undefined; it never rewrites a range that
+  // is already valid under the shared magnitude (e.g. "$80-$100k").
+  if (minValue && maxValue && minValue > maxValue) {
+    const literalMin = parseAmount(amounts[0], "");
+    const literalMax = parseAmount(amounts[1], "");
+    if (literalMin && literalMax && literalMin <= literalMax) {
+      minValue = literalMin;
+      maxValue = literalMax;
+    }
+  }
   // Reject inverted ranges so JSON-LD never advertises minValue > maxValue.
   if (!minValue || !maxValue || minValue > maxValue) return undefined;
 

--- a/tests/seo-lib.test.ts
+++ b/tests/seo-lib.test.ts
@@ -407,6 +407,17 @@ describe("parseJobCompensation", () => {
     expect(parseJobCompensation("£50k-£60k").currency).toBe("GBP");
   });
 
+  it("keeps a valid range when the shared k magnitude would invert it", () => {
+    // "$500-$2k": promoting 500 to 500000 would exceed the 2000 max, so fall
+    // back to the literal endpoints instead of dropping the range entirely.
+    expect(parseJobCompensation("$500-$2k").value).toMatchObject({
+      minValue: 500,
+      maxValue: 2000,
+    });
+    // A genuinely inverted range is still rejected.
+    expect(parseJobCompensation("$5k-$2")).toBeUndefined();
+  });
+
   it("infers pay periods from the compensation text", () => {
     expect(parseJobCompensation("$50-$60 per hour").value.unitText).toBe(
       "HOUR",


### PR DESCRIPTION
## Summary

`parseJobCompensation` applies a shared `k` magnitude to both endpoints, so a plain endpoint below 1000 is promoted to thousands (this is what makes `"$80-$100k"` resolve to `80000..100000`). But when that promotion pushes the **min above the max**, the inverted-range guard dropped the whole value and no `MonetaryAmount` was emitted:

```js
parseJobCompensation("$500-$2k")
// 500 promoted to 500000, max is 2000 -> 500000 > 2000 -> undefined (no salary markup)
```

So a legitimately-formatted mixed range silently loses its JobPosting salary structured data.

## Fix

When the shared magnitude inverts the range, fall back to the endpoints' **literal** values and use them only if they form a valid range:

```js
parseJobCompensation("$500-$2k") // -> minValue 500, maxValue 2000
```

This is **purely additive**: it only rescues ranges that previously returned `undefined`, and never rewrites a range already valid under the shared magnitude. Genuinely inverted ranges still return `undefined`.

## Changed files

- `packages/registry/src/seo-lib.js` — literal-endpoint fallback when the shared-k magnitude inverts the range.
- `tests/seo-lib.test.ts` — focused test for the rescued range and a still-rejected inverted range.

## Quality evidence

- **No visual impact** — structured-data (JSON-LD) logic only.
- Verified: `"$500-$2k" -> 500..2000`; the existing valid cases are unchanged (`"$100k-$140k" -> 100000..140000`, `"€80-€100k" -> 80000..100000`, `"$80-$100k" -> 80000..100000`); genuinely inverted ranges still return `undefined` (`"$5k-$2"`, `"$200k-$100k"`); a single value (`"$120k"`) still returns `undefined`.
- Backward compatibility: the fallback runs only on the `minValue > maxValue` path that already returned `undefined`, so no currently-valid output can change.

## Validation

```
pnpm exec vitest run tests/seo-lib.test.ts
git diff --check
```

## Notes

Filed as a direct PR since this repository restricts issue creation to non-collaborators; rationale is inline rather than a `Closes #` reference.
