### PR TITLE
test(scripts): extract carry-forward repo-stats projection and cover it

### DIFF
--- a/scripts/build-content-index.mjs
+++ b/scripts/build-content-index.mjs
@@ -19,6 +19,7 @@ import {
 import { pickAtlasEntry } from "./lib/atlas-entry.mjs";
 import { artifactOutputPath } from "./lib/artifact-output-path.mjs";
 import { parseGitContentUpdatedAt } from "./lib/git-content-updated-at.mjs";
+import { entryRepoStatsEntry } from "./lib/entry-repo-stats.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -228,22 +229,8 @@ function loadExistingEntryRepoStats() {
         const payload = JSON.parse(
           fs.readFileSync(path.join(categoryDir, fileName), "utf8"),
         );
-        const entry = payload?.entry;
-        if (!entry?.category || !entry?.slug) continue;
-        values.set(`${entry.category}:${entry.slug}`, {
-          stars:
-            typeof entry.githubStars === "number"
-              ? entry.githubStars
-              : undefined,
-          forks:
-            typeof entry.githubForks === "number"
-              ? entry.githubForks
-              : undefined,
-          updatedAt:
-            typeof entry.repoUpdatedAt === "string"
-              ? entry.repoUpdatedAt
-              : undefined,
-        });
+        const statsEntry = entryRepoStatsEntry(payload);
+        if (statsEntry) values.set(statsEntry[0], statsEntry[1]);
       } catch {
         // Regeneration should not fail just because a stale artifact is invalid.
       }

--- a/scripts/lib/entry-repo-stats.mjs
+++ b/scripts/lib/entry-repo-stats.mjs
@@ -1,0 +1,28 @@
+// Pure projection behind scripts/build-content-index.mjs: turn a previously
+// generated entry-detail JSON payload into a [key, repoStats] pair for the
+// carry-forward stats map, so a regeneration can reuse GitHub star/fork/updated
+// values without refetching. Split out from the filesystem walk so the payload
+// shaping can be unit-tested.
+
+/**
+ * Map an entry-detail payload to `["<category>:<slug>", { stars, forks,
+ * updatedAt }]`, or null when the payload has no usable entry (missing
+ * category/slug). Each stat is carried only when it has the expected type.
+ */
+export function entryRepoStatsEntry(payload) {
+  const entry = payload?.entry;
+  if (!entry?.category || !entry?.slug) return null;
+  return [
+    `${entry.category}:${entry.slug}`,
+    {
+      stars:
+        typeof entry.githubStars === "number" ? entry.githubStars : undefined,
+      forks:
+        typeof entry.githubForks === "number" ? entry.githubForks : undefined,
+      updatedAt:
+        typeof entry.repoUpdatedAt === "string"
+          ? entry.repoUpdatedAt
+          : undefined,
+    },
+  ];
+}

--- a/tests/entry-repo-stats.test.ts
+++ b/tests/entry-repo-stats.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { entryRepoStatsEntry } from "../scripts/lib/entry-repo-stats.mjs";
+
+describe("entryRepoStatsEntry", () => {
+  it("maps a payload to a keyed repo-stats pair", () => {
+    expect(
+      entryRepoStatsEntry({
+        entry: {
+          category: "mcp",
+          slug: "example",
+          githubStars: 12,
+          githubForks: 3,
+          repoUpdatedAt: "2026-01-01",
+        },
+      }),
+    ).toEqual([
+      "mcp:example",
+      { stars: 12, forks: 3, updatedAt: "2026-01-01" },
+    ]);
+  });
+
+  it("keeps a zero-count stat but drops wrongly-typed ones", () => {
+    expect(
+      entryRepoStatsEntry({
+        entry: { category: "agents", slug: "a", githubStars: 0 },
+      }),
+    ).toEqual([
+      "agents:a",
+      { stars: 0, forks: undefined, updatedAt: undefined },
+    ]);
+  });
+
+  it("leaves each stat undefined when it has the wrong type", () => {
+    expect(
+      entryRepoStatsEntry({
+        entry: {
+          category: "hooks",
+          slug: "h",
+          githubStars: "12",
+          githubForks: null,
+          repoUpdatedAt: 20260101,
+        },
+      }),
+    ).toEqual([
+      "hooks:h",
+      { stars: undefined, forks: undefined, updatedAt: undefined },
+    ]);
+  });
+
+  it("returns null when there is no usable entry", () => {
+    expect(entryRepoStatsEntry(null)).toBeNull();
+    expect(entryRepoStatsEntry({})).toBeNull();
+    expect(entryRepoStatsEntry({ entry: { slug: "a" } })).toBeNull();
+    expect(entryRepoStatsEntry({ entry: { category: "mcp" } })).toBeNull();
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/build-content-index.mjs` projected a previously generated entry-detail payload into a `[key, repoStats]` pair inline while walking the entries dir, so the guard and the typed star/fork/updatedAt carry-forward was untestable. This moves the pure projection into `scripts/lib/entry-repo-stats.mjs` - matching the existing `scripts/lib` convention - and uses it in the loop.

### Changes

- Add `scripts/lib/entry-repo-stats.mjs` - `entryRepoStatsEntry(payload)`.
- `scripts/build-content-index.mjs` - build the carry-forward stats map via `entryRepoStatsEntry`; drop the inline projection.
- Add `tests/entry-repo-stats.test.ts` - covers the keyed pair, a zero-count stat kept vs wrongly-typed stats dropped to `undefined`, and the null result when the payload has no usable entry (missing category/slug). Branch coverage 100% (10/10).

### Validation

- `pnpm exec vitest run tests/entry-repo-stats.test.ts` - 4 passed
- `node --check scripts/build-content-index.mjs` - clean; the projection is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the carried-forward stats map is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
