### PR TITLE
test(registry): cover content-schema text-utility edge cases

### DIFF
--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -1189,3 +1189,34 @@ describe("validateEntry category-specific recommended/semantic rules", () => {
     expect(result.missingRequired).toEqual([]);
   });
 });
+
+describe("content-schema text-utility edge cases", () => {
+  it("hard-truncates a seoDescription with no late word boundary", () => {
+    // a long unbroken tail means the last space in the 157-char slice is early,
+    // so the description is sliced at the char limit rather than a word boundary
+    const description = `short intro then ${"a".repeat(160)}`;
+    const seoDescription = deriveSeoFields(
+      { title: "T", description },
+      "mcp",
+    ).seoDescription;
+    expect(seoDescription.endsWith("...")).toBe(true);
+    expect(seoDescription.length).toBe(160);
+  });
+
+  it("does not treat a '## ' line inside a usage code block as a heading", () => {
+    const body = [
+      "## Usage",
+      "",
+      "```",
+      "## not a heading",
+      "run x",
+      "```",
+    ].join("\n");
+    const usageSnippet = inferStructuredFields(
+      { title: "T", slug: "s" },
+      body,
+      "commands",
+    ).usageSnippet;
+    expect(usageSnippet).toContain("## not a heading");
+  });
+});


### PR DESCRIPTION
### What & why

Two remaining text-utility branches in `packages/registry/src/content-schema-lib.js` were uncovered: hard-truncating a `seoDescription` that has no late word boundary (`deriveSeoFields` slices at the char limit rather than a space), and not treating a `"## "` line inside a usage code block as a heading (`inferStructuredFields` usage extraction). This adds cases for these - test-only, no source change.

Raises `content-schema-lib` branch coverage from 96.7% to 97.1% across its suite.

### Changes

- `tests/content-schema-lib.test.ts`: add a text-utility edge-case describe covering the no-word-boundary `seoDescription` truncation and the `## `-inside-code-block usage extraction.

### Validation

- `pnpm exec vitest run tests/content-schema-lib.test.ts` - 391 passed
- `pnpm exec prettier --check tests/content-schema-lib.test.ts` - clean

### Notes

No matching open issue - maintainer-lane internal test-coverage improvement. Test-only; no source behavior changes.
