### PR TITLE
test(registry): cover content-schema text-utility fallbacks

### DIFF
--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -1133,3 +1133,26 @@ describe("validateEntry brand color and source URL checks", () => {
     ).toContain("sourceUrls must use http or https");
   });
 });
+
+describe("content-schema text-utility fallbacks", () => {
+  it("falls back to 'section' ids for headings that have no slug", () => {
+    const headings = extractHeadings("## !!!\n\ntext\n\n## !!!\n");
+    expect(headings.map((h) => h.id)).toEqual(["section", "section-2"]);
+  });
+
+  it("ends the usage section at the next ## heading", () => {
+    const sections = extractSections("## Usage\n\nintro\n\n## Other\n\nx");
+    expect(sections.map((s) => s.title)).toEqual(["Usage", "Other"]);
+    expect(sections[0].markdown).toBe("intro");
+  });
+
+  it("truncates a long seoDescription at a sentence boundary", () => {
+    const longDesc =
+      "This is a reasonably long first sentence that should be picked. " +
+      "x".repeat(200);
+    expect(
+      deriveSeoFields({ title: "T", description: longDesc }, "mcp")
+        .seoDescription,
+    ).toBe("This is a reasonably long first sentence that should be picked.");
+  });
+});


### PR DESCRIPTION
### What & why

A few text-utility branches in `packages/registry/src/content-schema-lib.js` were uncovered: the `"section"` heading-id fallback (`extractHeadings`) for headings that slugify to nothing, ending the usage section at the next `##` heading (`extractSections`), and the sentence-boundary truncation of a long `seoDescription` (`deriveSeoFields`). This adds cases for these - test-only, no source change.

Raises `content-schema-lib` branch coverage from 95.2% to 96.1% across its suite.

### Changes

- `tests/content-schema-lib.test.ts`: add a text-utility-fallback describe covering the `extractHeadings` `"section"` id fallback, `extractSections` terminating usage at the next `##`, and `deriveSeoFields` sentence-boundary truncation.

### Validation

- `pnpm exec vitest run tests/content-schema-lib.test.ts` - 386 passed
- `pnpm exec prettier --check tests/content-schema-lib.test.ts` - clean

### Notes

No matching open issue - maintainer-lane internal test-coverage improvement. Test-only; no source behavior changes.
