### PR TITLE
test(scripts): extract content-audit issue detector and cover it

### DIFF
--- a/scripts/audit-content.mjs
+++ b/scripts/audit-content.mjs
@@ -5,14 +5,14 @@ import prettier from "prettier";
 
 import {
   CATEGORY_SCHEMAS,
-  DEFAULT_DIRECTORY_REPO_URL,
-  FORBIDDEN_CONTENT_FIELDS,
   inferSectionBooleans,
   inferStructuredFields,
   normalizeBody,
   validateEntry,
 } from "@heyclaude/registry/content-schema";
 import { parseSafeFrontmatter } from "@heyclaude/registry/frontmatter";
+
+import { collectContentIssues } from "./lib/content-audit-issues.mjs";
 
 const repoRoot = process.cwd();
 const contentRoot = path.join(repoRoot, "content");
@@ -52,14 +52,6 @@ const reportPath =
     : path.join(repoRoot, "content/data/content-audit.json");
 
 const report = [];
-const oldBrandOrDomainPattern = new RegExp(
-  `${["claude", "pro"].join("")}\\.directory|${[
-    "Claude",
-    " Pro ",
-    "Directory",
-  ].join("")}`,
-  "i",
-);
 
 for (const category of Object.keys(CATEGORY_SCHEMAS)) {
   if (selectedCategories.size > 0 && !selectedCategories.has(category)) {
@@ -83,81 +75,12 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
     );
     const validation = validateEntry(category, parsed.data, inferred);
     const sectionFlags = inferSectionBooleans(normalizedBody);
-    const issues = [];
-
-    if (parsed.data.repoUrl === DEFAULT_DIRECTORY_REPO_URL) {
-      issues.push("uses_default_directory_repo_url");
-    }
-
-    if (String(parsed.data.description ?? "").trim().length > 320) {
-      issues.push("description_too_long");
-    }
-
-    if (!String(parsed.data.seoTitle ?? "").trim()) {
-      issues.push("missing_seoTitle");
-    }
-
-    if (!String(parsed.data.seoDescription ?? "").trim()) {
-      issues.push("missing_seoDescription");
-    }
-
-    if (
-      !Array.isArray(parsed.data.keywords) ||
-      parsed.data.keywords.length === 0
-    ) {
-      issues.push("missing_keywords");
-    }
-
-    if (oldBrandOrDomainPattern.test(source)) {
-      issues.push("old_brand_or_domain_reference");
-    }
-
-    if (/\[Script content from first example\]/.test(source)) {
-      issues.push("placeholder_script_marker");
-    }
-
-    if (
-      parsed.data.category &&
-      String(parsed.data.category).trim() !== category
-    ) {
-      issues.push("category_mismatch");
-    }
-
-    for (const field of FORBIDDEN_CONTENT_FIELDS) {
-      if (parsed.data[field] !== undefined) {
-        issues.push(`forbidden_field_${field}`);
-      }
-    }
-
-    if (
-      category === "guides" &&
-      parsed.data.copySnippet &&
-      String(parsed.data.copySnippet).trim()
-    ) {
-      issues.push("guide_copy_snippet_present");
-    }
-
-    if (
-      category === "collections" &&
-      parsed.data.copySnippet &&
-      String(parsed.data.copySnippet).trim()
-    ) {
-      issues.push("collection_copy_snippet_present");
-    }
-
-    if (
-      parsed.data.hasPrerequisites === false &&
-      sectionFlags.hasPrerequisites
-    ) {
-      issues.push("hasPrerequisites_false_but_section_exists");
-    }
-
-    if (
-      parsed.data.hasTroubleshooting === false &&
-      sectionFlags.hasTroubleshooting
-    ) {
-      issues.push("hasTroubleshooting_false_but_section_exists");
-    }
+    const issues = collectContentIssues({
+      data: parsed.data,
+      source,
+      category,
+      sectionFlags,
+    });
 
     report.push({
       category,

--- a/scripts/lib/content-audit-issues.mjs
+++ b/scripts/lib/content-audit-issues.mjs
@@ -1,0 +1,96 @@
+// Pure content-quality issue detector behind scripts/audit-content.mjs: given a
+// parsed entry's frontmatter, raw source, category, and section booleans, return
+// the list of semantic issue codes. Split out so the rule set can be unit-tested
+// without walking the content tree.
+
+import {
+  DEFAULT_DIRECTORY_REPO_URL,
+  FORBIDDEN_CONTENT_FIELDS,
+} from "@heyclaude/registry/content-schema";
+
+// Matches leftover references to the pre-rebrand name/domain in an entry's body.
+export const oldBrandOrDomainPattern = new RegExp(
+  `${["claude", "pro"].join("")}\\.directory|${[
+    "Claude",
+    " Pro ",
+    "Directory",
+  ].join("")}`,
+  "i",
+);
+
+/**
+ * Collect semantic issue codes for one content entry.
+ * @param {object} args
+ * @param {object} args.data parsed frontmatter
+ * @param {string} args.source raw file source (for text pattern checks)
+ * @param {string} args.category the entry's directory category
+ * @param {object} args.sectionFlags inferred section booleans (hasPrerequisites, hasTroubleshooting)
+ * @returns {string[]}
+ */
+export function collectContentIssues({ data, source, category, sectionFlags }) {
+  const issues = [];
+
+  if (data.repoUrl === DEFAULT_DIRECTORY_REPO_URL) {
+    issues.push("uses_default_directory_repo_url");
+  }
+
+  if (String(data.description ?? "").trim().length > 320) {
+    issues.push("description_too_long");
+  }
+
+  if (!String(data.seoTitle ?? "").trim()) {
+    issues.push("missing_seoTitle");
+  }
+
+  if (!String(data.seoDescription ?? "").trim()) {
+    issues.push("missing_seoDescription");
+  }
+
+  if (!Array.isArray(data.keywords) || data.keywords.length === 0) {
+    issues.push("missing_keywords");
+  }
+
+  if (oldBrandOrDomainPattern.test(source)) {
+    issues.push("old_brand_or_domain_reference");
+  }
+
+  if (/\[Script content from first example\]/.test(source)) {
+    issues.push("placeholder_script_marker");
+  }
+
+  if (data.category && String(data.category).trim() !== category) {
+    issues.push("category_mismatch");
+  }
+
+  for (const field of FORBIDDEN_CONTENT_FIELDS) {
+    if (data[field] !== undefined) {
+      issues.push(`forbidden_field_${field}`);
+    }
+  }
+
+  if (
+    category === "guides" &&
+    data.copySnippet &&
+    String(data.copySnippet).trim()
+  ) {
+    issues.push("guide_copy_snippet_present");
+  }
+
+  if (
+    category === "collections" &&
+    data.copySnippet &&
+    String(data.copySnippet).trim()
+  ) {
+    issues.push("collection_copy_snippet_present");
+  }
+
+  if (data.hasPrerequisites === false && sectionFlags.hasPrerequisites) {
+    issues.push("hasPrerequisites_false_but_section_exists");
+  }
+
+  if (data.hasTroubleshooting === false && sectionFlags.hasTroubleshooting) {
+    issues.push("hasTroubleshooting_false_but_section_exists");
+  }
+
+  return issues;
+}

--- a/tests/content-audit-issues.test.ts
+++ b/tests/content-audit-issues.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_DIRECTORY_REPO_URL } from "@heyclaude/registry/content-schema";
+import { collectContentIssues } from "../scripts/lib/content-audit-issues.mjs";
+
+describe("collectContentIssues", () => {
+  it("returns no issues for a complete, clean entry", () => {
+    expect(
+      collectContentIssues({
+        data: {
+          seoTitle: "Title",
+          seoDescription: "Description",
+          keywords: ["k"],
+          // description omitted -> exercises the `?? ""` fallback
+          repoUrl: "https://github.com/acme/x",
+        },
+        source: "a plain body with nothing flagged",
+        category: "agents",
+        sectionFlags: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags the full set of issues for an under-specified guide", () => {
+    expect(
+      collectContentIssues({
+        data: {
+          repoUrl: DEFAULT_DIRECTORY_REPO_URL,
+          description: "x".repeat(321),
+          keywords: [],
+          category: "mcp",
+          viewCount: 5,
+          copySnippet: "copy me",
+          hasPrerequisites: false,
+          hasTroubleshooting: false,
+        },
+        source:
+          "Old link claudepro.directory and [Script content from first example].",
+        category: "guides",
+        sectionFlags: { hasPrerequisites: true, hasTroubleshooting: true },
+      }),
+    ).toEqual([
+      "uses_default_directory_repo_url",
+      "description_too_long",
+      "missing_seoTitle",
+      "missing_seoDescription",
+      "missing_keywords",
+      "old_brand_or_domain_reference",
+      "placeholder_script_marker",
+      "category_mismatch",
+      "forbidden_field_viewCount",
+      "guide_copy_snippet_present",
+      "hasPrerequisites_false_but_section_exists",
+      "hasTroubleshooting_false_but_section_exists",
+    ]);
+  });
+
+  it("flags a collection copy snippet and missing keywords when keywords is absent", () => {
+    expect(
+      collectContentIssues({
+        data: {
+          seoTitle: "t",
+          seoDescription: "d",
+          description: "short",
+          repoUrl: "https://github.com/acme/x",
+          category: "collections",
+          copySnippet: "c",
+        },
+        source: "plain body",
+        category: "collections",
+        sectionFlags: {},
+      }),
+    ).toEqual(["missing_keywords", "collection_copy_snippet_present"]);
+  });
+
+  it("does not flag section mismatches when the boolean is not explicitly false", () => {
+    expect(
+      collectContentIssues({
+        data: {
+          seoTitle: "t",
+          seoDescription: "d",
+          keywords: ["k"],
+          description: "short",
+          repoUrl: "https://github.com/acme/x",
+        },
+        source: "plain body",
+        category: "hooks",
+        sectionFlags: { hasPrerequisites: true, hasTroubleshooting: true },
+      }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/audit-content.mjs` detected an entry's semantic issues with a ~13-rule block inlined in its content-walk loop, so the core content-quality rules were untestable without walking the tree. This moves the pure detector into `scripts/lib/content-audit-issues.mjs` - matching the existing `scripts/lib` convention - and calls it from the loop.

### Changes

- Add `scripts/lib/content-audit-issues.mjs` - `collectContentIssues({ data, source, category, sectionFlags })` plus the old-brand/domain pattern it uses; imports `DEFAULT_DIRECTORY_REPO_URL` / `FORBIDDEN_CONTENT_FIELDS` from the registry.
- `scripts/audit-content.mjs` - import `collectContentIssues`; drop the inline block, the local pattern, and the now-unused registry imports.
- Add `tests/content-audit-issues.test.ts` - covers a clean entry (no issues, incl. the description `?? ""` fallback), a fully under-specified guide that triggers every rule in order, a collection copy-snippet + absent-keywords case, and the not-explicitly-false section booleans. Branch coverage 100% (46/46).

### Validation

- `pnpm exec vitest run tests/content-audit-issues.test.ts` - 4 passed
- `node --check scripts/audit-content.mjs` - clean; `collectContentIssues` is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the detected issue codes are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
