### PR TITLE
refactor(scripts): dedupe release-watch commit-log parsing and cover it

### DIFF
--- a/scripts/check-mcp-release-due.mjs
+++ b/scripts/check-mcp-release-due.mjs
@@ -7,9 +7,11 @@ import { pathToFileURL } from "node:url";
 import {
   buildMcpReleaseIssue,
   buildMcpReleaseReport,
+  COMMIT_LOG_FORMAT,
   isTrustedReleaseWatchIssue,
   latestSemverTag,
   MCP_RELEASE_DUE_MARKER,
+  parseCommitLog,
   parseReleaseWatchArgs,
 } from "./lib/release-watch-core.mjs";
 
@@ -68,25 +70,15 @@ function readPublishedPackageVersion(packageName) {
 }
 
 function readCommits(revisionRange) {
-  const format = "%x1e%H%x1f%s";
-  return git([
-    "log",
-    "--reverse",
-    "--no-merges",
-    `--format=${format}`,
-    revisionRange,
-  ])
-    .split("\x1e")
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .map((entry) => {
-      const [sha, subject] = entry.split("\x1f");
-      return {
-        sha,
-        subject: subject?.split("\n")[0] ?? "",
-        files: readCommitFiles(sha),
-      };
-    });
+  return parseCommitLog(
+    git([
+      "log",
+      "--reverse",
+      "--no-merges",
+      `--format=${COMMIT_LOG_FORMAT}`,
+      revisionRange,
+    ]),
+  ).map((commit) => ({ ...commit, files: readCommitFiles(commit.sha) }));
 }
 
 function readCommitFiles(sha) {

--- a/scripts/check-raycast-release-due.mjs
+++ b/scripts/check-raycast-release-due.mjs
@@ -7,8 +7,10 @@ import { pathToFileURL } from "node:url";
 import {
   buildRaycastReleaseIssue,
   buildRaycastReleaseReport,
+  COMMIT_LOG_FORMAT,
   isTrustedReleaseWatchIssue,
   latestSemverTag,
+  parseCommitLog,
   parseReleaseWatchArgs,
   RAYCAST_RELEASE_DUE_MARKER,
 } from "./lib/release-watch-core.mjs";
@@ -52,25 +54,15 @@ function readTags(pattern) {
 }
 
 function readCommits(revisionRange) {
-  const format = "%x1e%H%x1f%s";
-  return git([
-    "log",
-    "--reverse",
-    "--no-merges",
-    `--format=${format}`,
-    revisionRange,
-  ])
-    .split("\x1e")
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .map((entry) => {
-      const [sha, subject] = entry.split("\x1f");
-      return {
-        sha,
-        subject: subject?.split("\n")[0] ?? "",
-        files: readCommitFiles(sha),
-      };
-    });
+  return parseCommitLog(
+    git([
+      "log",
+      "--reverse",
+      "--no-merges",
+      `--format=${COMMIT_LOG_FORMAT}`,
+      revisionRange,
+    ]),
+  ).map((commit) => ({ ...commit, files: readCommitFiles(commit.sha) }));
 }
 
 function readCommitFiles(sha) {

--- a/scripts/lib/release-watch-core.mjs
+++ b/scripts/lib/release-watch-core.mjs
@@ -27,6 +27,26 @@ export function parseReleaseWatchArgs(argv) {
   return args;
 }
 
+// git log --format for readCommits: record-separated (\x1e) commits, each with
+// its hash and subject field-separated (\x1f).
+export const COMMIT_LOG_FORMAT = "%x1e%H%x1f%s";
+
+/**
+ * Parse `git log --format=COMMIT_LOG_FORMAT` output into { sha, subject } records
+ * (subject is the first line only). Blank records are dropped; a record with no
+ * subject field yields an empty subject.
+ */
+export function parseCommitLog(output) {
+  return String(output ?? "")
+    .split("\x1e")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [sha, subject] = entry.split("\x1f");
+      return { sha, subject: subject?.split("\n")[0] ?? "" };
+    });
+}
+
 export function readReleaseWatchConfig({ repoRoot = process.cwd() } = {}) {
   const configPath = resolve(repoRoot, RELEASE_WATCH_CONFIG_PATH);
   let parsed;

--- a/tests/commit-log.test.ts
+++ b/tests/commit-log.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMMIT_LOG_FORMAT,
+  parseCommitLog,
+} from "../scripts/lib/release-watch-core.mjs";
+
+// git log --format=COMMIT_LOG_FORMAT emits: \x1e<sha>\x1f<subject> per commit.
+const rec = (sha: string, subject: string) => `\x1e${sha}\x1f${subject}`;
+
+describe("parseCommitLog", () => {
+  it("keeps the format the parser expects", () => {
+    expect(COMMIT_LOG_FORMAT).toBe("%x1e%H%x1f%s");
+  });
+
+  it("parses record-separated commits into { sha, subject }", () => {
+    const output = rec("abc123", "feat: one") + rec("def456", "fix: two");
+    expect(parseCommitLog(output)).toEqual([
+      { sha: "abc123", subject: "feat: one" },
+      { sha: "def456", subject: "fix: two" },
+    ]);
+  });
+
+  it("uses only the first line of a multi-line subject", () => {
+    expect(parseCommitLog(rec("abc", "first line\nbody line"))).toEqual([
+      { sha: "abc", subject: "first line" },
+    ]);
+  });
+
+  it("yields an empty subject when the subject field is absent", () => {
+    expect(parseCommitLog("\x1eabc")).toEqual([{ sha: "abc", subject: "" }]);
+  });
+
+  it("drops blank records and handles empty/nullish output", () => {
+    expect(parseCommitLog("")).toEqual([]);
+    expect(parseCommitLog(null)).toEqual([]);
+    expect(parseCommitLog("\x1e" + rec("abc", "s"))).toEqual([
+      { sha: "abc", subject: "s" },
+    ]);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/check-mcp-release-due.mjs` and `scripts/check-raycast-release-due.mjs` each carried a byte-identical `readCommits` that parsed `git log` record output inline, and neither copy was tested. This hoists the pure record parsing (and the git `--format` string it pairs with) into the existing `scripts/lib/release-watch-core.mjs` (which both scripts already import) and uses it from both.

### Changes

- `scripts/lib/release-watch-core.mjs` - add `COMMIT_LOG_FORMAT` and `parseCommitLog`.
- `scripts/check-mcp-release-due.mjs`, `scripts/check-raycast-release-due.mjs` - `readCommits` now runs git with `COMMIT_LOG_FORMAT`, delegates record parsing to `parseCommitLog`, then attaches files per commit; drop the duplicated inline parse.
- Add `tests/commit-log.test.ts` - covers record-separated commit parsing, first-line-only subjects, the empty-subject and blank-record cases, and empty/nullish output. The new function's lines and branches are fully covered.

### Validation

- `pnpm exec vitest run tests/commit-log.test.ts tests/release-watch.test.ts tests/release-watch-args.test.ts` - 20 passed
- `node --check` on both scripts and the lib - clean; both now delegate to `parseCommitLog`
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (dedupe + pure-logic extraction + tests). No behavior change; the parsed commit records are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
