### PR TITLE
feat(web): entry detail collection item egress

### DIFF
--- a/apps/web/src/lib/entry-detail-collection-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-collection-cta-events-lib.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure entry detail collection item egress analytics helpers.
+ *
+ * Maps included-entry navigation from collection metadata to privacy-light
+ * event names without embedding entry titles or collection copy.
+ */
+
+export const ENTRY_DETAIL_COLLECTION_ITEMS_SURFACE = "detail-collection-items";
+
+export function entryDetailCollectionEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryDetailCollectionEntryAnalyticsEvent(): string {
+  return "detail_collection_entry_click";
+}
+
+export function entryDetailCollectionEntryAnalyticsData(
+  fromCategory: string,
+  fromSlug: string,
+  peerEntryRef: string,
+  itemIndex: number,
+  itemCount: number,
+) {
+  return {
+    entry: entryDetailCollectionEntryKey(fromCategory, fromSlug),
+    surface: ENTRY_DETAIL_COLLECTION_ITEMS_SURFACE,
+    peer: peerEntryRef,
+    itemIndex,
+    itemCount,
+  };
+}

--- a/apps/web/src/lib/entry-detail-collection-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-collection-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Entry detail collection item egress CTA event surface.
+ */
+export {
+  ENTRY_DETAIL_COLLECTION_ITEMS_SURFACE,
+  entryDetailCollectionEntryAnalyticsData,
+  entryDetailCollectionEntryAnalyticsEvent,
+  entryDetailCollectionEntryKey,
+} from "@/lib/entry-detail-collection-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -116,6 +116,10 @@ import {
   type EntryDetailCompareEgressLinkKind,
   type EntryDetailCompareEgressSurface,
 } from "@/lib/entry-detail-compare-egress-cta-events";
+import {
+  entryDetailCollectionEntryAnalyticsData,
+  entryDetailCollectionEntryAnalyticsEvent,
+} from "@/lib/entry-detail-collection-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
@@ -1277,7 +1281,11 @@ function SchemaDetails({ entry }: { entry: Entry }) {
               <FieldRow label="Estimated setup" value={entry.estimatedSetupTime} />
               <FieldRow label="Difficulty" value={entry.difficulty} />
             </FieldGrid>
-            <CollectionItemList values={entry.items} />
+            <CollectionItemList
+              values={entry.items}
+              fromCategory={entry.category}
+              fromSlug={entry.slug}
+            />
             <PillList label="Installation order" values={entry.installationOrder} />
           </MetadataGroup>
         )}
@@ -1375,7 +1383,15 @@ function PillList({ label, values }: { label: string; values?: string[] }) {
   );
 }
 
-function CollectionItemList({ values }: { values?: string[] }) {
+function CollectionItemList({
+  values,
+  fromCategory,
+  fromSlug,
+}: {
+  values?: string[];
+  fromCategory: string;
+  fromSlug: string;
+}) {
   if (!values?.length) return null;
   return (
     <div className="mt-3">
@@ -1383,7 +1399,7 @@ function CollectionItemList({ values }: { values?: string[] }) {
         Included entries
       </div>
       <div className="flex flex-wrap gap-1.5">
-        {values.map((value) => {
+        {values.map((value, itemIndex) => {
           const [category, slug] = value.split("/");
           if (category && slug) {
             return (
@@ -1391,6 +1407,18 @@ function CollectionItemList({ values }: { values?: string[] }) {
                 key={value}
                 to="/entry/$category/$slug"
                 params={{ category, slug }}
+                onClick={() =>
+                  trackEvent(
+                    entryDetailCollectionEntryAnalyticsEvent(),
+                    entryDetailCollectionEntryAnalyticsData(
+                      fromCategory,
+                      fromSlug,
+                      value,
+                      itemIndex,
+                      values.length,
+                    ),
+                  )
+                }
                 className="inline-flex rounded-md border border-border bg-surface px-2 py-0.5 font-mono text-xs text-ink-muted hover:text-ink"
               >
                 {value}

--- a/tests/entry-detail-collection-cta-events-lib.test.ts
+++ b/tests/entry-detail-collection-cta-events-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_DETAIL_COLLECTION_ITEMS_SURFACE,
+  entryDetailCollectionEntryAnalyticsData,
+  entryDetailCollectionEntryAnalyticsEvent,
+} from "@/lib/entry-detail-collection-cta-events-lib";
+
+describe("entry detail collection cta events lib", () => {
+  it("builds privacy-light collection item egress analytics", () => {
+    expect(entryDetailCollectionEntryAnalyticsEvent()).toBe(
+      "detail_collection_entry_click",
+    );
+    expect(
+      entryDetailCollectionEntryAnalyticsData(
+        "collections",
+        "starter-pack",
+        "mcp/browser",
+        1,
+        5,
+      ),
+    ).toEqual({
+      entry: "collections/starter-pack",
+      surface: ENTRY_DETAIL_COLLECTION_ITEMS_SURFACE,
+      peer: "mcp/browser",
+      itemIndex: 1,
+      itemCount: 5,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `detail_collection_entry_click` when users open included entries from collection metadata chips
- Privacy-light payload: parent entry, peer ref, item index/count, surface
- Entry detail collection CTA lib + wrapper + vitest coverage

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build pass locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)
- [ ] Manual: open a collection entry detail page and click included entry chips