### PR TITLE
test(registry): cover validateEntry category-specific rules

### DIFF
--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -1156,3 +1156,36 @@ describe("content-schema text-utility fallbacks", () => {
     ).toBe("This is a reasonably long first sentence that should be picked.");
   });
 });
+
+describe("validateEntry category-specific recommended/semantic rules", () => {
+  it("drops installCommand from a skills entry that ships a downloadUrl", () => {
+    const result = validateEntry("skills", {
+      slug: "s",
+      title: "S",
+      description: "D",
+      downloadUrl: "/downloads/skills/s.zip",
+    });
+    expect(result.missingRecommended).not.toContain("installCommand");
+  });
+
+  it("requires verifiedAt on a capability-pack skill", () => {
+    const result = validateEntry("skills", {
+      slug: "s",
+      title: "S",
+      description: "D",
+      skillType: "capability-pack",
+      retrievalSources: ["https://source.dev"],
+    });
+    expect(result.semanticErrors).toContain(
+      "capability-pack skills must include verifiedAt",
+    );
+  });
+
+  it("has no required fields for an unknown category", () => {
+    const result = validateEntry("totally-unknown-cat", {
+      slug: "s",
+      title: "S",
+    });
+    expect(result.missingRequired).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

More `validateEntry` branches in `packages/registry/src/content-schema-lib.js` were uncovered: a skills entry that ships a `downloadUrl` dropping `installCommand` from its recommended fields, the capability-pack skill `verifiedAt` requirement, and an unknown category having no required fields (the `schema?.required ?? []` fallback). This adds cases for these - test-only, no source change.

Raises `content-schema-lib` branch coverage from 96.1% to 96.7% across its suite.

### Changes

- `tests/content-schema-lib.test.ts`: add a `validateEntry` category-rules describe covering the skills-downloadUrl recommended splice, the capability-pack `verifiedAt` semantic error, and the unknown-category required-fields fallback.

### Validation

- `pnpm exec vitest run tests/content-schema-lib.test.ts` - 389 passed
- `pnpm exec prettier --check tests/content-schema-lib.test.ts` - clean

### Notes

No matching open issue - maintainer-lane internal test-coverage improvement. Test-only; no source behavior changes.
