### PR TITLE
test(web): cover non-alias and empty tokens in search-query-aliases-lib

### DIFF
--- a/tests/search-query-aliases-lib.test.ts
+++ b/tests/search-query-aliases-lib.test.ts
@@ -814,3 +814,29 @@ describe("search-query-aliases-lib", () => {
     expect(set.has("security")).toBe(true);
   });
 });
+
+describe("search-query-aliases-lib non-alias and empty tokens", () => {
+  it("queryAliasExpansions returns [] for an empty or whitespace token", () => {
+    expect(queryAliasExpansions("")).toEqual([]);
+    expect(queryAliasExpansions("   ")).toEqual([]);
+  });
+
+  it("queryAliasExpansions returns [] for a token that is not an alias key", () => {
+    expect(queryAliasExpansions("spreadsheet")).toEqual([]);
+  });
+
+  it("queryAliasExpansions does not treat inherited prototype names as aliases", () => {
+    // Object.hasOwn guards against "constructor"/"toString" resolving to Object.prototype.
+    expect(queryAliasExpansions("constructor")).toEqual([]);
+    expect(queryAliasExpansions("toString")).toEqual([]);
+  });
+
+  it("expandedTokenCandidates returns [] for an empty or whitespace token", () => {
+    expect(expandedTokenCandidates("")).toEqual([]);
+    expect(expandedTokenCandidates("   ")).toEqual([]);
+  });
+
+  it("expandedTokenCandidates returns just the token for a non-alias word", () => {
+    expect(expandedTokenCandidates("spreadsheet")).toEqual(["spreadsheet"]);
+  });
+});


### PR DESCRIPTION
## The gap

`search-query-aliases-lib.ts` was **66.66% branch** covered. `queryAliasExpansions` and `expandedTokenCandidates` were only exercised with known alias keys, so their guard branches never ran:

- `if (!key || !Object.hasOwn(SEARCH_QUERY_ALIASES, key)) return []` — neither the empty-key nor the not-an-alias-key operand;
- `if (!key) return []` in `expandedTokenCandidates`.

## What this adds

Empty/whitespace tokens returning `[]`; a non-alias word (`spreadsheet`) returning `[]` from `queryAliasExpansions` and `["spreadsheet"]` from `expandedTokenCandidates`; and the `Object.hasOwn` guard against inherited prototype names — `constructor` and `toString` resolve to `[]` rather than `Object.prototype` values.

**No source change.** Branch coverage goes to **100%**.

```
pnpm exec vitest run tests/search-query-aliases-lib.test.ts   # 207 passed
pnpm exec prettier --check tests/search-query-aliases-lib.test.ts   # clean
```