### PR TITLE
test(scripts): extract wrangler query-results parser and cover it

### DIFF
--- a/scripts/lib/wrangler-query-results.mjs
+++ b/scripts/lib/wrangler-query-results.mjs
@@ -1,0 +1,26 @@
+// Pure parser behind scripts/sync-votes-to-d1.mjs: extract the result rows from
+// the JSON that `wrangler d1 execute --json` prints. wrangler returns either a
+// single result object or an array of per-statement results; this returns the
+// relevant `results` array. Split out from the execFileSync caller so the parsing
+// can be unit-tested without invoking wrangler.
+
+/**
+ * Parse `wrangler d1 execute --json` output into the result rows. For an array
+ * payload, use the last statement that carries a `results` array; for an object
+ * payload, use its `results`. Returns [] when no results are present, and throws
+ * on empty output.
+ */
+export function parseWranglerQueryResults(output) {
+  const jsonText = String(output ?? "").trim();
+  if (!jsonText) {
+    throw new Error("Could not parse wrangler prune output");
+  }
+  const payload = JSON.parse(jsonText);
+  if (Array.isArray(payload)) {
+    const statement = [...payload]
+      .reverse()
+      .find((result) => Array.isArray(result?.results));
+    return statement?.results ?? [];
+  }
+  return Array.isArray(payload?.results) ? payload.results : [];
+}

--- a/scripts/sync-votes-to-d1.mjs
+++ b/scripts/sync-votes-to-d1.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { enumerateContentVoteKeys } from "./lib/enumerate-content-vote-keys.mjs";
 import { expectedKeyExclusionPredicate } from "./lib/d1-prune-predicate.mjs";
 import { wranglerArgs } from "./lib/wrangler-args.mjs";
+import { parseWranglerQueryResults } from "./lib/wrangler-query-results.mjs";
 
 const repoRoot = process.cwd();
 const d1Binding = process.env.SITE_D1_BINDING || "SITE_DB";
@@ -53,18 +54,7 @@ function runWranglerQuery(args) {
     ["--filter", "web", "exec", "wrangler", ...args],
     { cwd: repoRoot, encoding: "utf8" },
   );
-  const jsonText = output.trim();
-  if (!jsonText) {
-    throw new Error("Could not parse wrangler prune output");
-  }
-  const payload = JSON.parse(jsonText);
-  if (Array.isArray(payload)) {
-    const statement = [...payload]
-      .reverse()
-      .find((result) => Array.isArray(result?.results));
-    return statement?.results ?? [];
-  }
-  return Array.isArray(payload?.results) ? payload.results : [];
+  return parseWranglerQueryResults(output);
 }
 
 function pruneTableOrphans(runMode, tableName, whereClause) {

--- a/tests/wrangler-query-results.test.ts
+++ b/tests/wrangler-query-results.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { parseWranglerQueryResults } from "../scripts/lib/wrangler-query-results.mjs";
+
+describe("parseWranglerQueryResults", () => {
+  it("returns results from an object payload", () => {
+    expect(
+      parseWranglerQueryResults(
+        '{ "results": [{ "pruned": 3 }], "success": true }',
+      ),
+    ).toEqual([{ pruned: 3 }]);
+  });
+
+  it("returns [] from an object payload without a results array", () => {
+    expect(parseWranglerQueryResults('{ "success": true }')).toEqual([]);
+    expect(parseWranglerQueryResults('{ "results": "nope" }')).toEqual([]);
+  });
+
+  it("uses the last statement carrying results from an array payload", () => {
+    const output = JSON.stringify([
+      { results: [{ a: 1 }] },
+      { results: [{ b: 2 }] },
+      { success: true },
+    ]);
+    expect(parseWranglerQueryResults(output)).toEqual([{ b: 2 }]);
+  });
+
+  it("returns [] from an array payload with no statement carrying results", () => {
+    expect(parseWranglerQueryResults('[{ "success": true }]')).toEqual([]);
+  });
+
+  it("throws on empty/whitespace output", () => {
+    expect(() => parseWranglerQueryResults("   ")).toThrow(
+      /Could not parse wrangler prune output/,
+    );
+    expect(() => parseWranglerQueryResults(null)).toThrow(
+      /Could not parse wrangler prune output/,
+    );
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/sync-votes-to-d1.mjs` parsed the JSON that `wrangler d1 execute --json` prints inline inside its `execFileSync` caller, so the results extraction (array of per-statement results vs a single object payload) was untestable without invoking wrangler. This moves the pure parser into `scripts/lib/wrangler-query-results.mjs` - matching the existing `scripts/lib` convention - and has `runWranglerQuery` delegate to it.

### Changes

- Add `scripts/lib/wrangler-query-results.mjs` - `parseWranglerQueryResults(output)`.
- `scripts/sync-votes-to-d1.mjs` - `runWranglerQuery` now execs and delegates the parse; drop the inline JSON handling.
- Add `tests/wrangler-query-results.test.ts` - covers the object-payload results, the object-without-results and non-array-results fallbacks, the last-statement-with-results pick from an array payload, the no-results array fallback, and the empty-output throw. Branch coverage 100% (10/10).

### Validation

- `pnpm exec vitest run tests/wrangler-query-results.test.ts` - 5 passed
- `node --check scripts/sync-votes-to-d1.mjs` - clean; the parser is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the parsed rows are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
