### PR TITLE
test(mcp): cover registry-filter tag and trust-filter edge cases

### DIFF
--- a/tests/mcp-registry-filter-lib.test.ts
+++ b/tests/mcp-registry-filter-lib.test.ts
@@ -63,3 +63,40 @@ describe("registry-filter-lib trust filters", () => {
     );
   });
 });
+
+describe("registry-filter edge cases", () => {
+  it("does not match a tag for an entry with no tags", () => {
+    expect(entryMatchesTag({}, "foo")).toBe(false);
+  });
+
+  it("rejects entries that fail an individual trust filter", () => {
+    // hasPrivacyNotes: require present, entry has none
+    expect(
+      entryMatchesTrustFilters(
+        { privacyNotes: [] },
+        { hasPrivacyNotes: "true" },
+      ),
+    ).toBe(false);
+    // downloadTrust mismatch
+    expect(
+      entryMatchesTrustFilters(
+        { downloadTrust: "community" },
+        { downloadTrust: "verified" },
+      ),
+    ).toBe(false);
+    // claimStatus mismatch
+    expect(
+      entryMatchesTrustFilters(
+        { claimStatus: "unclaimed" },
+        { claimStatus: "verified" },
+      ),
+    ).toBe(false);
+    // sourceStatus mismatch
+    expect(
+      entryMatchesTrustFilters(
+        { trustSignals: { sourceStatus: "verified" } },
+        { sourceStatus: "unverified" },
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### What & why

The remaining branches in `packages/mcp/src/registry-filter-lib.js` were uncovered: `entryMatchesTag` for an entry with no tags (the `entry.tags || []` fallback), and `entryMatchesTrustFilters` rejecting entries that fail an individual filter (`hasPrivacyNotes`, `downloadTrust`, `claimStatus`, `sourceStatus`). This adds cases for these - test-only, no source change.

Raises `registry-filter-lib` branch coverage from 87.1% to 100%.

### Changes

- `tests/mcp-registry-filter-lib.test.ts`: add an edge-cases describe covering the no-tags path and each trust-filter rejection.

### Validation

- `pnpm exec vitest run tests/mcp-registry-filter-lib.test.ts` - 7 passed
- `pnpm exec prettier --check tests/mcp-registry-filter-lib.test.ts` - clean

### Notes

No matching open issue - maintainer-lane internal test-coverage improvement. Test-only; no source behavior changes.
