### PR TITLE
test(scripts): extract weekly-brief CLI helpers and cover them

### DIFF
--- a/scripts/generate-weekly-brief.mjs
+++ b/scripts/generate-weekly-brief.mjs
@@ -9,18 +9,11 @@ import {
   renderWeeklyBriefMarkdown,
 } from "@heyclaude/registry/weekly-brief";
 
+import { argValue, envelopeEntries, hasFlag } from "./lib/weekly-brief-cli.mjs";
+
 const repoRoot = process.cwd();
 const defaultDataDir = path.join(repoRoot, "apps/web/public/data");
-
-function argValue(name, fallback = "") {
-  const prefix = `${name}=`;
-  const match = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
-  return match ? match.slice(prefix.length) : fallback;
-}
-
-function hasFlag(name) {
-  return process.argv.slice(2).includes(name);
-}
+const cliArgs = process.argv.slice(2);
 
 function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
@@ -38,13 +31,6 @@ function readJson(filePath, artifactName) {
   }
 }
 
-function envelopeEntries(payload, label) {
-  if (!payload || !Array.isArray(payload.entries)) {
-    throw new Error(`${label} must contain an entries array.`);
-  }
-  return payload.entries;
-}
-
 function usage() {
   return [
     "Usage: pnpm brief:weekly [--format=markdown|json] [--days=7] [--data-dir=apps/web/public/data]",
@@ -54,14 +40,17 @@ function usage() {
   ].join("\n");
 }
 
-if (hasFlag("--help") || hasFlag("-h")) {
+if (hasFlag("--help", cliArgs) || hasFlag("-h", cliArgs)) {
   console.log(usage());
   process.exit(0);
 }
 
-const format = argValue("--format", "markdown");
-const days = Number(argValue("--days", "7"));
-const dataDir = path.resolve(repoRoot, argValue("--data-dir", defaultDataDir));
+const format = argValue("--format", cliArgs, "markdown");
+const days = Number(argValue("--days", cliArgs, "7"));
+const dataDir = path.resolve(
+  repoRoot,
+  argValue("--data-dir", cliArgs, defaultDataDir),
+);
 
 if (!["markdown", "json"].includes(format)) {
   console.error("Invalid --format. Expected markdown or json.");

--- a/scripts/lib/weekly-brief-cli.mjs
+++ b/scripts/lib/weekly-brief-cli.mjs
@@ -1,0 +1,24 @@
+// Pure CLI/payload helpers behind scripts/generate-weekly-brief.mjs: reading
+// `--name=value` flag values and boolean flags out of an argv list, and pulling
+// the entries array out of a registry artifact envelope. Split out - with argv
+// injected - so they can be unit-tested without process.argv or the filesystem.
+
+/** Value of a `--name=value` flag in argv, or `fallback` when absent. */
+export function argValue(name, argv, fallback = "") {
+  const prefix = `${name}=`;
+  const match = argv.find((arg) => arg.startsWith(prefix));
+  return match ? match.slice(prefix.length) : fallback;
+}
+
+/** Whether the boolean flag `name` is present in argv. */
+export function hasFlag(name, argv) {
+  return argv.includes(name);
+}
+
+/** Return payload.entries, throwing a labelled error when it is not an array. */
+export function envelopeEntries(payload, label) {
+  if (!payload || !Array.isArray(payload.entries)) {
+    throw new Error(`${label} must contain an entries array.`);
+  }
+  return payload.entries;
+}

--- a/tests/weekly-brief-cli.test.ts
+++ b/tests/weekly-brief-cli.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  argValue,
+  envelopeEntries,
+  hasFlag,
+} from "../scripts/lib/weekly-brief-cli.mjs";
+
+describe("argValue", () => {
+  it("reads the value of a --name=value flag", () => {
+    expect(argValue("--format", ["--format=json", "--days=7"])).toBe("json");
+    expect(argValue("--days", ["--format=json", "--days=7"])).toBe("7");
+  });
+
+  it("returns the fallback (default '') when the flag is absent", () => {
+    expect(argValue("--format", ["--days=7"], "markdown")).toBe("markdown");
+    expect(argValue("--format", [])).toBe("");
+  });
+
+  it("returns an empty string for a flag given with an empty value", () => {
+    expect(argValue("--format", ["--format="], "markdown")).toBe("");
+  });
+});
+
+describe("hasFlag", () => {
+  it("detects a boolean flag", () => {
+    expect(hasFlag("--help", ["--help"])).toBe(true);
+    expect(hasFlag("-h", ["--format=json", "-h"])).toBe(true);
+    expect(hasFlag("--help", ["--format=json"])).toBe(false);
+    expect(hasFlag("--help", [])).toBe(false);
+  });
+});
+
+describe("envelopeEntries", () => {
+  it("returns the entries array from a payload envelope", () => {
+    const entries = [{ slug: "a" }];
+    expect(envelopeEntries({ entries }, "directory-index.json")).toBe(entries);
+  });
+
+  it("throws a labelled error when entries is missing or not an array", () => {
+    expect(() => envelopeEntries({}, "directory-index.json")).toThrow(
+      /directory-index\.json must contain an entries array/,
+    );
+    expect(() => envelopeEntries(null, "changelog.json")).toThrow(
+      /changelog\.json must contain an entries array/,
+    );
+    expect(() => envelopeEntries({ entries: "nope" }, "x.json")).toThrow(
+      /x\.json must contain an entries array/,
+    );
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/generate-weekly-brief.mjs` read its `--name=value` flags, boolean flags, and the entries array out of each artifact envelope with local helpers that closed over `process.argv` and had no direct tests (the weekly-brief suite exercises the registry lib, not the script). This moves the pure helpers into `scripts/lib/weekly-brief-cli.mjs` - matching the existing `scripts/lib` convention - with argv injected, and imports them back.

### Changes

- Add `scripts/lib/weekly-brief-cli.mjs` - `argValue(name, argv, fallback)`, `hasFlag(name, argv)`, `envelopeEntries(payload, label)`.
- `scripts/generate-weekly-brief.mjs` - build `cliArgs` once and pass it; drop the local copies.
- Add `tests/weekly-brief-cli.test.ts` - covers `--name=value` reads incl. the fallback and empty-value cases, boolean flag detection, and the entries envelope (array returned vs labelled throw for missing/non-array). Branch coverage 100% (7/7).

### Validation

- `pnpm exec vitest run tests/weekly-brief-cli.test.ts` - 6 passed
- `node --check scripts/generate-weekly-brief.mjs` - clean; all three helpers still used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; argument and envelope handling are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
