### PR TITLE
test(mcp): cover missing-field fallbacks and asset types in registry-compare-lib

### DIFF
--- a/tests/mcp-registry-compare-lib.test.ts
+++ b/tests/mcp-registry-compare-lib.test.ts
@@ -8542,3 +8542,50 @@ describe("registry-compare-lib buildCompareEntriesResponse", () => {
     expect(response.entries).toHaveLength(1);
   });
 });
+
+describe("registry-compare-lib missing-field fallbacks", () => {
+  const deps = {
+    normalizePlatform,
+    buildSkillPlatformCompatibility,
+    entryInstallComplexity,
+    categoryPrimaryAsset,
+    sourceSummary,
+    entryTrustSummary,
+    entryCanonicalUrl,
+  };
+
+  it("defaults tags/platforms/asset types for a bare entry", () => {
+    const row = buildCompareEntryRow(
+      { category: "mcp", slug: "s", title: "T", description: "d" },
+      "",
+      deps,
+    );
+    expect(row.tags).toEqual([]);
+    expect(row.platforms).toEqual([]);
+    expect(row.copyableAssetTypes).toEqual([]);
+  });
+
+  it("treats entries without tags as empty when intersecting shared tags", () => {
+    expect(sharedCompareTags([{ slug: "a" }, { tags: ["x"] }])).toEqual([]);
+    expect(sharedCompareTags([{ tags: ["x", "y"] }, { slug: "b" }])).toEqual(
+      [],
+    );
+  });
+
+  it("lists config and script asset types when the entry provides them", () => {
+    const row = buildCompareEntryRow(
+      {
+        category: "mcp",
+        slug: "s",
+        title: "T",
+        configSnippet: "{ }",
+        scriptBody: "echo hi",
+      },
+      "",
+      deps,
+    );
+    expect(row.copyableAssetTypes).toEqual(
+      expect.arrayContaining(["config_snippet", "script"]),
+    );
+  });
+});


### PR DESCRIPTION
Covers the remaining branches in `registry-compare-lib`: the `entry.tags || []` / `entry.platforms || []` and config/install/script asset-type ternary arms in `buildCompareEntryRow` (bare entry for the empty arms, config+script entry for the populated arms), and the tag fallbacks in `sharedCompareTags` when the first or a later compared entry omits tags. Lib branch coverage 68.2% -> 100% (22/22). Test-only change.