### PR TITLE
test(scripts): extract preview-url host guard and cover it

### DIFF
--- a/scripts/lib/preview-url-host.mjs
+++ b/scripts/lib/preview-url-host.mjs
@@ -1,0 +1,26 @@
+// Pure host matching behind scripts/resolve-pr-preview-url.mjs: deciding whether
+// a candidate deployment host is a HeyClaude PRODUCTION preview host. Split out
+// so the (fiddly) worker-label rules can be unit-tested without the GitHub API /
+// filesystem layers the resolver uses to gather candidate URLs.
+
+// A preview URL for this project must be a HeyClaude PRODUCTION host. This
+// Cloudflare account hosts several unrelated projects, so GitHub
+// deployment/status lookups can surface a sibling project's URL (e.g.
+// gittensory.aethereal.dev) — running the artifact contract against that is
+// wrong. Accept only the production site and Cloudflare Workers Builds preview
+// aliases for the prod worker (<version>-heyclaude-prod.<subdomain>.workers.dev).
+// Deliberately excludes the retired dev worker (heyclaude-dev.*.workers.dev and
+// dev.heyclau.de).
+export function isHeyClaudePreviewHost(hostname) {
+  const host = String(hostname || "").toLowerCase();
+  if (host === "heyclau.de" || host === "www.heyclau.de") return true;
+  if (!host.endsWith(".workers.dev")) return false;
+  // The worker name is the first dot-label of the host: "heyclaude-prod" or a
+  // Workers Builds preview alias "<version>-heyclaude-prod". Match the label
+  // exactly so a sibling worker whose name merely CONTAINS the substring (e.g.
+  // "heyclaude-prod-next") or a "…heyclaude-prod…" subdomain is not selected.
+  const workerLabel = host.split(".")[0];
+  return (
+    workerLabel === "heyclaude-prod" || workerLabel.endsWith("-heyclaude-prod")
+  );
+}

--- a/scripts/resolve-pr-preview-url.mjs
+++ b/scripts/resolve-pr-preview-url.mjs
@@ -9,6 +9,7 @@ import {
   prNumber,
   previewCandidatesFromEnv,
 } from "./lib/preview-url-event.mjs";
+import { isHeyClaudePreviewHost } from "./lib/preview-url-host.mjs";
 
 const githubUrlPattern = /^https:\/\/github\.com\//i;
 const blockedPreviewHosts = new Set([
@@ -22,28 +23,6 @@ const blockedPreviewHosts = new Set([
 ]);
 const nonDeploymentSourcePattern =
   /(?:coderabbit|superagent|contributor trust|pipelock|codeql|trunk|security scan|repo scan)/i;
-
-// A preview URL for this project must be a HeyClaude PRODUCTION host. This
-// Cloudflare account hosts several unrelated projects, so GitHub
-// deployment/status lookups can surface a sibling project's URL (e.g.
-// gittensory.aethereal.dev) — running the artifact contract against that is
-// wrong. Accept only the production site and Cloudflare Workers Builds preview
-// aliases for the prod worker (<version>-heyclaude-prod.<subdomain>.workers.dev).
-// Deliberately excludes the retired dev worker (heyclaude-dev.*.workers.dev and
-// dev.heyclau.de).
-function isHeyClaudePreviewHost(hostname) {
-  const host = String(hostname || "").toLowerCase();
-  if (host === "heyclau.de" || host === "www.heyclau.de") return true;
-  if (!host.endsWith(".workers.dev")) return false;
-  // The worker name is the first dot-label of the host: "heyclaude-prod" or a
-  // Workers Builds preview alias "<version>-heyclaude-prod". Match the label
-  // exactly so a sibling worker whose name merely CONTAINS the substring (e.g.
-  // "heyclaude-prod-next") or a "…heyclaude-prod…" subdomain is not selected.
-  const workerLabel = host.split(".")[0];
-  return (
-    workerLabel === "heyclaude-prod" || workerLabel.endsWith("-heyclaude-prod")
-  );
-}
 
 export function normalizeBaseUrl(value) {
   const trimmed = String(value || "").trim();

--- a/tests/preview-url-host.test.ts
+++ b/tests/preview-url-host.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { isHeyClaudePreviewHost } from "../scripts/lib/preview-url-host.mjs";
+
+describe("isHeyClaudePreviewHost", () => {
+  it("accepts the production apex and www hosts (case-insensitive)", () => {
+    expect(isHeyClaudePreviewHost("heyclau.de")).toBe(true);
+    expect(isHeyClaudePreviewHost("www.heyclau.de")).toBe(true);
+    expect(isHeyClaudePreviewHost("WWW.HEYCLAU.DE")).toBe(true);
+  });
+
+  it("accepts the prod worker and its Workers Builds preview aliases", () => {
+    expect(isHeyClaudePreviewHost("heyclaude-prod.example.workers.dev")).toBe(
+      true,
+    );
+    expect(
+      isHeyClaudePreviewHost("a1b2c3-heyclaude-prod.example.workers.dev"),
+    ).toBe(true);
+  });
+
+  it("rejects sibling workers that merely contain the prod label", () => {
+    expect(
+      isHeyClaudePreviewHost("heyclaude-prod-next.example.workers.dev"),
+    ).toBe(false);
+    expect(isHeyClaudePreviewHost("heyclaude-prodx.example.workers.dev")).toBe(
+      false,
+    );
+  });
+
+  it("rejects the retired dev worker and dev apex", () => {
+    expect(isHeyClaudePreviewHost("heyclaude-dev.example.workers.dev")).toBe(
+      false,
+    );
+    expect(isHeyClaudePreviewHost("dev.heyclau.de")).toBe(false);
+  });
+
+  it("rejects non-workers.dev sibling hosts and other domains", () => {
+    expect(isHeyClaudePreviewHost("gittensory.aethereal.dev")).toBe(false);
+    expect(isHeyClaudePreviewHost("example.com")).toBe(false);
+  });
+
+  it("treats the prod label only when it is the first dot-label", () => {
+    // "heyclaude-prod" appears but not as the worker (first) label
+    expect(isHeyClaudePreviewHost("preview.heyclaude-prod.workers.dev")).toBe(
+      false,
+    );
+  });
+
+  it("rejects empty, nullish, and non-string input", () => {
+    expect(isHeyClaudePreviewHost("")).toBe(false);
+    expect(isHeyClaudePreviewHost(null)).toBe(false);
+    expect(isHeyClaudePreviewHost(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Behavior-preserving refactor + test coverage, mirroring the recent `test(scripts): extract … and cover it` refactors. The pure HeyClaude production-host check in `scripts/resolve-pr-preview-url.mjs` was defined inline and untested; this splits it into `scripts/lib/preview-url-host.mjs` and covers its (fiddly) worker-label matching rules.

Extracted (unchanged logic):
- `isHeyClaudePreviewHost(hostname)` — accepts the production apex/`www`, and only the prod Cloudflare worker (`heyclaude-prod`) or its Workers Builds preview aliases (`<version>-heyclaude-prod`) on `*.workers.dev`; rejects sibling workers that merely contain the label, the retired dev worker, and unrelated Cloudflare-account hosts.

The resolver now imports it; no runtime behavior changes.

## Files

- `scripts/lib/preview-url-host.mjs` — the pure host guard (new)
- `scripts/resolve-pr-preview-url.mjs` — imports the guard instead of defining it inline
- `tests/preview-url-host.test.ts` — 7 cases (apex/www, prod worker + alias, sibling/`-next`/`-prodx` rejection, dev-worker rejection, non-first-label, empty/nullish)

No content, registry, generated-artifact, or `apps/web` changes.

## Validation

```
pnpm exec prettier --check <changed files>                                      # clean
pnpm exec vitest run tests/preview-url-host.test.ts \
  tests/deployment-preview-url.test.ts tests/preview-url-event.test.ts          # 37 passed
```

The existing resolver tests (`selectPreviewUrl`, which uses this guard) still pass, confirming the refactor is behavior-preserving. The extracted helper lives in coverage-scoped `scripts/lib/**` and is fully exercised by the new test, satisfying `codecov/patch`.
