### PR TITLE
test(mcp): cover non-object payloads in registry-response withPublicPolicy

### DIFF
--- a/tests/mcp-registry-response-lib.test.ts
+++ b/tests/mcp-registry-response-lib.test.ts
@@ -73,4 +73,10 @@ describe("registry-response-lib policy attachment", () => {
       policy: { readOnly: true },
     });
   });
+
+  it("returns non-object payloads unchanged", () => {
+    expect(withPublicPolicy(null)).toBeNull();
+    expect(withPublicPolicy("plain")).toBe("plain");
+    expect(withPublicPolicy([1, 2])).toEqual([1, 2]);
+  });
 });


### PR DESCRIPTION
Covers the remaining branch in `registry-response-lib` `withPublicPolicy`: the `!result || typeof result !== "object" || Array.isArray(result)` early-return for null, primitive, and array payloads (previously only object payloads were exercised, across both dedicated and server test files). Lib branch coverage 92.3% -> 100% (13/13). Test-only change.