### PR TITLE
test(scripts): extract ordered string-array equality and cover it

### DIFF
--- a/scripts/lib/equal-string-arrays.mjs
+++ b/scripts/lib/equal-string-arrays.mjs
@@ -1,0 +1,12 @@
+// Pure ordered-equality check behind scripts/validate-raycast-feed.mjs: used to
+// verify that an entry's mcpInstallTargets exactly match its detail payload's
+// (same values in the same order). Split out so the comparison can be
+// unit-tested in isolation.
+
+/** True when two arrays have the same length and equal items at each index. */
+export function equalStringArrays(left, right) {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => item === right[index])
+  );
+}

--- a/scripts/validate-raycast-feed.mjs
+++ b/scripts/validate-raycast-feed.mjs
@@ -11,6 +11,7 @@ import {
 
 import { stringHasLoneSurrogate } from "./lib/lone-surrogate.mjs";
 import { objectBlock, objectDefinesKey } from "./lib/raycast-source-block.mjs";
+import { equalStringArrays } from "./lib/equal-string-arrays.mjs";
 
 const repoRoot = process.cwd();
 const feedPath = path.join(repoRoot, "apps/web/public/data/raycast-index.json");
@@ -105,13 +106,6 @@ function normalizeMcpInstallTargets(value, label) {
     targets.push(item);
   }
   return targets;
-}
-
-function equalStringArrays(left, right) {
-  return (
-    left.length === right.length &&
-    left.every((item, index) => item === right[index])
-  );
 }
 
 if (!fs.existsSync(feedPath)) {

--- a/tests/equal-string-arrays.test.ts
+++ b/tests/equal-string-arrays.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { equalStringArrays } from "../scripts/lib/equal-string-arrays.mjs";
+
+describe("equalStringArrays", () => {
+  it("is true for arrays with the same items in the same order", () => {
+    expect(equalStringArrays(["a", "b"], ["a", "b"])).toBe(true);
+    expect(equalStringArrays([], [])).toBe(true);
+  });
+
+  it("is false when lengths differ", () => {
+    expect(equalStringArrays(["a"], ["a", "b"])).toBe(false);
+    expect(equalStringArrays(["a", "b"], ["a"])).toBe(false);
+  });
+
+  it("is false when items differ or are out of order", () => {
+    expect(equalStringArrays(["a", "b"], ["a", "c"])).toBe(false);
+    expect(equalStringArrays(["a", "b"], ["b", "a"])).toBe(false);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/validate-raycast-feed.mjs` verifies that an entry's `mcpInstallTargets` exactly match its detail payload's (same values, same order) with a local `equalStringArrays` helper that had no unit tests. This moves the pure function into `scripts/lib/equal-string-arrays.mjs` - matching the existing `scripts/lib` convention - and imports it back.

### Changes

- Add `scripts/lib/equal-string-arrays.mjs` - `equalStringArrays`.
- `scripts/validate-raycast-feed.mjs` - import it; drop the local copy.
- Add `tests/equal-string-arrays.test.ts` - covers equal arrays (incl. empty), length mismatches, and differing/out-of-order items. Branch coverage 100% (2/2).

### Validation

- `pnpm exec vitest run tests/equal-string-arrays.test.ts` - 3 passed
- `node --check scripts/validate-raycast-feed.mjs` - clean; the helper is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the comparison is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
