### PR TITLE
test(scripts): extract thin-content markdown cell helpers and cover them

### DIFF
--- a/scripts/lib/thin-content-text.mjs
+++ b/scripts/lib/thin-content-text.mjs
@@ -16,6 +16,18 @@ export const TEXT_FIELDS = [
 /** Coerce to a string and trim; null/undefined become "". */
 export const collapseWhitespace = (value) => String(value ?? "").trim();
 
+// Escape backslashes first, then pipes, so a literal "\" in the text can't
+// combine with the inserted escape (CodeQL js/incomplete-sanitization).
+/** Escape a value for use inside a markdown table cell. */
+export const escapePipes = (text) =>
+  String(text).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+
+/** Trim and clamp text to `max` chars, appending an ellipsis when truncated. */
+export const truncate = (text, max = 140) => {
+  const value = collapseWhitespace(text);
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+};
+
 /**
  * The primary "intro" we de-duplicate on: the description is what shows up in
  * listings and meta tags, so duplicate descriptions are the real SEO risk.

--- a/scripts/report-thin-content.mjs
+++ b/scripts/report-thin-content.mjs
@@ -5,12 +5,14 @@ import { fileURLToPath } from "node:url";
 import {
   collapseWhitespace,
   combinedTextOf,
+  escapePipes,
   introOf,
   jaccard,
   normalizeForCompare,
   round,
   shinglesOf,
   tokenize,
+  truncate,
 } from "./lib/thin-content-text.mjs";
 
 /*
@@ -333,14 +335,6 @@ const summary = {
 // --- output ---
 
 const limit = (list) => (top > 0 ? list.slice(0, top) : list);
-// Escape backslashes first, then pipes, so a literal "\" in the text can't
-// combine with the inserted escape (CodeQL js/incomplete-sanitization).
-const escapePipes = (text) =>
-  String(text).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
-const truncate = (text, max = 140) => {
-  const value = collapseWhitespace(text);
-  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
-};
 
 function renderMarkdown() {
   const lines = [];

--- a/tests/thin-content-text.test.ts
+++ b/tests/thin-content-text.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   collapseWhitespace,
   combinedTextOf,
+  escapePipes,
   introOf,
   jaccard,
   normalizeForCompare,
@@ -10,6 +11,7 @@ import {
   shinglesOf,
   TEXT_FIELDS,
   tokenize,
+  truncate,
 } from "../scripts/lib/thin-content-text.mjs";
 
 describe("collapseWhitespace", () => {
@@ -97,5 +99,34 @@ describe("round", () => {
     expect(round(1 / 3)).toBe(0.333);
     expect(round(0.12345, 2)).toBe(0.12);
     expect(round(2)).toBe(2);
+  });
+});
+
+describe("escapePipes", () => {
+  it("escapes backslashes before pipes so the escape can't be neutralized", () => {
+    expect(escapePipes("a|b")).toBe("a\\|b");
+    expect(escapePipes("a\\b")).toBe("a\\\\b");
+    // a literal backslash before a pipe must not swallow the pipe escape
+    expect(escapePipes("a\\|b")).toBe("a\\\\\\|b");
+  });
+
+  it("coerces non-strings", () => {
+    expect(escapePipes(42)).toBe("42");
+  });
+});
+
+describe("truncate", () => {
+  it("returns the trimmed value when within the limit", () => {
+    expect(truncate("  hello  ")).toBe("hello");
+  });
+
+  it("clamps to max chars with a trailing ellipsis when longer", () => {
+    const out = truncate("abcdef", 4);
+    expect(out).toBe("abc…");
+    expect(out.length).toBe(4);
+  });
+
+  it("does not truncate a value exactly at the limit", () => {
+    expect(truncate("abcd", 4)).toBe("abcd");
   });
 });


### PR DESCRIPTION
### What & why

`scripts/report-thin-content.mjs` escaped and truncated its markdown table cells with local `escapePipes`/`truncate` helpers that had no direct tests. This moves them into the existing `scripts/lib/thin-content-text.mjs` (which the script already imports, and which holds the `collapseWhitespace` that `truncate` builds on) and imports them back.

### Changes

- `scripts/lib/thin-content-text.mjs` - add `escapePipes` and `truncate`.
- `scripts/report-thin-content.mjs` - import them; drop the local copies.
- `tests/thin-content-text.test.ts` - cover pipe/backslash escaping (backslash-first so the escape can't be neutralized) and non-string coercion, plus `truncate`'s within-limit, at-limit, and over-limit (ellipsis) cases. Branch coverage 100% (25/25).

### Validation

- `pnpm exec vitest run tests/thin-content-text.test.ts` - 16 passed
- `node --check scripts/report-thin-content.mjs` - clean; both helpers are imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the rendered report cells are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
