### PR TITLE
test(registry): cover source-url helpers for nullish/empty/unparseable input

### DIFF
--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -731,3 +731,22 @@ describe("canonicalizeSourceUrl path normalization table", () => {
     expect(canonicalizeSourceUrl(input)).toBe(expected);
   });
 });
+
+describe("URL helpers handle nullish, empty, and unparseable input", () => {
+  it("treats nullish/empty values as valid optional URLs", () => {
+    expect(isPublicHttpsUrl(null)).toBe(true);
+    expect(isPublicHttpsUrl(undefined)).toBe(true);
+    expect(isPublicHttpUrl(null)).toBe(true);
+  });
+
+  it("rejects a non-empty value that cannot be parsed as a URL", () => {
+    expect(isPublicHttpsUrl("not a url")).toBe(false);
+    expect(isPublicHttpUrl("http://")).toBe(false);
+  });
+
+  it("returns '' from publicHttpUrlHref for nullish or empty input", () => {
+    expect(publicHttpUrlHref(null)).toBe("");
+    expect(publicHttpUrlHref("")).toBe("");
+    expect(publicHttpUrlHref("   ")).toBe("");
+  });
+});


### PR DESCRIPTION
### What & why

The nullish-coalescing and empty/unparseable guards in `packages/registry/src/source-url-lib.js` were uncovered: `isPublicHttpsUrl` / `isPublicHttpUrl` treating nullish values as valid optional URLs and returning `false` for a non-empty unparseable value, and `publicHttpUrlHref` returning `""` for nullish/empty input. This adds cases for these - test-only, no source change.

Raises `source-url-lib` branch coverage from 91.3% to 98.8% across its suite.

### Changes

- `tests/source-url-lib.test.ts`: add a describe covering nullish/undefined inputs (valid optional), a non-empty unparseable value (rejected), and `publicHttpUrlHref` returning `""` for nullish/empty/whitespace.

### Validation

- `pnpm exec vitest run tests/source-url-lib.test.ts` - 221 passed
- `pnpm exec prettier --check tests/source-url-lib.test.ts` - clean

### Notes

No matching open issue - maintainer-lane internal test-coverage improvement. Test-only; no source behavior changes.
