### PR TITLE
test(mcp): cover null array args in registry-collection intersection

### DIFF
--- a/tests/mcp-registry-collection-lib.test.ts
+++ b/tests/mcp-registry-collection-lib.test.ts
@@ -38,6 +38,12 @@ describe("registry-collection-lib array helpers", () => {
       intersection(["Codex", "codex", "Cursor"], ["cursor", "vscode"]),
     ).toEqual(["cursor"]);
   });
+
+  it("treats null array arguments as empty", () => {
+    expect(intersection(null, null)).toEqual([]);
+    expect(intersection(["a"], null)).toEqual([]);
+    expect(intersection(null, ["a"])).toEqual([]);
+  });
 });
 
 describe("registry-collection-lib date floors", () => {


### PR DESCRIPTION
Covers the two remaining branches in `registry-collection-lib` `intersection`: the `left || []` / `right || []` null-guards (default params only catch `undefined`, so `null` arguments still need the fallback). Lib branch coverage 93.1% -> 100% (29/29). Test-only change.