### PR TITLE
test(mcp): cover platform sorting in registry-stats-lib

### DIFF
--- a/tests/mcp-registry-stats-lib.test.ts
+++ b/tests/mcp-registry-stats-lib.test.ts
@@ -3042,3 +3042,35 @@ describe("registry-stats-lib missing-field fallbacks", () => {
     expect(response.registry.categories).toEqual({});
   });
 });
+
+describe("registry-stats-lib platform sorting", () => {
+  const manifest = {
+    schemaVersion: 2,
+    generatedAt: "2026-07-14",
+    totalEntries: 2,
+    categories: { mcp: 2 },
+  };
+
+  it("returns registry platforms sorted alphabetically by name", () => {
+    // Two entries spanning several platforms out of order, so the platform
+    // sort comparator runs and the response keys come back alphabetized.
+    const entries = [
+      makeEntry({ slug: "a", platforms: ["vscode", "cursor"] }),
+      makeEntry({ slug: "b", platforms: ["claude-code", "windsurf"] }),
+    ];
+    const response = buildRegistryStatsResponse({
+      manifest,
+      entries,
+      packageName: "@heyclaude/mcp",
+      packageVersion: "1.0.0",
+    });
+    expect(Object.keys(response.platforms)).toEqual([
+      "claude-code",
+      "cursor",
+      "vscode",
+      "windsurf",
+    ]);
+    expect(response.platforms["cursor"]).toBe(1);
+    expect(response.platforms["claude-code"]).toBe(1);
+  });
+});


### PR DESCRIPTION
## The gap

`registry-stats-lib.js` was **95.23% line** covered. `buildRegistryStatsResponse` sorts the registry platform stats alphabetically:

```js
platforms: Object.fromEntries(
  [...platformCounts.entries()].sort((left, right) => left[0].localeCompare(right[0])),
),
```

Every existing `buildRegistryStatsResponse` test used entries that shared a single platform, so `platformCounts` never held two distinct keys and the sort comparator (line 97) never ran.

## What this adds

One case with two entries spanning four out-of-order platforms (`vscode`, `cursor`, `claude-code`, `windsurf`), asserting the response `platforms` keys come back alphabetized and the counts are correct.

**No source change.** Line and branch coverage both go to **100%**.

```
pnpm exec vitest run tests/mcp-registry-stats-lib.test.ts   # 383 passed
pnpm exec prettier --check tests/mcp-registry-stats-lib.test.ts   # clean
```