### PR TITLE
test(scripts): extract git content-updated-at parser and cover it

### DIFF
--- a/scripts/build-content-index.mjs
+++ b/scripts/build-content-index.mjs
@@ -18,6 +18,7 @@ import {
 
 import { pickAtlasEntry } from "./lib/atlas-entry.mjs";
 import { artifactOutputPath } from "./lib/artifact-output-path.mjs";
+import { parseGitContentUpdatedAt } from "./lib/git-content-updated-at.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -199,39 +200,17 @@ function writeTextFile(filePath, value) {
 }
 
 function loadGitContentUpdatedAt() {
-  const values = new Map();
-
   try {
     const output = execFileSync(
       "git",
       ["log", "--format=@@heyclaude:%cI", "--name-only", "--", "content"],
       { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
     );
-    let commitUpdatedAt = null;
-
-    for (const line of output.split("\n")) {
-      if (line.startsWith("@@heyclaude:")) {
-        commitUpdatedAt = line.slice("@@heyclaude:".length).trim() || null;
-        continue;
-      }
-
-      const relativePath = line.trim();
-      if (
-        !commitUpdatedAt ||
-        !relativePath.startsWith("content/") ||
-        !relativePath.endsWith(".mdx") ||
-        values.has(relativePath)
-      ) {
-        continue;
-      }
-
-      values.set(relativePath, commitUpdatedAt);
-    }
+    return parseGitContentUpdatedAt(output);
   } catch {
     // Keep registry generation usable outside a Git checkout.
+    return new Map();
   }
-
-  return values;
 }
 
 function loadExistingEntryRepoStats() {

--- a/scripts/lib/git-content-updated-at.mjs
+++ b/scripts/lib/git-content-updated-at.mjs
@@ -1,0 +1,38 @@
+// Pure parser behind scripts/build-content-index.mjs: turning the
+// `git log --format=@@heyclaude:%cI --name-only -- content` output into a
+// map of content file path -> most-recent commit ISO timestamp. Split out from
+// the execFileSync caller so the parsing can be unit-tested without a git
+// checkout.
+
+/**
+ * Parse `git log` output (commit markers interleaved with changed file names)
+ * into a Map of "content/....mdx" -> the commit timestamp of its most recent
+ * change. Because git logs newest-first, the first timestamp seen for a path
+ * wins; blank/unknown commit markers reset the current timestamp so orphan file
+ * lines are skipped.
+ */
+export function parseGitContentUpdatedAt(output) {
+  const values = new Map();
+  let commitUpdatedAt = null;
+
+  for (const line of String(output ?? "").split("\n")) {
+    if (line.startsWith("@@heyclaude:")) {
+      commitUpdatedAt = line.slice("@@heyclaude:".length).trim() || null;
+      continue;
+    }
+
+    const relativePath = line.trim();
+    if (
+      !commitUpdatedAt ||
+      !relativePath.startsWith("content/") ||
+      !relativePath.endsWith(".mdx") ||
+      values.has(relativePath)
+    ) {
+      continue;
+    }
+
+    values.set(relativePath, commitUpdatedAt);
+  }
+
+  return values;
+}

--- a/tests/git-content-updated-at.test.ts
+++ b/tests/git-content-updated-at.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGitContentUpdatedAt } from "../scripts/lib/git-content-updated-at.mjs";
+
+describe("parseGitContentUpdatedAt", () => {
+  it("maps each content .mdx path to its commit timestamp", () => {
+    const output = [
+      "@@heyclaude:2026-02-02T00:00:00Z",
+      "content/agents/a.mdx",
+      "content/mcp/b.mdx",
+    ].join("\n");
+    expect([...parseGitContentUpdatedAt(output).entries()]).toEqual([
+      ["content/agents/a.mdx", "2026-02-02T00:00:00Z"],
+      ["content/mcp/b.mdx", "2026-02-02T00:00:00Z"],
+    ]);
+  });
+
+  it("keeps the first (most recent) timestamp for a repeated path", () => {
+    const output = [
+      "@@heyclaude:2026-02-02T00:00:00Z",
+      "content/agents/a.mdx",
+      "@@heyclaude:2026-01-01T00:00:00Z",
+      "content/agents/a.mdx",
+    ].join("\n");
+    expect(parseGitContentUpdatedAt(output).get("content/agents/a.mdx")).toBe(
+      "2026-02-02T00:00:00Z",
+    );
+  });
+
+  it("skips non-content paths and non-mdx files", () => {
+    const output = [
+      "@@heyclaude:2026-02-02T00:00:00Z",
+      "content/agents/a.mdx",
+      "README.md",
+      "content/agents/a.json",
+    ].join("\n");
+    expect([...parseGitContentUpdatedAt(output).keys()]).toEqual([
+      "content/agents/a.mdx",
+    ]);
+  });
+
+  it("skips file lines that appear before any commit marker", () => {
+    const output = ["content/agents/orphan.mdx"].join("\n");
+    expect(parseGitContentUpdatedAt(output).size).toBe(0);
+  });
+
+  it("resets on a blank commit marker so later files are skipped", () => {
+    const output = ["@@heyclaude:", "content/agents/a.mdx"].join("\n");
+    expect(parseGitContentUpdatedAt(output).size).toBe(0);
+  });
+
+  it("returns an empty map for empty/nullish output", () => {
+    expect(parseGitContentUpdatedAt("").size).toBe(0);
+    expect(parseGitContentUpdatedAt(null).size).toBe(0);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/build-content-index.mjs` parsed the `git log --name-only` output into a path -> commit-timestamp map inline inside its `execFileSync` caller, so the parsing (commit-marker handling, newest-wins dedup, path filtering) was untestable without a git checkout. This moves the pure parser into `scripts/lib/git-content-updated-at.mjs` - matching the existing `scripts/lib` convention - and has `loadGitContentUpdatedAt` delegate to it.

### Changes

- Add `scripts/lib/git-content-updated-at.mjs` - `parseGitContentUpdatedAt(output)`.
- `scripts/build-content-index.mjs` - `loadGitContentUpdatedAt` now execs and delegates the parse (returning an empty Map outside a git checkout); drop the inline loop.
- Add `tests/git-content-updated-at.test.ts` - covers mapping content `.mdx` paths to their commit timestamp, first-wins for a repeated path, skipping non-content/non-mdx paths and orphan file lines before any commit marker, the blank-commit-marker reset, and empty/nullish input. Branch coverage 100% (12/12).

### Validation

- `pnpm exec vitest run tests/git-content-updated-at.test.ts` - 6 passed
- `node --check scripts/build-content-index.mjs` - clean; the parser is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the resulting map is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
