### PR TITLE
feat(web): insights page entry egress analytics

### DIFF
--- a/apps/web/src/lib/insights-page-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/insights-page-entry-cta-events-lib.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure insights page entry egress analytics helpers.
+ *
+ * Maps contributor, quality, validators, and state report entry navigation to
+ * privacy-light event names without embedding entry titles or page copy.
+ */
+
+import type { ContributorAcceptedEntryRole } from "@/data/contributors";
+
+export const CONTRIBUTOR_PROFILE_SURFACE = "contributor-profile";
+export const QUALITY_QUEUE_SURFACE = "quality-queue";
+export const VALIDATORS_ATTENTION_SURFACE = "validators-attention";
+export const VALIDATORS_RECENT_REVIEWED_SURFACE = "validators-recent-reviewed";
+export const STATE_REPORT_SURFACE = "state-report";
+
+export type QualityQueueId = "improvement" | "trust";
+export type StateReportId = "claude-tooling" | "mcp-servers";
+export type ContributorProfileRole = ContributorAcceptedEntryRole | "reviewed";
+
+export function insightsPageEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function contributorProfileEntryAnalyticsEvent(): string {
+  return "contributor_profile_entry_click";
+}
+
+export function contributorProfileEntryAnalyticsData(
+  category: string,
+  slug: string,
+  contributorSlug: string,
+  role: ContributorProfileRole,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    entry: insightsPageEntryKey(category, slug),
+    surface: CONTRIBUTOR_PROFILE_SURFACE,
+    contributorSlug,
+    role,
+    rowIndex,
+    rowCount,
+  };
+}
+
+export function qualityQueueEntryAnalyticsEvent(): string {
+  return "quality_queue_entry_click";
+}
+
+export function qualityQueueEntryAnalyticsData(
+  category: string,
+  slug: string,
+  queueId: QualityQueueId,
+  score: number,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    entry: insightsPageEntryKey(category, slug),
+    surface: QUALITY_QUEUE_SURFACE,
+    queueId,
+    score,
+    rowIndex,
+    rowCount,
+  };
+}
+
+export function validatorsAttentionEntryAnalyticsEvent(): string {
+  return "validators_attention_entry_click";
+}
+
+export function validatorsAttentionEntryAnalyticsData(
+  category: string,
+  slug: string,
+  expertiseId: string,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    entry: insightsPageEntryKey(category, slug),
+    surface: VALIDATORS_ATTENTION_SURFACE,
+    expertiseId,
+    rowIndex,
+    rowCount,
+  };
+}
+
+export function validatorsRecentReviewedEntryAnalyticsEvent(): string {
+  return "validators_recent_reviewed_entry_click";
+}
+
+export function validatorsRecentReviewedEntryAnalyticsData(
+  category: string,
+  slug: string,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    entry: insightsPageEntryKey(category, slug),
+    surface: VALIDATORS_RECENT_REVIEWED_SURFACE,
+    rowIndex,
+    rowCount,
+  };
+}
+
+export function stateReportEntryAnalyticsEvent(): string {
+  return "state_report_entry_click";
+}
+
+export function stateReportEntryAnalyticsData(
+  category: string,
+  slug: string,
+  reportId: StateReportId,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    entry: insightsPageEntryKey(category, slug),
+    surface: STATE_REPORT_SURFACE,
+    reportId,
+    rowIndex,
+    rowCount,
+  };
+}

--- a/apps/web/src/lib/insights-page-entry-cta-events.ts
+++ b/apps/web/src/lib/insights-page-entry-cta-events.ts
@@ -1,0 +1,24 @@
+/**
+ * Insights page entry egress CTA event surface.
+ */
+export {
+  CONTRIBUTOR_PROFILE_SURFACE,
+  QUALITY_QUEUE_SURFACE,
+  STATE_REPORT_SURFACE,
+  VALIDATORS_ATTENTION_SURFACE,
+  VALIDATORS_RECENT_REVIEWED_SURFACE,
+  contributorProfileEntryAnalyticsData,
+  contributorProfileEntryAnalyticsEvent,
+  insightsPageEntryKey,
+  qualityQueueEntryAnalyticsData,
+  qualityQueueEntryAnalyticsEvent,
+  stateReportEntryAnalyticsData,
+  stateReportEntryAnalyticsEvent,
+  validatorsAttentionEntryAnalyticsData,
+  validatorsAttentionEntryAnalyticsEvent,
+  validatorsRecentReviewedEntryAnalyticsData,
+  validatorsRecentReviewedEntryAnalyticsEvent,
+  type ContributorProfileRole,
+  type QualityQueueId,
+  type StateReportId,
+} from "@/lib/insights-page-entry-cta-events-lib";

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -23,6 +23,11 @@ import { Monogram } from "@/components/monogram";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
+import { trackEvent } from "@/lib/analytics";
+import {
+  contributorProfileEntryAnalyticsData,
+  contributorProfileEntryAnalyticsEvent,
+} from "@/lib/insights-page-entry-cta-events";
 import { contributorPersonJsonLd } from "@/lib/contributor-person-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
 import { ogImageMetaTags } from "@/lib/og-meta-lib";
@@ -233,12 +238,14 @@ function ContributionSection({
         <p className="mt-3 text-sm text-ink-muted">{empty ?? "No entries yet."}</p>
       ) : (
         <div className="mt-4 divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-          {entries.map((entry) => (
+          {entries.map((entry, rowIndex) => (
             <ContributionRow
               key={`${role ?? "accepted"}-${entry.category}-${entry.slug}`}
               entry={entry}
               contributor={contributor}
               role={role ?? contributorAcceptedEntryRole(contributor, entry) ?? "authored"}
+              rowIndex={rowIndex}
+              rowCount={entries.length}
             />
           ))}
         </div>
@@ -267,10 +274,14 @@ function ContributionRow({
   entry,
   contributor,
   role,
+  rowIndex,
+  rowCount,
 }: {
   entry: Entry;
   contributor: Contributor;
   role: ContributionRole;
+  rowIndex: number;
+  rowCount: number;
 }) {
   const RoleIcon = roleIcon[role];
   const submitter = submitterAttribution(entry);
@@ -291,6 +302,19 @@ function ContributionRow({
         <Link
           to="/entry/$category/$slug"
           params={{ category: entry.category, slug: entry.slug }}
+          onClick={() =>
+            trackEvent(
+              contributorProfileEntryAnalyticsEvent(),
+              contributorProfileEntryAnalyticsData(
+                entry.category,
+                entry.slug,
+                contributor.slug,
+                role,
+                rowIndex,
+                rowCount,
+              ),
+            )
+          }
           className="inline-flex max-w-full flex-wrap items-baseline gap-x-2"
         >
           <h3 className="font-display text-[15px] font-semibold tracking-tight text-ink group-hover:underline">

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -21,6 +21,12 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { entryRef } from "@/lib/entry-identity";
+import { trackEvent } from "@/lib/analytics";
+import {
+  qualityQueueEntryAnalyticsData,
+  qualityQueueEntryAnalyticsEvent,
+  type QualityQueueId,
+} from "@/lib/insights-page-entry-cta-events";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/quality")({
@@ -188,11 +194,13 @@ function QualityPage() {
         <Queue
           title="Improvement queue"
           help="Lowest-scoring entries by completeness and trust signals."
+          queueId="improvement"
           rows={improvementQueue}
         />
         <Queue
           title="Trust queue"
           help="Solid entries with one or two recommendations."
+          queueId="trust"
           rows={trustQueue}
         />
       </div>
@@ -424,7 +432,17 @@ function Bar({ label, pct }: { label: string; pct: number }) {
   );
 }
 
-function Queue({ title, help, rows }: { title: string; help: string; rows: QualityRow[] }) {
+function Queue({
+  title,
+  help,
+  queueId,
+  rows,
+}: {
+  title: string;
+  help: string;
+  queueId: QualityQueueId;
+  rows: QualityRow[];
+}) {
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-surface">
       <div className="border-b border-border px-5 py-3">
@@ -432,12 +450,25 @@ function Queue({ title, help, rows }: { title: string; help: string; rows: Quali
         <p className="text-xs text-ink-muted">{help}</p>
       </div>
       <ul>
-        {rows.map((r) => (
+        {rows.map((r, rowIndex) => (
           <li key={entryRef(r.entry)} className="border-b border-border px-5 py-3 last:border-0">
             <div className="flex items-center justify-between gap-3">
               <Link
                 to="/entry/$category/$slug"
                 params={{ category: r.entry.category, slug: r.entry.slug }}
+                onClick={() =>
+                  trackEvent(
+                    qualityQueueEntryAnalyticsEvent(),
+                    qualityQueueEntryAnalyticsData(
+                      r.entry.category,
+                      r.entry.slug,
+                      queueId,
+                      r.score,
+                      rowIndex,
+                      rows.length,
+                    ),
+                  )
+                }
                 className="truncate text-sm font-medium text-ink hover:underline"
               >
                 {r.entry.title}

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -21,6 +21,11 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { CountUp } from "@/components/count-up";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { trackEvent } from "@/lib/analytics";
+import {
+  stateReportEntryAnalyticsData,
+  stateReportEntryAnalyticsEvent,
+} from "@/lib/insights-page-entry-cta-events";
 
 const PATH = "/state-of-claude-tooling";
 const TITLE = "State of Claude Tooling";
@@ -259,7 +264,7 @@ function StateOfClaudeToolingPage() {
           The ten most recently dated entries in the registry snapshot.
         </p>
         <ol className="mt-4 overflow-hidden rounded-xl border border-border bg-surface">
-          {RECENT_ADDITIONS.map((e) => (
+          {RECENT_ADDITIONS.map((e, rowIndex) => (
             <li
               key={`${e.category}/${e.slug}`}
               className="flex items-center justify-between gap-3 border-b border-border px-5 py-3 last:border-0"
@@ -267,6 +272,18 @@ function StateOfClaudeToolingPage() {
               <Link
                 to="/entry/$category/$slug"
                 params={{ category: e.category, slug: e.slug }}
+                onClick={() =>
+                  trackEvent(
+                    stateReportEntryAnalyticsEvent(),
+                    stateReportEntryAnalyticsData(
+                      e.category,
+                      e.slug,
+                      "claude-tooling",
+                      rowIndex,
+                      RECENT_ADDITIONS.length,
+                    ),
+                  )
+                }
                 className="min-w-0 truncate text-sm font-medium text-ink hover:underline"
               >
                 {e.title}

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -17,6 +17,11 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
+import { trackEvent } from "@/lib/analytics";
+import {
+  stateReportEntryAnalyticsData,
+  stateReportEntryAnalyticsEvent,
+} from "@/lib/insights-page-entry-cta-events";
 
 const PATH = "/state-of-mcp-servers";
 const TITLE = "State of MCP Servers 2026";
@@ -260,7 +265,7 @@ function StateOfMcpServersPage() {
           The ten most recently dated MCP servers in the registry snapshot.
         </p>
         <ol className="mt-4 overflow-hidden rounded-xl border border-border bg-surface">
-          {RECENT.map((e) => (
+          {RECENT.map((e, rowIndex) => (
             <li
               key={`${e.category}/${e.slug}`}
               className="flex items-center justify-between gap-3 border-b border-border px-5 py-3 last:border-0"
@@ -268,6 +273,18 @@ function StateOfMcpServersPage() {
               <Link
                 to="/entry/$category/$slug"
                 params={{ category: e.category, slug: e.slug }}
+                onClick={() =>
+                  trackEvent(
+                    stateReportEntryAnalyticsEvent(),
+                    stateReportEntryAnalyticsData(
+                      e.category,
+                      e.slug,
+                      "mcp-servers",
+                      rowIndex,
+                      RECENT.length,
+                    ),
+                  )
+                }
                 className="min-w-0 truncate text-sm font-medium text-ink hover:underline"
               >
                 {e.title}

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -15,6 +15,13 @@ import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { siteConfig } from "@/lib/site";
+import { trackEvent } from "@/lib/analytics";
+import {
+  validatorsAttentionEntryAnalyticsData,
+  validatorsAttentionEntryAnalyticsEvent,
+  validatorsRecentReviewedEntryAnalyticsData,
+  validatorsRecentReviewedEntryAnalyticsEvent,
+} from "@/lib/insights-page-entry-cta-events";
 import atlasRegistry from "@/generated/atlas-registry.json";
 
 export const Route = createFileRoute("/validators")({
@@ -169,11 +176,23 @@ function ValidatorsPage() {
                 <p className="text-xs text-ink-muted">No obvious metadata gaps in this area.</p>
               ) : (
                 <ul className="space-y-2">
-                  {coverage.needsAttention.map((entry) => (
+                  {coverage.needsAttention.map((entry, rowIndex) => (
                     <li key={`${entry.category}/${entry.slug}`}>
                       <Link
                         to="/entry/$category/$slug"
                         params={{ category: entry.category, slug: entry.slug }}
+                        onClick={() =>
+                          trackEvent(
+                            validatorsAttentionEntryAnalyticsEvent(),
+                            validatorsAttentionEntryAnalyticsData(
+                              entry.category,
+                              entry.slug,
+                              coverage.id,
+                              rowIndex,
+                              coverage.needsAttention.length,
+                            ),
+                          )
+                        }
                         className="block rounded-lg border border-border bg-background p-3 transition-colors hover:bg-surface-2"
                       >
                         <div className="flex flex-wrap items-center gap-1.5">
@@ -204,11 +223,22 @@ function ValidatorsPage() {
               snapshot.
             </p>
           ) : (
-            RECENT_REVIEWED.map((entry) => (
+            RECENT_REVIEWED.map((entry, rowIndex) => (
               <Link
                 key={`${entry.category}/${entry.slug}`}
                 to="/entry/$category/$slug"
                 params={{ category: entry.category, slug: entry.slug }}
+                onClick={() =>
+                  trackEvent(
+                    validatorsRecentReviewedEntryAnalyticsEvent(),
+                    validatorsRecentReviewedEntryAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      rowIndex,
+                      RECENT_REVIEWED.length,
+                    ),
+                  )
+                }
                 className="grid gap-3 border-b border-border px-5 py-3 text-sm last:border-0 hover:bg-surface-2 sm:grid-cols-[1fr_120px]"
               >
                 <div className="min-w-0">

--- a/tests/insights-page-entry-cta-events-lib.test.ts
+++ b/tests/insights-page-entry-cta-events-lib.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTRIBUTOR_PROFILE_SURFACE,
+  QUALITY_QUEUE_SURFACE,
+  STATE_REPORT_SURFACE,
+  VALIDATORS_ATTENTION_SURFACE,
+  VALIDATORS_RECENT_REVIEWED_SURFACE,
+  contributorProfileEntryAnalyticsData,
+  contributorProfileEntryAnalyticsEvent,
+  qualityQueueEntryAnalyticsData,
+  qualityQueueEntryAnalyticsEvent,
+  stateReportEntryAnalyticsData,
+  stateReportEntryAnalyticsEvent,
+  validatorsAttentionEntryAnalyticsData,
+  validatorsAttentionEntryAnalyticsEvent,
+  validatorsRecentReviewedEntryAnalyticsData,
+  validatorsRecentReviewedEntryAnalyticsEvent,
+} from "@/lib/insights-page-entry-cta-events-lib";
+
+describe("insights page entry cta events lib", () => {
+  it("builds privacy-light contributor profile entry egress analytics", () => {
+    expect(contributorProfileEntryAnalyticsEvent()).toBe(
+      "contributor_profile_entry_click",
+    );
+    expect(
+      contributorProfileEntryAnalyticsData(
+        "mcp",
+        "browser",
+        "alice",
+        "submitted-authored",
+        1,
+        4,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: CONTRIBUTOR_PROFILE_SURFACE,
+      contributorSlug: "alice",
+      role: "submitted-authored",
+      rowIndex: 1,
+      rowCount: 4,
+    });
+  });
+
+  it("builds privacy-light quality queue entry egress analytics", () => {
+    expect(qualityQueueEntryAnalyticsEvent()).toBe("quality_queue_entry_click");
+    expect(
+      qualityQueueEntryAnalyticsData(
+        "skills",
+        "demo",
+        "improvement",
+        42,
+        0,
+        10,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: QUALITY_QUEUE_SURFACE,
+      queueId: "improvement",
+      score: 42,
+      rowIndex: 0,
+      rowCount: 10,
+    });
+  });
+
+  it("builds privacy-light validators entry egress analytics", () => {
+    expect(validatorsAttentionEntryAnalyticsEvent()).toBe(
+      "validators_attention_entry_click",
+    );
+    expect(
+      validatorsAttentionEntryAnalyticsData("agents", "foo", "MCP", 2, 5),
+    ).toEqual({
+      entry: "agents/foo",
+      surface: VALIDATORS_ATTENTION_SURFACE,
+      expertiseId: "MCP",
+      rowIndex: 2,
+      rowCount: 5,
+    });
+    expect(validatorsRecentReviewedEntryAnalyticsEvent()).toBe(
+      "validators_recent_reviewed_entry_click",
+    );
+    expect(
+      validatorsRecentReviewedEntryAnalyticsData("hooks", "bar", 3, 12),
+    ).toEqual({
+      entry: "hooks/bar",
+      surface: VALIDATORS_RECENT_REVIEWED_SURFACE,
+      rowIndex: 3,
+      rowCount: 12,
+    });
+  });
+
+  it("builds privacy-light state report entry egress analytics", () => {
+    expect(stateReportEntryAnalyticsEvent()).toBe("state_report_entry_click");
+    expect(
+      stateReportEntryAnalyticsData("mcp", "browser", "mcp-servers", 0, 10),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: STATE_REPORT_SURFACE,
+      reportId: "mcp-servers",
+      rowIndex: 0,
+      rowCount: 10,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add privacy-light entry egress analytics for contributor profiles, quality queues, validators, and state reports
- New events: `contributor_profile_entry_click`, `quality_queue_entry_click`, `validators_attention_entry_click`, `validators_recent_reviewed_entry_click`, `state_report_entry_click`
- Insights page entry CTA lib + wrapper + vitest coverage

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build pass locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)
- [ ] Manual: click entries on contributor, quality, validators, and state report pages