### PR TITLE
test(scripts): extract predictable /tmp debug path check and cover it

### DIFF
--- a/scripts/lib/shared-tmp-debug-paths.mjs
+++ b/scripts/lib/shared-tmp-debug-paths.mjs
@@ -1,0 +1,26 @@
+// Pure hygiene check behind scripts/validate-content.mjs: find predictable,
+// shared /tmp debug/startup paths in a submitted script body. A fixed path under
+// the world-writable /tmp is a symlink/race risk, so submissions should use a
+// randomized path ($$, $RANDOM, mktemp's XXXX). Split out so the detection can be
+// unit-tested without walking the content tree.
+
+const sharedTmpDebugPathPattern =
+  /(^|[^A-Za-z0-9_$\/{.-])(\/tmp\/[A-Za-z0-9_.$\/{}-]*(?:debug|startup)[A-Za-z0-9_.$\/{}-]*)/gi;
+const nonPredictableTmpPathPattern = /\$\$|\$RANDOM|\$\{RANDOM\}|X{3,}/i;
+
+/**
+ * Return the distinct predictable /tmp debug/startup paths referenced in
+ * `scriptBody`. Paths that include a randomizing token ($$, $RANDOM, ${RANDOM},
+ * or 3+ X placeholders) are treated as non-predictable and excluded.
+ */
+export function findPredictableSharedTmpDebugPaths(scriptBody) {
+  const paths = new Set();
+  for (const match of String(scriptBody || "").matchAll(
+    sharedTmpDebugPathPattern,
+  )) {
+    const tmpPath = match[2];
+    if (!tmpPath || nonPredictableTmpPathPattern.test(tmpPath)) continue;
+    paths.add(tmpPath);
+  }
+  return [...paths];
+}

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -13,6 +13,7 @@ import {
 import { parseSafeFrontmatter } from "@heyclaude/registry/frontmatter";
 
 import { duplicateTopLevelFrontmatterKeys } from "./lib/frontmatter-dupe-keys.mjs";
+import { findPredictableSharedTmpDebugPaths } from "./lib/shared-tmp-debug-paths.mjs";
 
 const repoRoot = process.cwd();
 const contentRoot = path.join(repoRoot, "content");
@@ -55,9 +56,6 @@ const oldBrandOrDomainPattern = new RegExp(
   ].join("")}`,
   "i",
 );
-const sharedTmpDebugPathPattern =
-  /(^|[^A-Za-z0-9_$\/{.-])(\/tmp\/[A-Za-z0-9_.$\/{}-]*(?:debug|startup)[A-Za-z0-9_.$\/{}-]*)/gi;
-const nonPredictableTmpPathPattern = /\$\$|\$RANDOM|\$\{RANDOM\}|X{3,}/i;
 
 function checkBashSyntax(scriptBody) {
   const result = spawnSync("bash", ["--noprofile", "--norc", "-n", "-s"], {
@@ -87,18 +85,6 @@ function checkBashSyntax(scriptBody) {
   }
 
   return { ok: true };
-}
-
-function findPredictableSharedTmpDebugPaths(scriptBody) {
-  const paths = new Set();
-  for (const match of String(scriptBody || "").matchAll(
-    sharedTmpDebugPathPattern,
-  )) {
-    const tmpPath = match[2];
-    if (!tmpPath || nonPredictableTmpPathPattern.test(tmpPath)) continue;
-    paths.add(tmpPath);
-  }
-  return [...paths];
 }
 
 for (const category of Object.keys(CATEGORY_SCHEMAS)) {

--- a/tests/shared-tmp-debug-paths.test.ts
+++ b/tests/shared-tmp-debug-paths.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { findPredictableSharedTmpDebugPaths } from "../scripts/lib/shared-tmp-debug-paths.mjs";
+
+describe("findPredictableSharedTmpDebugPaths", () => {
+  it("finds predictable /tmp debug and startup paths", () => {
+    expect(
+      findPredictableSharedTmpDebugPaths("cat /tmp/debug.log here"),
+    ).toEqual(["/tmp/debug.log"]);
+    expect(
+      findPredictableSharedTmpDebugPaths("echo x > /tmp/startup-config"),
+    ).toEqual(["/tmp/startup-config"]);
+  });
+
+  it("excludes paths randomized with $$ / $RANDOM / XXXX", () => {
+    expect(findPredictableSharedTmpDebugPaths("/tmp/debug-$$")).toEqual([]);
+    expect(findPredictableSharedTmpDebugPaths("/tmp/debug-$RANDOM")).toEqual(
+      [],
+    );
+    expect(findPredictableSharedTmpDebugPaths("/tmp/debugXXXXXX")).toEqual([]);
+  });
+
+  it("ignores /tmp paths without a debug/startup segment", () => {
+    expect(findPredictableSharedTmpDebugPaths("/tmp/foo.log")).toEqual([]);
+    expect(findPredictableSharedTmpDebugPaths("no tmp here")).toEqual([]);
+    expect(findPredictableSharedTmpDebugPaths("")).toEqual([]);
+  });
+
+  it("de-duplicates a repeated path", () => {
+    expect(
+      findPredictableSharedTmpDebugPaths(
+        "/tmp/debug.log and again /tmp/debug.log",
+      ),
+    ).toEqual(["/tmp/debug.log"]);
+  });
+
+  it("returns each distinct predictable path, skipping randomized ones in the same body", () => {
+    expect(
+      findPredictableSharedTmpDebugPaths(
+        "a /tmp/debug.a and /tmp/startupZ and /tmp/debug-$$",
+      ),
+    ).toEqual(["/tmp/debug.a", "/tmp/startupZ"]);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/validate-content.mjs` detected predictable, shared `/tmp` debug/startup paths in submitted script bodies (a symlink/race hygiene check) with a local function and two module-scoped regexes that had no direct tests. This moves the pure detector into `scripts/lib/shared-tmp-debug-paths.mjs` - matching the existing `scripts/lib` convention - and imports it back.

### Changes

- Add `scripts/lib/shared-tmp-debug-paths.mjs` - `findPredictableSharedTmpDebugPaths`, with its shared-tmp and non-predictable-token patterns.
- `scripts/validate-content.mjs` - import the detector; drop the local copy and the two patterns.
- Add `tests/shared-tmp-debug-paths.test.ts` - covers predictable debug/startup paths, exclusion of `$$`/`$RANDOM`/`XXXX` randomized paths, ignoring `/tmp` paths without a debug/startup segment, de-duplication, and a mixed body. Branch coverage 100% (6/6).

### Validation

- `pnpm exec vitest run tests/shared-tmp-debug-paths.test.ts` - 5 passed
- `node --check scripts/validate-content.mjs` - clean; the detector is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the flagged paths are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
