### PR TITLE
test(registry): cover validateEntry brand-color and source-url checks

### DIFF
--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -1110,3 +1110,26 @@ describe("deriveSeoFields title fallbacks", () => {
     ).toEqual(expect.arrayContaining(["a", "b"]));
   });
 });
+
+describe("validateEntry brand color and source URL checks", () => {
+  const base = { slug: "a", title: "A", description: "D" };
+
+  it("validates comma-separated brandColors and flags a non-hex value", () => {
+    expect(
+      validateEntry("mcp", { ...base, brandColors: "#796eff, notahex" })
+        .semanticErrors,
+    ).toContain("brandColors must be hex colors such as #796eff");
+    expect(
+      validateEntry("mcp", { ...base, brandColors: "#796eff" }).semanticErrors,
+    ).not.toContain("brandColors must be hex colors such as #796eff");
+  });
+
+  it("flags a sourceUrls entry that is not an http(s) URL", () => {
+    expect(
+      validateEntry("mcp", {
+        ...base,
+        sourceUrls: ["https://ok.dev", "not-a-url"],
+      }).semanticErrors,
+    ).toContain("sourceUrls must use http or https");
+  });
+});


### PR DESCRIPTION
### What & why

Two validation branches in `packages/registry/src/content-schema-lib.js` `validateEntry` were uncovered: parsing a comma-separated `brandColors` string (vs an array) and flagging a non-hex value, and rejecting a `sourceUrls` array entry that is not an http(s) URL. This adds cases for these - test-only, no source change.

Raises `content-schema-lib` branch coverage from 94.7% to 95.2% across its suite.

### Changes

- `tests/content-schema-lib.test.ts`: add a `validateEntry` brand-color / source-URL describe covering the comma-string `brandColors` path (with a non-hex value flagged) and the `sourceUrls` http(s) check.

### Validation

- `pnpm exec vitest run tests/content-schema-lib.test.ts` - 383 passed
- `pnpm exec prettier --check tests/content-schema-lib.test.ts` - clean

### Notes

No matching open issue - maintainer-lane internal test-coverage improvement. Test-only; no source behavior changes.
