### PR TITLE
test(scripts): cover the MCP safety-metadata shape assertion

### DIFF
--- a/scripts/lib/mcp-tool-payload.mjs
+++ b/scripts/lib/mcp-tool-payload.mjs
@@ -1,7 +1,21 @@
-// Pure parsers behind scripts/validate-mcp-package.mjs: reading the JSON payload
-// out of an MCP tool result and out of a CLI JSON blob. Split out from the smoke
-// harness so the extraction/branching can be unit-tested without spawning the
-// packaged MCP server.
+// Pure helpers behind scripts/validate-mcp-package.mjs: reading the JSON payload
+// out of an MCP tool result / CLI JSON blob, and asserting the safety-metadata
+// shape an entry must expose. Split out from the smoke harness so the parsing and
+// the shape check can be unit-tested without spawning the packaged MCP server.
+
+/**
+ * Assert that `payload` exposes `safetyNotes` and `privacyNotes` as arrays,
+ * throwing a labelled error otherwise. Mirrors the safety-metadata contract the
+ * packaged MCP server must satisfy.
+ */
+export function assertSafetyMetadataShape(payload, label) {
+  if (!Array.isArray(payload?.safetyNotes)) {
+    throw new Error(`${label} did not expose safetyNotes as an array.`);
+  }
+  if (!Array.isArray(payload?.privacyNotes)) {
+    throw new Error(`${label} did not expose privacyNotes as an array.`);
+  }
+}
 
 /** Parse a JSON blob; when it is an array, return its first element. */
 export function parseJsonOutput(output) {

--- a/scripts/validate-mcp-package.mjs
+++ b/scripts/validate-mcp-package.mjs
@@ -8,7 +8,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
-import { parseJsonOutput, parseToolPayload } from "./lib/mcp-tool-payload.mjs";
+import {
+  assertSafetyMetadataShape,
+  parseJsonOutput,
+  parseToolPayload,
+} from "./lib/mcp-tool-payload.mjs";
 
 const execFile = promisify(execFileCallback);
 const repoRoot = path.resolve(
@@ -30,17 +34,6 @@ const { StdioClientTransport } = await import(
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
-}
-
-function assertSafetyMetadataShape(payload, label) {
-  assert(
-    Array.isArray(payload?.safetyNotes),
-    `${label} did not expose safetyNotes as an array.`,
-  );
-  assert(
-    Array.isArray(payload?.privacyNotes),
-    `${label} did not expose privacyNotes as an array.`,
-  );
 }
 
 async function run(command, args, options = {}) {

--- a/tests/mcp-tool-payload.test.ts
+++ b/tests/mcp-tool-payload.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  assertSafetyMetadataShape,
   parseJsonOutput,
   parseToolPayload,
 } from "../scripts/lib/mcp-tool-payload.mjs";
@@ -42,5 +43,34 @@ describe("parseToolPayload", () => {
     );
     expect(() => parseToolPayload({})).toThrow(/did not include JSON text/);
     expect(() => parseToolPayload(null)).toThrow(/did not include JSON text/);
+  });
+});
+
+describe("assertSafetyMetadataShape", () => {
+  it("passes when safetyNotes and privacyNotes are arrays", () => {
+    expect(() =>
+      assertSafetyMetadataShape(
+        { safetyNotes: [], privacyNotes: ["x"] },
+        "entry",
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws a labelled error when safetyNotes is not an array", () => {
+    expect(() =>
+      assertSafetyMetadataShape({ privacyNotes: [] }, "search entry"),
+    ).toThrow(/search entry did not expose safetyNotes as an array/);
+    expect(() => assertSafetyMetadataShape(null, "x")).toThrow(
+      /x did not expose safetyNotes as an array/,
+    );
+  });
+
+  it("throws when privacyNotes is not an array (safetyNotes ok)", () => {
+    expect(() =>
+      assertSafetyMetadataShape(
+        { safetyNotes: [], privacyNotes: "nope" },
+        "detail",
+      ),
+    ).toThrow(/detail did not expose privacyNotes as an array/);
   });
 });


### PR DESCRIPTION
### What & why

`scripts/validate-mcp-package.mjs` asserts that each entry the packaged MCP server returns exposes `safetyNotes`/`privacyNotes` as arrays, but that check (`assertSafetyMetadataShape`) lived in the smoke harness and had no unit tests. This moves it into the existing `scripts/lib/mcp-tool-payload.mjs` (which the script already imports) and imports it back.

### Changes

- `scripts/lib/mcp-tool-payload.mjs` - add `assertSafetyMetadataShape` (throws directly rather than via the script-local `assert`).
- `scripts/validate-mcp-package.mjs` - import the assertion; drop the local copy (the local `assert` stays for the rest of the smoke checks).
- `tests/mcp-tool-payload.test.ts` - cover the pass case, the labelled throw when `safetyNotes` is missing/not an array (incl. a nullish payload), and the throw when `privacyNotes` is not an array. Branch coverage 100% (10/10).

### Validation

- `pnpm exec vitest run tests/mcp-tool-payload.test.ts` - 8 passed
- `node --check scripts/validate-mcp-package.mjs` - clean; the assertion is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the safety-metadata assertion is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
