### PR TITLE
test(registry): cover content-builder optional-field defaults

### DIFF
--- a/tests/content-builder-lib.test.ts
+++ b/tests/content-builder-lib.test.ts
@@ -610,3 +610,44 @@ describe("public wrapper re-exports", () => {
     expect(wrapper.DEFAULT_DIRECTORY_REPO_URL).toBe(DEFAULT_DIRECTORY_REPO_URL);
   });
 });
+
+describe("buildContentEntryFromMdx optional-field defaults", () => {
+  it("falls back to 'skill' when the slug is only whitespace", () => {
+    const platforms = buildDefaultSkillPlatformCompatibility(
+      { slug: "   " },
+      {},
+    );
+    expect(platforms[4].adapterPath).toBe(
+      "/data/skill-adapters/cursor/skill.mdc",
+    );
+  });
+
+  it("defaults the optional fields when the frontmatter omits them", () => {
+    const entry = buildEntry({
+      fileName: "min.mdx",
+      source: mdx(["title: Minimal", "dateAdded: 2026-01-03"].join("\n")),
+    });
+    // slug derived from the file name; description defaults to ""
+    expect(entry.slug).toBe("min");
+    expect(entry.description).toBe("");
+    // optional snippets/metadata are dropped (undefined) rather than emitted
+    expect(entry.cardDescription).toBeUndefined();
+    expect(entry.commandSyntax).toBeUndefined();
+    expect(entry.retrievalSources).toBeUndefined();
+  });
+
+  it("uses a frontmatter commandSyntax when none is inferred", () => {
+    const entry = buildEntry({
+      fileName: "cmd.mdx",
+      source: mdx(
+        [
+          "title: Cmd",
+          "slug: cmd",
+          "commandSyntax: /deploy [env]",
+          "dateAdded: 2026-01-03",
+        ].join("\n"),
+      ),
+    });
+    expect(entry.commandSyntax).toBe("/deploy [env]");
+  });
+});


### PR DESCRIPTION
### What & why

Several optional-field fallback branches in `packages/registry/src/content-builder-lib.js` were uncovered: the whitespace-slug fallback in `buildDefaultSkillPlatformCompatibility`, and the drop-to-`undefined` / default-to-`""` handling in `buildContentEntryFromMdx` when the frontmatter omits `description`, `cardDescription`, `commandSyntax`, and `retrievalSources`. This adds cases for these - test-only, no source change.

### Changes

- `tests/content-builder-lib.test.ts`:
  - `buildDefaultSkillPlatformCompatibility`: a whitespace-only slug falls back to `"skill"` in the Cursor adapter path.
  - `buildContentEntryFromMdx`: a minimal entry (title + dateAdded only) defaults `description` to `""` and drops the optional snippets/metadata; a frontmatter `commandSyntax` is used when none is inferred.

Raises `content-builder-lib` branch coverage from 96.3% to 97.7%.

### Validation

- `pnpm exec vitest run tests/content-builder-lib.test.ts` - 30 passed
- `pnpm exec prettier --check tests/content-builder-lib.test.ts` - clean

### Notes

No matching open issue - maintainer-lane internal test-coverage improvement. Test-only; no source behavior changes.
