### PR TITLE
test(mcp): cover digit/ampersand slug and slugless skill compatibility in platforms-lib

### DIFF
--- a/tests/mcp-platforms-lib.test.ts
+++ b/tests/mcp-platforms-lib.test.ts
@@ -67,3 +67,18 @@ describe("platforms re-export compatibility", () => {
     expect(buildCompatibilityFromWrapper).toBe(buildSkillPlatformCompatibility);
   });
 });
+
+describe("platforms-lib slug and compatibility edge cases", () => {
+  it("keeps digits and joins ampersands adjacent to alphanumerics", () => {
+    expect(platformFeedSlug("a1&b2")).toBe("a1-andb2");
+    expect(platformFeedSlug("Claude 2 & Code 3")).toBe("claude-2-and-code-3");
+  });
+
+  it("builds default skill compatibility for a skills entry without a slug", () => {
+    const compatibility = buildSkillPlatformCompatibility({
+      category: "skills",
+    });
+    expect(compatibility.length).toBeGreaterThan(0);
+    expect(compatibility[0].platform).toBe("Claude");
+  });
+});


### PR DESCRIPTION
Covers the remaining branches in `platforms-lib`: the digit character class and the ampersand-adjacent-to-alphanumeric separator insertion in `slugPart` (via `platformFeedSlug`), and the `entry?.slug || ""` fallback in `buildSkillPlatformCompatibility` for a skills entry without a slug. Lib branch coverage 89.7% -> 100% (29/29). Test-only change.