### PR TITLE
fix(registry): require http(s) in isPublicGitHubHostUrl

### DIFF
--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -154,14 +154,26 @@ export function isPublicGitHubProfileUrl(value) {
 }
 
 /**
- * Return true when a URL resolves to github.com or a *.github.com host.
+ * Return true when a URL resolves to github.com or a *.github.com host over
+ * HTTP(S) and without embedded userinfo. The protocol guard matches the other
+ * public-URL validators here (`isPublicHttpUrl`, `publicHttpUrlHref`): a
+ * non-http(s) URL such as `ftp://github.com/x` or `ws://raw.github.com/x` is
+ * not a public GitHub web URL even though its hostname is a GitHub host.
  *
  * @param {unknown} value
  * @returns {boolean}
  */
 export function isPublicGitHubHostUrl(value) {
-  const hostname = publicUrlHostname(value);
-  if (!hostname) return false;
+  const url = parseUrl(value);
+  if (
+    !url ||
+    url.username ||
+    url.password ||
+    (url.protocol !== "https:" && url.protocol !== "http:")
+  ) {
+    return false;
+  }
+  const hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
   return hostname === "github.com" || hostname.endsWith(".github.com");
 }
 

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -116,6 +116,24 @@ describe("public URL userinfo helpers", () => {
     expect(isPublicGitHubHostUrl("https://gist.github.com/octocat")).toBe(true);
   });
 
+  it("treats http and www GitHub hosts as public", () => {
+    expect(isPublicGitHubHostUrl("http://github.com/octocat")).toBe(true);
+    expect(isPublicGitHubHostUrl("https://www.github.com/octocat")).toBe(true);
+    expect(isPublicGitHubHostUrl("https://raw.githubusercontent.com/x")).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-http(s) URLs even on a GitHub host", () => {
+    // A GitHub hostname over ftp/ws is not a public GitHub web URL; the protocol
+    // guard matches the sibling public-URL validators.
+    expect(isPublicGitHubHostUrl("ftp://github.com/octocat")).toBe(false);
+    expect(isPublicGitHubHostUrl("ws://raw.github.com/socket")).toBe(false);
+    expect(isPublicGitHubHostUrl("ssh://git@github.com/owner/repo")).toBe(
+      false,
+    );
+  });
+
   it("rejects reserved GitHub product surfaces as profiles", () => {
     // A single path segment that is a reserved GitHub page is not a user
     // profile, mirroring how the repo-URL parser rejects reserved owners.


### PR DESCRIPTION
## The gap

`isPublicGitHubHostUrl` only looked at the hostname, ignoring the scheme:

```js
const hostname = publicUrlHostname(value);   // parses ANY protocol
if (!hostname) return false;
return hostname === "github.com" || hostname.endsWith(".github.com");
```

So non-http(s) URLs on a GitHub host classified as public GitHub web URLs:

| URL | before | after |
|---|---|---|
| `https://github.com/x` | ✅ | ✅ |
| `http://github.com/x` | ✅ | ✅ |
| `https://gist.github.com/x` | ✅ | ✅ |
| `https://www.github.com/x` | ✅ | ✅ |
| `https://token@github.com/x` | ❌ | ❌ |
| `ftp://github.com/x` | ✅ | ❌ |
| `ws://raw.github.com/x` | ✅ | ❌ |
| `ssh://git@github.com/owner/repo` | ✅ | ❌ |

Every sibling validator in this module — `isPublicHttpUrl`, `publicHttpUrlHref`, `isPublicHttpsUrl` — already requires an `http(s)` scheme. `isPublicGitHubHostUrl` was the lone exception, so this aligns it with the rest of the file.

## Why it matters

It gates `entry.sourceUrl` "open-source" classification in `apps/web/src/data/tools.ts`:

```js
if (entry.repoUrl || isPublicGitHubHostUrl(entry.sourceUrl)) return "open-source";
```

A non-http GitHub-host `sourceUrl` would read as open-source.

## The fix

Parse once, reject embedded userinfo and any non-`http(s)` scheme, then apply the existing www-stripped `github.com` / `*.github.com` host check. All previously-accepted http(s) hosts (including `gist.` and `www.`) are unchanged.

## Tests

Extends `tests/source-url-lib.test.ts`: `http`/`www` hosts still accepted, `raw.githubusercontent.com` still rejected (different apex), and `ftp`/`ws`/`ssh` GitHub-host URLs now rejected. Every pre-existing assertion (https/token@/gist) passes unchanged.

```
pnpm exec vitest run tests/source-url-lib.test.ts   # 218 passed
pnpm test    # 63 failed / 38 failing files — identical to main's baseline; zero new failures
pnpm exec prettier --check <changed files>   # clean
```

Refs #4920