### PR TITLE
test(mcp): cover missing-value fallbacks in registry-copyable-asset-lib

### DIFF
--- a/tests/mcp-registry-copyable-asset-lib.test.ts
+++ b/tests/mcp-registry-copyable-asset-lib.test.ts
@@ -3247,3 +3247,26 @@ describe("registry-copyable-asset-lib buildCopyableAssetResponse", () => {
     expect(response.assets.length).toBeGreaterThan(0);
   });
 });
+
+describe("registry-copyable-asset-lib missing-value fallbacks", () => {
+  it("returns null when a requested type has no matching assets", () => {
+    expect(
+      selectPrimaryAsset([], { category: "mcp" }, "install_command"),
+    ).toBeNull();
+  });
+
+  it("defaults installCommand to an empty string when the entry omits it", () => {
+    const response = buildCopyableAssetResponse({
+      entry: { category: "mcp", slug: "s", title: "T" },
+      platform: "",
+      requestedType: "",
+      assets: [],
+      primary: null,
+      compatibility: null,
+      source: null,
+      trust: null,
+      canonicalUrl: "https://example.com/s",
+    });
+    expect(response.installCommand).toBe("");
+  });
+});


### PR DESCRIPTION
Covers the remaining branches in `registry-copyable-asset-lib`: `selectPrimaryAsset` returning null via `assets[0] || null` when a requested type has no matching assets, and the `entry.installCommand || ""` fallback in `buildCopyableAssetResponse` for an entry that omits it. Lib branch coverage 90.5% -> 100% (21/21). Test-only change.