### PR TITLE
test(mcp): cover platform-selected compatibility in registry-safety-review-lib

### DIFF
--- a/tests/mcp-registry-safety-review-lib.test.ts
+++ b/tests/mcp-registry-safety-review-lib.test.ts
@@ -5594,3 +5594,58 @@ describe("registry-safety-review-lib buildSafetyReviewResponse", () => {
     expect(response.count).toBe(1);
   });
 });
+
+describe("registry-safety-review-lib platform-selected compatibility", () => {
+  const deps = (
+    compatibility: Array<{ platform: string; support: string }>,
+  ) => ({
+    normalizePlatform: (platform: string) => platform,
+    buildSkillPlatformCompatibility: () => compatibility,
+    entryCanonicalUrl: () => "https://heyclau.de/entry/skills/designer",
+    entryTrustSummary: () => ({ level: "trusted" }),
+  });
+
+  it("selects the compatibility row whose normalized platform matches", () => {
+    const row = buildSafetyReviewRow(
+      makeEntry({ category: "skills", slug: "designer" }),
+      "cursor",
+      deps([
+        { platform: "claude-code", support: "native" },
+        { platform: "cursor", support: "adapter" },
+      ]),
+    );
+    expect(row.selectedCompatibility).toEqual({
+      platform: "cursor",
+      support: "adapter",
+    });
+  });
+
+  it("returns a null selection when no compatibility row matches the platform", () => {
+    const row = buildSafetyReviewRow(
+      makeEntry({ category: "skills", slug: "designer" }),
+      "codex",
+      deps([{ platform: "cursor", support: "adapter" }]),
+    );
+    expect(row.selectedCompatibility).toBeNull();
+  });
+
+  it("normalizes the compatibility platform before comparing", () => {
+    const row = buildSafetyReviewRow(
+      makeEntry({ category: "skills", slug: "designer" }),
+      "cursor",
+      {
+        normalizePlatform: (platform: string) =>
+          platform === "cursor-rules" ? "cursor" : platform,
+        buildSkillPlatformCompatibility: () => [
+          { platform: "cursor-rules", support: "adapter" },
+        ],
+        entryCanonicalUrl: () => "u",
+        entryTrustSummary: () => ({}),
+      },
+    );
+    expect(row.selectedCompatibility).toEqual({
+      platform: "cursor-rules",
+      support: "adapter",
+    });
+  });
+});


### PR DESCRIPTION
## The gap

`registry-safety-review-lib.js` was **90.9% line** covered. `buildSafetyReviewRow` was only ever called with an empty `platform`, so the `platform ? …` branch — the `find` callback that selects the compatibility row whose `normalizePlatform(item.platform)` equals the requested platform (line 38) — never executed.

## What this adds

Three cases through the function's injected deps:
- a requested platform selects the matching compatibility row;
- a platform with no matching row yields `selectedCompatibility: null`;
- the compatibility row's platform is normalized before the comparison (a `cursor-rules` row matches a `cursor` request).

**No source change.** Line and branch coverage both go to **100%**.

```
pnpm exec vitest run tests/mcp-registry-safety-review-lib.test.ts   # 452 passed
pnpm exec prettier --check tests/mcp-registry-safety-review-lib.test.ts   # clean
```