### PR TITLE
test(web): cover tagless entries in tags-lib

### DIFF
--- a/tests/tags-lib.test.ts
+++ b/tests/tags-lib.test.ts
@@ -109,3 +109,25 @@ describe("computeRelatedTags", () => {
     expect(computeRelatedTags(groups, "ai", 1)).toHaveLength(1);
   });
 });
+
+describe("tags-lib entries without tags", () => {
+  it("buildTagGroups treats a tagless entry as contributing no groups", () => {
+    const tagless = { ...entry("b", []), tags: undefined } as Entry;
+    const groups = buildTagGroups([entry("a", ["ai"]), tagless]);
+    expect(groups.map((group) => group.slug)).toEqual(["ai"]);
+  });
+
+  it("computeRelatedTags skips a grouped entry that has no tags", () => {
+    const tagless = { ...entry("x", []), tags: undefined } as Entry;
+    const groups = [
+      { slug: "ai", name: "AI", entries: [tagless, entry("y", ["ai", "ml"])] },
+      {
+        slug: "ml",
+        name: "ML",
+        entries: [entry("y", ["ai", "ml"]), entry("z", ["ml"])],
+      },
+    ];
+    const related = computeRelatedTags(groups, "ai");
+    expect(related.map((group) => group.slug)).toEqual(["ml"]);
+  });
+});


### PR DESCRIPTION
## The gap

`tags-lib.ts` was **91.3% branch** covered. Both `buildTagGroups` and `computeRelatedTags` iterate `entry.tags ?? []`, but every existing fixture supplied a `tags` array (a `[]` is still defined, so `?? []` never fires), leaving the `undefined` fallback untested in both.

## What this adds

- `buildTagGroups` with a tagless entry alongside a tagged one — the tagless entry contributes no groups.
- `computeRelatedTags` on a group whose entries include a tagless one — it's skipped, and the genuine related tag (a 2-entry `ml` group) is still returned.

**No source change.** Branch coverage goes to **100%**.

```
pnpm exec vitest run tests/tags-lib.test.ts   # 12 passed
pnpm exec prettier --check tests/tags-lib.test.ts   # clean
```