### PR TITLE
feat(web): changelog platforms and tools entry egress

### DIFF
--- a/apps/web/src/lib/directory-page-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/directory-page-entry-cta-events-lib.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure directory page entry egress analytics helpers.
+ *
+ * Maps changelog diff, platforms matrix, and tools directory entry navigation
+ * to privacy-light event names without embedding entry titles or page copy.
+ */
+
+import type { ReleaseStream } from "@/data/changelog";
+import type { Platform, PlatformSupport } from "@/types/registry";
+
+export const CHANGELOG_DIFF_SURFACE = "changelog-diff";
+export const PLATFORMS_MATRIX_SURFACE = "platforms-matrix";
+export const TOOLS_DIRECTORY_SURFACE = "tools-directory";
+
+export type ChangelogDiffChangeKind = "added" | "updated" | "removed";
+
+export function directoryPageEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function changelogDiffEntryAnalyticsEvent(): string {
+  return "changelog_diff_entry_click";
+}
+
+export function changelogDiffEntryAnalyticsData(
+  category: string,
+  slug: string,
+  changeKind: ChangelogDiffChangeKind,
+  rowIndex: number,
+  rowCount: number,
+  releaseStream: ReleaseStream,
+) {
+  return {
+    entry: directoryPageEntryKey(category, slug),
+    surface: CHANGELOG_DIFF_SURFACE,
+    changeKind,
+    rowIndex,
+    rowCount,
+    releaseStream,
+  };
+}
+
+export function platformsMatrixEntryAnalyticsEvent(): string {
+  return "platforms_matrix_entry_click";
+}
+
+export function platformsMatrixEntryAnalyticsData(
+  category: string,
+  slug: string,
+  platformId: Platform,
+  support: PlatformSupport,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    entry: directoryPageEntryKey(category, slug),
+    surface: PLATFORMS_MATRIX_SURFACE,
+    platformId,
+    support,
+    rowIndex,
+    rowCount,
+  };
+}
+
+export function toolsDirectoryEntryAnalyticsEvent(): string {
+  return "tools_directory_entry_click";
+}
+
+export function toolsDirectoryEntryAnalyticsData(
+  slug: string,
+  cardIndex: number,
+  toolCount: number,
+) {
+  return {
+    entry: directoryPageEntryKey("tools", slug),
+    surface: TOOLS_DIRECTORY_SURFACE,
+    cardIndex,
+    toolCount,
+  };
+}

--- a/apps/web/src/lib/directory-page-entry-cta-events.ts
+++ b/apps/web/src/lib/directory-page-entry-cta-events.ts
@@ -1,0 +1,16 @@
+/**
+ * Directory page entry egress CTA event surface.
+ */
+export {
+  CHANGELOG_DIFF_SURFACE,
+  PLATFORMS_MATRIX_SURFACE,
+  TOOLS_DIRECTORY_SURFACE,
+  changelogDiffEntryAnalyticsData,
+  changelogDiffEntryAnalyticsEvent,
+  directoryPageEntryKey,
+  platformsMatrixEntryAnalyticsData,
+  platformsMatrixEntryAnalyticsEvent,
+  toolsDirectoryEntryAnalyticsData,
+  toolsDirectoryEntryAnalyticsEvent,
+  type ChangelogDiffChangeKind,
+} from "@/lib/directory-page-entry-cta-events-lib";

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -5,6 +5,11 @@ import { CHANGELOG, RELEASE_NOTES, type ReleaseStream } from "@/data/changelog";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
 import { PageContainer } from "@/components/page-container";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  changelogDiffEntryAnalyticsData,
+  changelogDiffEntryAnalyticsEvent,
+} from "@/lib/directory-page-entry-cta-events";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { changelogItemListJsonLd } from "@/lib/changelog-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
@@ -212,11 +217,24 @@ function ChangelogPage() {
                                 <Icon className="h-3 w-3" /> {k} · {items.length}
                               </div>
                               <ul className="space-y-1 text-xs">
-                                {items.map((d) => (
+                                {items.map((d, rowIndex) => (
                                   <li key={`${d.category}/${d.slug}`} className="truncate">
                                     <Link
                                       to="/entry/$category/$slug"
                                       params={{ category: d.category, slug: d.slug }}
+                                      onClick={() =>
+                                        trackEvent(
+                                          changelogDiffEntryAnalyticsEvent(),
+                                          changelogDiffEntryAnalyticsData(
+                                            d.category,
+                                            d.slug,
+                                            k,
+                                            rowIndex,
+                                            items.length,
+                                            note.stream,
+                                          ),
+                                        )
+                                      }
                                       className="text-ink hover:underline"
                                     >
                                       {d.title}

--- a/apps/web/src/routes/platforms.tsx
+++ b/apps/web/src/routes/platforms.tsx
@@ -6,6 +6,11 @@ import { PageHeader } from "@/components/page-header";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { trackEvent } from "@/lib/analytics";
+import {
+  platformsMatrixEntryAnalyticsData,
+  platformsMatrixEntryAnalyticsEvent,
+} from "@/lib/directory-page-entry-cta-events";
 
 // Same card for og:image and twitter:image; the inputs are static.
 const OG_IMAGE = ogImageUrl({ title: "Platform compatibility", eyebrow: "Platforms" });
@@ -72,7 +77,7 @@ function PlatformsPage() {
               <div className="font-display text-base font-semibold text-ink">{p.label}</div>
               <p className="mt-1 text-xs text-ink-muted">{p.tagline}</p>
               <ul className="mt-4 space-y-2 text-xs">
-                {rows.map((r) => (
+                {rows.map((r, rowIndex) => (
                   <li
                     key={`${r.category}/${r.slug}`}
                     className="flex items-center justify-between gap-2 border-t border-border pt-2 first:border-0 first:pt-0"
@@ -80,6 +85,19 @@ function PlatformsPage() {
                     <Link
                       to="/entry/$category/$slug"
                       params={{ category: r.category, slug: r.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          platformsMatrixEntryAnalyticsEvent(),
+                          platformsMatrixEntryAnalyticsData(
+                            r.category,
+                            r.slug,
+                            p.id,
+                            r.support,
+                            rowIndex,
+                            rows.length,
+                          ),
+                        )
+                      }
                       className="truncate text-ink hover:underline"
                     >
                       {r.title}

--- a/apps/web/src/routes/tools.tsx
+++ b/apps/web/src/routes/tools.tsx
@@ -6,6 +6,11 @@ import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { trackEvent } from "@/lib/analytics";
+import {
+  toolsDirectoryEntryAnalyticsData,
+  toolsDirectoryEntryAnalyticsEvent,
+} from "@/lib/directory-page-entry-cta-events";
 
 // Same card for og:image and twitter:image; the inputs are static.
 const OG_IMAGE = ogImageUrl({ title: "Tools that pair well with Claude", eyebrow: "Tools" });
@@ -81,11 +86,17 @@ function ToolsPage() {
       </div>
 
       <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {COMMERCIAL_TOOLS.map((t) => (
+        {COMMERCIAL_TOOLS.map((t, cardIndex) => (
           <Link
             key={t.slug}
             to="/entry/$category/$slug"
             params={{ category: "tools", slug: t.slug }}
+            onClick={() =>
+              trackEvent(
+                toolsDirectoryEntryAnalyticsEvent(),
+                toolsDirectoryEntryAnalyticsData(t.slug, cardIndex, COMMERCIAL_TOOLS.length),
+              )
+            }
             className="group flex flex-col gap-3 rounded-xl border border-border bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2"
           >
             <div className="flex items-start justify-between gap-2">

--- a/tests/directory-page-entry-cta-events-lib.test.ts
+++ b/tests/directory-page-entry-cta-events-lib.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHANGELOG_DIFF_SURFACE,
+  PLATFORMS_MATRIX_SURFACE,
+  TOOLS_DIRECTORY_SURFACE,
+  changelogDiffEntryAnalyticsData,
+  changelogDiffEntryAnalyticsEvent,
+  platformsMatrixEntryAnalyticsData,
+  platformsMatrixEntryAnalyticsEvent,
+  toolsDirectoryEntryAnalyticsData,
+  toolsDirectoryEntryAnalyticsEvent,
+} from "@/lib/directory-page-entry-cta-events-lib";
+
+describe("directory page entry cta events lib", () => {
+  it("builds privacy-light changelog diff entry egress analytics", () => {
+    expect(changelogDiffEntryAnalyticsEvent()).toBe(
+      "changelog_diff_entry_click",
+    );
+    expect(
+      changelogDiffEntryAnalyticsData(
+        "mcp",
+        "browser",
+        "added",
+        0,
+        5,
+        "release",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: CHANGELOG_DIFF_SURFACE,
+      changeKind: "added",
+      rowIndex: 0,
+      rowCount: 5,
+      releaseStream: "release",
+    });
+  });
+
+  it("builds privacy-light platforms matrix entry egress analytics", () => {
+    expect(platformsMatrixEntryAnalyticsEvent()).toBe(
+      "platforms_matrix_entry_click",
+    );
+    expect(
+      platformsMatrixEntryAnalyticsData(
+        "skills",
+        "demo",
+        "cursor",
+        "native",
+        2,
+        8,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: PLATFORMS_MATRIX_SURFACE,
+      platformId: "cursor",
+      support: "native",
+      rowIndex: 2,
+      rowCount: 8,
+    });
+  });
+
+  it("builds privacy-light tools directory entry egress analytics", () => {
+    expect(toolsDirectoryEntryAnalyticsEvent()).toBe(
+      "tools_directory_entry_click",
+    );
+    expect(toolsDirectoryEntryAnalyticsData("cursor", 1, 12)).toEqual({
+      entry: "tools/cursor",
+      surface: TOOLS_DIRECTORY_SURFACE,
+      cardIndex: 1,
+      toolCount: 12,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add privacy-light entry egress analytics for changelog diff links, platforms matrix rows, and tools directory cards
- New events: `changelog_diff_entry_click`, `platforms_matrix_entry_click`, `tools_directory_entry_click`
- Directory page entry CTA lib + wrapper + vitest coverage

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build pass locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)
- [ ] Manual: click changelog diff entries, platform matrix rows, tools cards