### PR TITLE
test(web): cover disallow-less rules in robots-policy-lib

### DIFF
--- a/tests/robots-policy-lib.test.ts
+++ b/tests/robots-policy-lib.test.ts
@@ -613,3 +613,19 @@ describe("robots-policy-lib", () => {
     expect(renderRobotsTxt()).toContain("Sitemap:");
   });
 });
+
+describe("robots-policy-lib rules without disallow paths", () => {
+  it("omits Disallow lines for a rule that has no disallow list", () => {
+    const policy = {
+      rules: [{ userAgent: "*", allow: "/" }],
+      contentSignal: "",
+      sitemap: "https://heyclau.de/sitemap.xml",
+      host: "heyclau.de",
+    } as Parameters<typeof renderRobotsTxt>[0];
+    const output = renderRobotsTxt(policy);
+    expect(output).toContain("User-agent: *");
+    expect(output).toContain("Allow: /");
+    expect(output).not.toContain("Disallow:");
+    expect(output).toContain("Sitemap: https://heyclau.de/sitemap.xml");
+  });
+});


### PR DESCRIPTION
## The gap

`robots-policy-lib.ts` was **88.9% branch** covered. `renderRobotsTxt` was only ever called with the default policy from `getRobotsPolicy()`, whose every rule carries a `disallow` array, so the `for (const path of rule.disallow ?? [])` fallback for a rule *without* a disallow list never ran.

## What this adds

A custom policy with a `disallow`-less rule, asserting `renderRobotsTxt` emits no `Disallow:` lines while still emitting the `User-agent`, `Allow`, and `Sitemap` lines.

**No source change.** Branch coverage goes to **100%**.

```
pnpm exec vitest run tests/robots-policy-lib.test.ts   # 203 passed
pnpm exec prettier --check tests/robots-policy-lib.test.ts   # clean
```