### PR TITLE
refactor(scripts): share repo-stats projection with site stats and cover it

### DIFF
--- a/scripts/build-content-index.mjs
+++ b/scripts/build-content-index.mjs
@@ -19,7 +19,7 @@ import {
 import { pickAtlasEntry } from "./lib/atlas-entry.mjs";
 import { artifactOutputPath } from "./lib/artifact-output-path.mjs";
 import { parseGitContentUpdatedAt } from "./lib/git-content-updated-at.mjs";
-import { entryRepoStatsEntry } from "./lib/entry-repo-stats.mjs";
+import { entryRepoStatsEntry, pickRepoStats } from "./lib/entry-repo-stats.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -244,21 +244,7 @@ function loadExistingSiteStats() {
   if (!fs.existsSync(siteStatsFile)) return null;
 
   try {
-    const payload = JSON.parse(fs.readFileSync(siteStatsFile, "utf8"));
-    return {
-      stars:
-        typeof payload.githubStars === "number"
-          ? payload.githubStars
-          : undefined,
-      forks:
-        typeof payload.githubForks === "number"
-          ? payload.githubForks
-          : undefined,
-      updatedAt:
-        typeof payload.repoUpdatedAt === "string"
-          ? payload.repoUpdatedAt
-          : undefined,
-    };
+    return pickRepoStats(JSON.parse(fs.readFileSync(siteStatsFile, "utf8")));
   } catch {
     return null;
   }

--- a/scripts/lib/entry-repo-stats.mjs
+++ b/scripts/lib/entry-repo-stats.mjs
@@ -5,24 +5,27 @@
 // shaping can be unit-tested.
 
 /**
+ * Project GitHub repo stats off any source object (an entry or the site-stats
+ * payload) into `{ stars, forks, updatedAt }`, carrying each value only when it
+ * has the expected type.
+ */
+export function pickRepoStats(source) {
+  const s = source ?? {};
+  return {
+    stars: typeof s.githubStars === "number" ? s.githubStars : undefined,
+    forks: typeof s.githubForks === "number" ? s.githubForks : undefined,
+    updatedAt:
+      typeof s.repoUpdatedAt === "string" ? s.repoUpdatedAt : undefined,
+  };
+}
+
+/**
  * Map an entry-detail payload to `["<category>:<slug>", { stars, forks,
  * updatedAt }]`, or null when the payload has no usable entry (missing
- * category/slug). Each stat is carried only when it has the expected type.
+ * category/slug).
  */
 export function entryRepoStatsEntry(payload) {
   const entry = payload?.entry;
   if (!entry?.category || !entry?.slug) return null;
-  return [
-    `${entry.category}:${entry.slug}`,
-    {
-      stars:
-        typeof entry.githubStars === "number" ? entry.githubStars : undefined,
-      forks:
-        typeof entry.githubForks === "number" ? entry.githubForks : undefined,
-      updatedAt:
-        typeof entry.repoUpdatedAt === "string"
-          ? entry.repoUpdatedAt
-          : undefined,
-    },
-  ];
+  return [`${entry.category}:${entry.slug}`, pickRepoStats(entry)];
 }

--- a/tests/entry-repo-stats.test.ts
+++ b/tests/entry-repo-stats.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, it } from "vitest";
 
-import { entryRepoStatsEntry } from "../scripts/lib/entry-repo-stats.mjs";
+import {
+  entryRepoStatsEntry,
+  pickRepoStats,
+} from "../scripts/lib/entry-repo-stats.mjs";
+
+describe("pickRepoStats", () => {
+  it("carries correctly-typed stats and drops the rest", () => {
+    expect(
+      pickRepoStats({
+        githubStars: 5,
+        githubForks: 0,
+        repoUpdatedAt: "2026-02-02",
+      }),
+    ).toEqual({ stars: 5, forks: 0, updatedAt: "2026-02-02" });
+    expect(
+      pickRepoStats({
+        githubStars: "5",
+        githubForks: null,
+        repoUpdatedAt: 20260202,
+      }),
+    ).toEqual({ stars: undefined, forks: undefined, updatedAt: undefined });
+  });
+
+  it("treats a nullish source as empty stats", () => {
+    expect(pickRepoStats(null)).toEqual({
+      stars: undefined,
+      forks: undefined,
+      updatedAt: undefined,
+    });
+  });
+});
 
 describe("entryRepoStatsEntry", () => {
   it("maps a payload to a keyed repo-stats pair", () => {


### PR DESCRIPTION
### What & why

`scripts/build-content-index.mjs` projected GitHub repo stats twice with the same typed star/fork/updatedAt shaping: once per entry (via `entryRepoStatsEntry`) and once for the site-stats payload (inline in `loadExistingSiteStats`). This extracts the shared projection into `pickRepoStats` in `scripts/lib/entry-repo-stats.mjs` and uses it from both, so the site-stats path is covered too.

### Changes

- `scripts/lib/entry-repo-stats.mjs` - add `pickRepoStats(source)`; `entryRepoStatsEntry` now delegates to it. Named `pickRepoStats` to avoid colliding with the script's local `repoStats` Map.
- `scripts/build-content-index.mjs` - `loadExistingSiteStats` uses `pickRepoStats`; drop its inline projection.
- `tests/entry-repo-stats.test.ts` - add direct `pickRepoStats` cases (typed vs wrongly-typed stats, nullish source) alongside the existing `entryRepoStatsEntry` cases. Branch coverage 100% (12/12).

### Validation

- `pnpm exec vitest run tests/entry-repo-stats.test.ts` - 6 passed
- `node --check scripts/build-content-index.mjs` - clean; `pickRepoStats` coexists with the local `repoStats` Map
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (dedupe + pure-logic extraction + tests). No behavior change; both stats projections are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
