### PR TITLE
test(mcp): cover categoryPrimaryAsset fallbacks in registry-asset-lib

### DIFF
--- a/tests/mcp-registry-asset-lib.test.ts
+++ b/tests/mcp-registry-asset-lib.test.ts
@@ -81,3 +81,26 @@ describe("registry-asset-lib install complexity", () => {
     ).toBe("higher");
   });
 });
+
+describe("registry-asset-lib categoryPrimaryAsset fallbacks", () => {
+  it("falls back to full_content preference for an unrecognized category", () => {
+    expect(
+      categoryPrimaryAsset({
+        category: "mystery",
+        fullCopyableContent: "hello world",
+      }),
+    ).toMatchObject({ type: "full_content", content: "hello world" });
+  });
+
+  it("returns the first available asset when no preferred type is present", () => {
+    // mcp prefers config_snippet/install_command/usage; only full_content exists,
+    // so the response falls through to the first available asset.
+    expect(
+      categoryPrimaryAsset({ category: "mcp", body: "just the body" }),
+    ).toMatchObject({ type: "full_content", content: "just the body" });
+  });
+
+  it("returns null when the entry has no copyable assets", () => {
+    expect(categoryPrimaryAsset({ category: "mcp" })).toBeNull();
+  });
+});


### PR DESCRIPTION
## The gap

`registry-asset-lib.js` was **90.32% branch** covered. `categoryPrimaryAsset` was only tested with recognized categories whose preferred asset type was present, so three fallback branches never ran:

- `preferredByCategory[entry.category] || ["full_content"]` — the unknown-category default (line 74);
- `preferred.map(…).find(Boolean) || assets[0]` — dropping to the first available asset when no preferred type matches (line 78);
- `… || null` — the empty-entry case (line 79).

## What this adds

One case for each: an unrecognized category resolving to the `full_content` asset; an `mcp` entry that has only `full_content` (none of mcp's preferred types) falling through to it; and an entry with no copyable content returning `null`.

**No source change.** Branch coverage goes to **100%**.

```
pnpm exec vitest run tests/mcp-registry-asset-lib.test.ts   # 9 passed
pnpm exec prettier --check tests/mcp-registry-asset-lib.test.ts   # clean
```