### PR TITLE
test(web): cover the nullish-error branch in brief-issues-lib

### DIFF
--- a/tests/brief-issues-lib.test.ts
+++ b/tests/brief-issues-lib.test.ts
@@ -1412,3 +1412,10 @@ describe("brief-issues-lib parseBriefIssueRow", () => {
     expect(issue.sent_at).toBe("2026-06-02T09:05:00.000Z");
   });
 });
+
+describe("brief-issues-lib isMissingBriefIssuesInfra nullish input", () => {
+  it("treats null and undefined as unrelated errors (fails closed)", () => {
+    expect(isMissingBriefIssuesInfra(null)).toBe(false);
+    expect(isMissingBriefIssuesInfra(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds the one missing test for `isMissingBriefIssuesInfra` in `apps/web/src/lib/brief-issues-lib.ts`.

The matcher normalizes its input with `String(error ?? "")` so a nullish error still produces a searchable string, but every existing test passed either an `Error` instance or a non-empty string — the `?? ""` fallback was never exercised.

New case: `null` and `undefined` inputs, which normalize to `""`, match neither table pattern, and return `false` (fail closed).

## Coverage

Scoped to the file: branch coverage **83.33% → 100%** (statements/lines/functions were already 100%).

## Validation

- `pnpm exec vitest run tests/brief-issues-lib.test.ts` — 237 passed
- `pnpm exec prettier --check tests/brief-issues-lib.test.ts`
- Test-only change; no source or generated-artifact edits.
