### PR TITLE
test(web): cover browse, site, feeds, and draft branch edges

### DIFF
--- a/tests/ai-referral-cta-events-lib.test.ts
+++ b/tests/ai-referral-cta-events-lib.test.ts
@@ -18,4 +18,10 @@ describe("ai referral cta events lib", () => {
       landingSegment: "agents",
     });
   });
+
+  it("treats blank and slash-only paths as the home landing segment", () => {
+    expect(aiReferralLandingSegment("")).toBe("home");
+    expect(aiReferralLandingSegment("   ")).toBe("home");
+    expect(aiReferralLandingSegment("///")).toBe("home");
+  });
 });

--- a/tests/app-shell-footer-lib.test.ts
+++ b/tests/app-shell-footer-lib.test.ts
@@ -36,6 +36,8 @@ describe("app-shell-footer-lib", () => {
     expect(footerColumnSpanClass(2)).toBe("md:col-span-2");
     expect(footerColumnSpanClass()).toBe("md:col-span-2");
     expect(shellFooterBrandSpanClass()).toBe("md:col-span-4");
+    expect(shellFooterBrandSpanClass(3)).toBe("md:col-span-3");
+    expect(shellFooterBrandSpanClass(2)).toBe("md:col-span-2");
   });
 
   it("fits brand and link columns into the 12-column footer grid", () => {

--- a/tests/browse-filter-decision-hints-lib.test.ts
+++ b/tests/browse-filter-decision-hints-lib.test.ts
@@ -107,4 +107,101 @@ describe("browse filter decision hints lib", () => {
       kind: null,
     });
   });
+
+  it("builds trust-filter guidance when every result shares one trust level", () => {
+    const results = [entry(), entry({ slug: "two" })];
+    expect(
+      browseFilterDecisionUiState({ ...emptySlice, trust: "review" }, results),
+    ).toEqual({
+      hint: "All 2 results are review trust — check install risk per entry.",
+      kind: "trust-filter",
+    });
+  });
+
+  it("switches signal-filter copy when compare already has two entries", () => {
+    expect(
+      browseFilterDecisionUiState(
+        { ...emptySlice, signal: "safety-notes" },
+        [entry(), entry({ slug: "two" })],
+        2,
+      ),
+    ).toEqual({
+      hint: "Safety notes filter — open compare to see trust gaps in your selection.",
+      kind: "signal-filter",
+    });
+  });
+
+  it("nudges compare when a narrow filter set has fewer than two selections", () => {
+    expect(
+      browseFilterDecisionUiState(
+        { ...emptySlice, category: "skills", platform: "claude-code" },
+        [entry(), entry({ slug: "two" })],
+        0,
+      ),
+    ).toEqual({
+      hint: "Narrow filter set — select entries to compare trust side by side.",
+      kind: "narrow-set",
+    });
+  });
+
+  it("opens compare guidance when two entries are already selected", () => {
+    expect(
+      browseFilterDecisionUiState(
+        { ...emptySlice, q: "memory" },
+        [entry(), entry({ slug: "two" })],
+        2,
+      ),
+    ).toEqual({
+      hint: "Open compare to review trust and next steps across your selection.",
+      kind: "compare",
+    });
+  });
+
+  it("suggests compare for text/category/source/platform filters with enough results", () => {
+    const results = [entry(), entry({ slug: "two" }), entry({ slug: "three" })];
+    expect(
+      browseFilterDecisionUiState({ ...emptySlice, q: "memory" }, results, 0),
+    ).toEqual({
+      hint: "Select entries to compare install and trust signals side by side.",
+      kind: "compare",
+    });
+    expect(
+      browseFilterDecisionUiState(
+        { ...emptySlice, source: "source-backed" },
+        results,
+        0,
+      ).kind,
+    ).toBe("compare");
+    expect(
+      browseFilterDecisionUiState(
+        { ...emptySlice, platform: "claude-code" },
+        results,
+        0,
+      ).kind,
+    ).toBe("compare");
+  });
+
+  it("counts every active browse filter dimension", () => {
+    expect(
+      browseActiveFilterCount({
+        ...emptySlice,
+        q: "memory",
+        category: "skills",
+        trust: "trusted",
+        source: "source-backed",
+        signal: "reviewed",
+        platform: "claude-code",
+      }),
+    ).toBe(6);
+  });
+
+  it("returns null trust-mix hint for fewer than two entries or a single trust level", () => {
+    expect(browseFilteredTrustMixHint([entry()])).toBeNull();
+    expect(
+      browseFilteredTrustMixHint([
+        entry({ trust: "trusted" }),
+        entry({ slug: "two", trust: "trusted" }),
+      ]),
+    ).toBeNull();
+  });
 });

--- a/tests/browse-results-trust-decision-lib.test.ts
+++ b/tests/browse-results-trust-decision-lib.test.ts
@@ -102,4 +102,83 @@ describe("browse results trust decision lib", () => {
       ),
     ).toContain("Review status");
   });
+
+  it("returns an empty coverage chip list for zero results", () => {
+    expect(browseTrustCoverageChips([])).toEqual([]);
+  });
+
+  it("classifies high and neutral coverage chip emphasis", () => {
+    const results = [
+      entry({
+        trust: "trusted",
+        safetyNotes: "Careful",
+        privacyNotes: "Local only",
+        reviewed: true,
+        source: "source-backed",
+        claimed: true,
+      }),
+      entry({
+        slug: "two",
+        trust: "trusted",
+        safetyNotes: "Careful",
+        privacyNotes: "Local only",
+        reviewed: true,
+        source: "source-backed",
+        claimed: true,
+      }),
+      entry({
+        slug: "three",
+        trust: "trusted",
+        safetyNotes: "Careful",
+        privacyNotes: "Local only",
+        reviewed: true,
+        source: "source-backed",
+        claimed: true,
+      }),
+    ];
+    const coverage = browseTrustCoverageChips(results);
+    expect(coverage.find((chip) => chip.id === "safety")).toMatchObject({
+      emphasis: "high",
+      percent: 100,
+    });
+    expect(coverage.find((chip) => chip.id === "reviewed")?.emphasis).toBe(
+      "high",
+    );
+  });
+
+  it("warns about weak trust-signal coverage when multiple chips are low", () => {
+    const sparse = [
+      entry(),
+      entry({ slug: "two" }),
+      entry({ slug: "three" }),
+      entry({ slug: "four" }),
+    ];
+    expect(browseTrustPanelDecisionHint(sparse, 0, [])).toContain(
+      "of results have key trust signals",
+    );
+  });
+
+  it("prefers side-by-side compare copy when diverging labels exist and compare is ready", () => {
+    expect(
+      browseTrustPanelDecisionHint(
+        [entry(), entry({ slug: "two" })],
+        2,
+        ["Review status"],
+      ),
+    ).toContain("open compare to review side by side");
+  });
+
+  it("falls back to mixed-trust guidance when labels do not diverge", () => {
+    expect(
+      browseTrustPanelDecisionHint(
+        [
+          entry({ trust: "trusted" }),
+          entry({ slug: "two", trust: "review" }),
+          entry({ slug: "three", trust: "limited" }),
+        ],
+        0,
+        [],
+      ),
+    ).toContain("Mixed trust levels");
+  });
 });

--- a/tests/browse-results-trust-decision-lib.test.ts
+++ b/tests/browse-results-trust-decision-lib.test.ts
@@ -160,11 +160,9 @@ describe("browse results trust decision lib", () => {
 
   it("prefers side-by-side compare copy when diverging labels exist and compare is ready", () => {
     expect(
-      browseTrustPanelDecisionHint(
-        [entry(), entry({ slug: "two" })],
-        2,
-        ["Review status"],
-      ),
+      browseTrustPanelDecisionHint([entry(), entry({ slug: "two" })], 2, [
+        "Review status",
+      ]),
     ).toContain("open compare to review side by side");
   });
 

--- a/tests/browse-theme-distribution-lib.test.ts
+++ b/tests/browse-theme-distribution-lib.test.ts
@@ -105,4 +105,19 @@ describe("browseThemeDistributionState", () => {
     expect(tags).not.toContain("");
     expect(tags).toContain("memory");
   });
+
+  it("classifies a balanced two-theme view as mixed concentration", () => {
+    // Top theme under 50% and fewer than 2x distinct tags vs entries => mixed.
+    const state = browseThemeDistributionState([
+      entry("a", ["memory", "rag"]),
+      entry("b", ["search", "graph"]),
+      entry("c", ["memory", "tools"]),
+      entry("d", ["search", "hooks"]),
+      entry("e", ["graph", "rag"]),
+    ]);
+    expect(state.focusPercent).toBeLessThan(50);
+    expect(state.concentration).toBe("mixed");
+    expect(state.heading).toContain("A few themes lead this view");
+    expect(state.summary).toContain("distinct themes");
+  });
 });

--- a/tests/command-bar-cta-events-lib.test.ts
+++ b/tests/command-bar-cta-events-lib.test.ts
@@ -57,5 +57,21 @@ describe("command bar cta events lib", () => {
       resultCount: 4,
       scopeCategory: "mcp",
     });
+    expect(
+      commandBarResultSelectAnalyticsData("skills", "demo", 0, 1, "", 0),
+    ).toEqual({
+      surface: COMMAND_BAR_SURFACE,
+      entry: "skills/demo",
+      resultIndex: 0,
+      resultCount: 1,
+      scopeCategory: "all",
+      queryLength: 0,
+    });
+    expect(commandBarSearchSubmitAnalyticsData(0, 0, "")).toEqual({
+      surface: COMMAND_BAR_SURFACE,
+      queryLength: 0,
+      resultCount: 0,
+      scopeCategory: "all",
+    });
   });
 });

--- a/tests/content-loader-lib.test.ts
+++ b/tests/content-loader-lib.test.ts
@@ -2485,4 +2485,52 @@ describe("content-loader-lib loadTextFromAssetsBinding", () => {
     );
     expect(result).toBe("text-39");
   });
+
+  it("throws when the assets binding returns a non-ok text response", async () => {
+    const assets = {
+      fetch: vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+    };
+    await expect(
+      loadTextFromAssetsBinding(assets, "https://example/data/down.txt"),
+    ).rejects.toThrow("503");
+  });
+});
+
+describe("content-loader-lib edge branches", () => {
+  it("throws a generic not-found error when every path fails without an error", async () => {
+    const readFile = vi.fn().mockRejectedValue(undefined);
+    await expect(readLocalDataFileFromPaths([], readFile)).rejects.toThrow(
+      "Local data artifact not found",
+    );
+  });
+
+  it("throws after exhausting json read retries", async () => {
+    const readFile = vi.fn().mockRejectedValue(new Error("disk busy"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      readLocalJsonDataFileWithRetry(
+        "broken.json",
+        ["/broken.json"],
+        readFile,
+        sleep,
+        2,
+      ),
+    ).rejects.toThrow("disk busy");
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not sleep after the final failed json read attempt", async () => {
+    const readFile = vi.fn().mockResolvedValue("not-json");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      readLocalJsonDataFileWithRetry(
+        "invalid.json",
+        ["/invalid.json"],
+        readFile,
+        sleep,
+        1,
+      ),
+    ).rejects.toThrow();
+    expect(sleep).not.toHaveBeenCalled();
+  });
 });

--- a/tests/entry-detail-command-center-lib.test.ts
+++ b/tests/entry-detail-command-center-lib.test.ts
@@ -157,4 +157,69 @@ describe("entry detail command center lib", () => {
       { id: "signals", label: "Community signals", targetId: "signals" },
     ]);
   });
+
+  it("keeps browse as the only quick link when docs and source are absent", () => {
+    expect(resolveDetailQuickLinks(entry()).map((link) => link.id)).toEqual([
+      "browse",
+    ]);
+  });
+
+  it("treats list-only safety and privacy notes as present for the safety gate", () => {
+    const installable = entry({ installCommand: "npm i fixture" });
+    expect(
+      shouldElevateDetailSafetyGate(
+        "low",
+        entry({
+          ...installable,
+          safetyNotesList: ["Runs locally"],
+          privacyNotesList: ["No telemetry"],
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      detailSafetyGateMessage(
+        "low",
+        entry({ ...installable, safetyNotesList: ["Runs locally"] }),
+      ),
+    ).toContain("Missing privacy notes");
+    expect(
+      detailSafetyGateMessage(
+        "low",
+        entry({ ...installable, privacyNotesList: ["No telemetry"] }),
+      ),
+    ).toContain("Missing safety notes");
+  });
+
+  it("does not elevate low-risk entries without install payloads", () => {
+    expect(shouldElevateDetailSafetyGate("low", entry())).toBe(false);
+    expect(detailSafetyGateMessage("low", entry())).toBeNull();
+  });
+
+  it("falls back to generic trust review copy when notes exist but risk still elevates", () => {
+    expect(
+      detailSafetyGateMessage(
+        "review",
+        entry({
+          installCommand: "npm i fixture",
+          safetyNotes: "ok",
+          privacyNotes: "ok",
+        }),
+      ),
+    ).toContain("Review safety and privacy notes");
+  });
+
+  it("builds partial community anchors when only one section has content", () => {
+    expect(resolveDetailCommunityAnchors(2, 0, false)).toEqual([
+      {
+        id: "related",
+        label: "Related entries",
+        targetId: "related",
+        count: 2,
+      },
+    ]);
+    expect(resolveDetailCommunityAnchors(0, 1, true)).toEqual([
+      { id: "guides", label: "Related guides", targetId: "guides", count: 1 },
+      { id: "signals", label: "Community signals", targetId: "signals" },
+    ]);
+  });
 });

--- a/tests/feeds-trending-items.test.ts
+++ b/tests/feeds-trending-items.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getGrowthSurfaces } = vi.hoisted(() => ({
+  getGrowthSurfaces: vi.fn(),
+}));
+
+vi.mock("@/lib/growth-surfaces", () => ({
+  getGrowthSurfaces,
+}));
+
+import { trendingItems } from "@/lib/feeds";
+
+describe("feeds trendingItems branch coverage", () => {
+  beforeEach(() => {
+    getGrowthSurfaces.mockReset();
+  });
+
+  it("returns an empty list when no live signals are available", async () => {
+    getGrowthSurfaces.mockResolvedValue({
+      communitySignalsAvailable: false,
+      votesAvailable: false,
+      intentEventsAvailable: false,
+      communityTrending: [],
+    });
+
+    await expect(trendingItems()).resolves.toEqual([]);
+  });
+
+  it("maps community trending entries into feed items when live signals exist", async () => {
+    getGrowthSurfaces.mockResolvedValue({
+      communitySignalsAvailable: true,
+      votesAvailable: false,
+      intentEventsAvailable: false,
+      communityTrending: [
+        {
+          category: "mcp",
+          slug: "live-trending-fixture",
+          title: "Live Trending Fixture",
+          description: "Fixture description",
+          dateAdded: "2026-01-15T00:00:00.000Z",
+        },
+      ],
+    });
+
+    await expect(trendingItems()).resolves.toEqual([
+      {
+        title: "Live Trending Fixture",
+        link: "/entry/mcp/live-trending-fixture",
+        guid: "trending:mcp/live-trending-fixture",
+        pubDate: "2026-01-15T00:00:00.000Z",
+        description: "Fixture description",
+        category: "mcp",
+      },
+    ]);
+  });
+
+  it("falls back to epoch pubDate when trending entries omit dateAdded", async () => {
+    getGrowthSurfaces.mockResolvedValue({
+      communitySignalsAvailable: false,
+      votesAvailable: true,
+      intentEventsAvailable: false,
+      communityTrending: [
+        {
+          category: "skills",
+          slug: "undated-fixture",
+          title: "Undated Fixture",
+          description: "No date",
+        },
+      ],
+    });
+
+    const items = await trendingItems();
+    expect(items[0]?.pubDate).toBe(new Date(0).toISOString());
+  });
+});

--- a/tests/site-lib.test.ts
+++ b/tests/site-lib.test.ts
@@ -1,15 +1,30 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  buildCategoryDescriptions,
   buildCategoryLabels,
+  buildCategoryQuickstarts,
+  buildCategorySeoDescriptions,
+  buildCategoryUsageHints,
   categoryAccentClasses,
   categorySpecCategories,
+  publicCsvEnv,
+  publicEnv,
   publicHttpUrl,
 } from "../apps/web/src/lib/site-lib";
 
 describe("site-lib publicHttpUrl", () => {
   it("accepts https url", () => {
     expect(publicHttpUrl("https://example.com/")).toBe("https://example.com");
+  });
+  it("accepts http url and strips trailing slash", () => {
+    expect(publicHttpUrl("http://example.com/path/")).toBe(
+      "http://example.com/path",
+    );
+  });
+  it("rejects non-http protocols and empty input", () => {
+    expect(publicHttpUrl("javascript:alert(1)")).toBe("");
+    expect(publicHttpUrl("")).toBe("");
   });
   it("rejects invalid url", () => {
     expect(publicHttpUrl("not-a-url")).toBe("");
@@ -373,5 +388,83 @@ describe("site-lib category builders", () => {
   it("buildCategoryLabels matrix 49", () => {
     const labels = buildCategoryLabels(categorySpecCategories);
     expect(Object.keys(labels).length).toBeGreaterThan(5);
+  });
+});
+
+describe("site-lib publicEnv and publicCsvEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads trimmed values from import.meta.env first", () => {
+    vi.stubEnv("VITE_BRANCH_FIXTURE", "  from-vite  ");
+    expect(publicEnv("VITE_BRANCH_FIXTURE")).toBe("from-vite");
+  });
+
+  it("falls back to process.env when import.meta.env is empty", () => {
+    vi.stubEnv("VITE_MISSING_FIXTURE", "");
+    process.env.VITE_MISSING_FIXTURE = "  from-process  ";
+    expect(publicEnv("VITE_MISSING_FIXTURE")).toBe("from-process");
+    delete process.env.VITE_MISSING_FIXTURE;
+  });
+
+  it("returns fallback csv values when the env var is blank", () => {
+    vi.stubEnv("VITE_CSV_FIXTURE", "");
+    expect(publicCsvEnv("VITE_CSV_FIXTURE", ["alpha", "beta"])).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("splits, trims, and drops empty csv entries", () => {
+    vi.stubEnv("VITE_CSV_FIXTURE", " alpha , , beta ,gamma ");
+    expect(publicCsvEnv("VITE_CSV_FIXTURE")).toEqual(["alpha", "beta", "gamma"]);
+  });
+});
+
+describe("site-lib category builders", () => {
+  const fixtureMap = {
+    agents: {
+      label: "Agents",
+      description: "Agent description",
+      seoDescription: "Agent SEO",
+      usageHint: "Use agents for workflows",
+      quickstart: ["Install", "Run"],
+    },
+    tools: {
+      label: "Tools",
+      description: "Tool description",
+      usageHint: "Use tools carefully",
+      quickstart: "not-an-array" as unknown as string[],
+    },
+  };
+
+  it("builds category label, description, seo, usage, and quickstart maps", () => {
+    expect(buildCategoryLabels(fixtureMap)).toEqual({
+      agents: "Agents",
+      tools: "Tools",
+    });
+    expect(buildCategoryDescriptions(fixtureMap)).toEqual({
+      agents: "Agent description",
+      tools: "Tool description",
+    });
+    expect(buildCategorySeoDescriptions(fixtureMap)).toEqual({
+      agents: "Agent SEO",
+      tools: "Tool description",
+    });
+    expect(buildCategoryUsageHints(fixtureMap)).toEqual({
+      agents: "Use agents for workflows",
+      tools: "Use tools carefully",
+    });
+    expect(buildCategoryQuickstarts(fixtureMap)).toEqual({
+      agents: ["Install", "Run"],
+      tools: [],
+    });
+  });
+
+  it("exposes accent classes for every catalog category", () => {
+    for (const category of Object.keys(categorySpecCategories)) {
+      expect(categoryAccentClasses[category]).toContain("border-border");
+    }
   });
 });

--- a/tests/site-lib.test.ts
+++ b/tests/site-lib.test.ts
@@ -418,7 +418,11 @@ describe("site-lib publicEnv and publicCsvEnv", () => {
 
   it("splits, trims, and drops empty csv entries", () => {
     vi.stubEnv("VITE_CSV_FIXTURE", " alpha , , beta ,gamma ");
-    expect(publicCsvEnv("VITE_CSV_FIXTURE")).toEqual(["alpha", "beta", "gamma"]);
+    expect(publicCsvEnv("VITE_CSV_FIXTURE")).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
   });
 });
 

--- a/tests/submission-gate-drafts-branch-coverage.test.ts
+++ b/tests/submission-gate-drafts-branch-coverage.test.ts
@@ -22,14 +22,19 @@ describe("submission-gate drafts branch coverage", () => {
   it("derives slugs from nested draft payloads and strips unsupported bodies", () => {
     expect(draftFieldsFromBody(["not", "a", "record"])).toEqual({});
     expect(
-      draftFieldsFromBody({ fields: { category: "hooks", title: "Hook Draft" } }),
+      draftFieldsFromBody({
+        fields: { category: "hooks", title: "Hook Draft" },
+      }),
     ).toEqual({ category: "hooks", title: "Hook Draft" });
     expect(slugify('  "Branch" Draft!  ')).toBe("branch-draft");
   });
 
   it("hashes overlong branch names while preserving the full target slug", () => {
     const longSlug = "x".repeat(120);
-    const target = buildDraftTarget({ category: "skills", slug: longSlug }, "main");
+    const target = buildDraftTarget(
+      { category: "skills", slug: longSlug },
+      "main",
+    );
     expect(target.slug).toBe(longSlug);
     expect(target.branchName.length).toBeLessThanOrEqual(120);
     expect(target.branchName).toMatch(/-[a-z0-9]{8}$/);
@@ -58,7 +63,7 @@ describe("submission-gate drafts branch coverage", () => {
         download_url: "https://example.com/pkg.zip",
         install_command: "npm i fixture",
         usage_snippet: "Run locally",
-        config_snippet: "{ \"enabled\": true }",
+        config_snippet: '{ "enabled": true }',
         full_copyable_content: "Step one\nStep two",
         command_syntax: "/fixture run",
         trigger: "manual",
@@ -103,7 +108,9 @@ describe("submission-gate drafts branch coverage", () => {
     );
 
     expect(mdx).toContain('submittedBy: "@valid-contributor"');
-    expect(mdx).toContain('authorProfileUrl: "https://github.com/valid-contributor"');
+    expect(mdx).toContain(
+      'authorProfileUrl: "https://github.com/valid-contributor"',
+    );
     expect(mdx).toContain('documentationUrl: "https://example.com/docs"');
   });
 });

--- a/tests/submission-gate-drafts-branch-coverage.test.ts
+++ b/tests/submission-gate-drafts-branch-coverage.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildContributorMdx,
+  buildDraftTarget,
+  draftFieldsFromBody,
+  normalizeCategory,
+  slugify,
+} from "../apps/submission-gate/src/drafts";
+
+describe("submission-gate drafts branch coverage", () => {
+  it("rejects unsupported categories and empty slugs when building draft targets", () => {
+    expect(normalizeCategory("Unknown Category")).toBe("");
+    expect(() =>
+      buildDraftTarget({ category: "unknown", name: "Fixture" }, "main"),
+    ).toThrow("supported category and slug");
+    expect(() =>
+      buildDraftTarget({ category: "skills", name: "   " }, "main"),
+    ).toThrow("supported category and slug");
+  });
+
+  it("derives slugs from nested draft payloads and strips unsupported bodies", () => {
+    expect(draftFieldsFromBody(["not", "a", "record"])).toEqual({});
+    expect(
+      draftFieldsFromBody({ fields: { category: "hooks", title: "Hook Draft" } }),
+    ).toEqual({ category: "hooks", title: "Hook Draft" });
+    expect(slugify('  "Branch" Draft!  ')).toBe("branch-draft");
+  });
+
+  it("hashes overlong branch names while preserving the full target slug", () => {
+    const longSlug = "x".repeat(120);
+    const target = buildDraftTarget({ category: "skills", slug: longSlug }, "main");
+    expect(target.slug).toBe(longSlug);
+    expect(target.branchName.length).toBeLessThanOrEqual(120);
+    expect(target.branchName).toMatch(/-[a-z0-9]{8}$/);
+    expect(target.targetPath).toBe(`content/skills/${longSlug}.mdx`);
+  });
+
+  it("renders multiline yaml scalars, truncated one-line fields, and optional metadata", () => {
+    const longDescription = `${"word ".repeat(80).trim()} trailing`;
+    const mdx = buildContributorMdx(
+      {
+        category: "skills",
+        name: "Branch Coverage Skill",
+        slug: "branch-coverage-skill",
+        description: longDescription,
+        card_description: "Short card copy",
+        safety_notes: "Line one\nLine two",
+        privacy_notes: "Local only",
+        prerequisites: "Node 22\npnpm installed",
+        retrieval_sources: "Docs\nGitHub README",
+        tested_platforms: "Claude Code\nCursor",
+        items: "Item one\nItem two",
+        brand_name: "Fixture Brand",
+        brand_domain: "fixture.example",
+        github_url: "https://github.com/example/repo",
+        website_url: "https://example.com",
+        download_url: "https://example.com/pkg.zip",
+        install_command: "npm i fixture",
+        usage_snippet: "Run locally",
+        config_snippet: "{ \"enabled\": true }",
+        full_copyable_content: "Step one\nStep two",
+        command_syntax: "/fixture run",
+        trigger: "manual",
+        script_language: "bash",
+        skill_type: "workflow",
+        skill_level: "intermediate",
+        verification_status: "reviewed",
+        verified_at: "2026-01-01",
+        pricing_model: "free",
+        disclosure: "Maintainer-owned fixture",
+        tags: "testing, coverage",
+      },
+      "not-a-valid-login!",
+    );
+
+    expect(mdx).toContain("cardDescription:");
+    expect(mdx).toContain("brandName:");
+    expect(mdx).toContain("repoUrl:");
+    expect(mdx).toContain("prerequisites:");
+    expect(mdx).toContain("retrievalSources:");
+    expect(mdx).toContain("testedPlatforms:");
+    expect(mdx).toContain("items:");
+    expect(mdx).toContain("copySnippet:");
+    expect(mdx).toContain('submittedBy: "website"');
+    expect(mdx).not.toContain("authorProfileUrl:");
+    expect(mdx).toContain("Line one");
+    expect(mdx).toContain("Step one");
+    expect(mdx).toContain("...");
+  });
+
+  it("uses contributor profile metadata when the github login is valid", () => {
+    const mdx = buildContributorMdx(
+      {
+        category: "mcp",
+        name: "Contributor MCP",
+        description: "Source-backed MCP fixture.",
+        docs_url: "https://example.com/docs",
+        safety_notes: "Review network access.",
+        privacy_notes: "No telemetry.",
+      },
+      "valid-contributor",
+    );
+
+    expect(mdx).toContain('submittedBy: "@valid-contributor"');
+    expect(mdx).toContain('authorProfileUrl: "https://github.com/valid-contributor"');
+    expect(mdx).toContain('documentationUrl: "https://example.com/docs"');
+  });
+});


### PR DESCRIPTION
## Summary
- Expand branch coverage for browse filter/trust decision helpers, entry detail command center, theme distribution, and app shell footer span classes.
- Cover site-lib env/csv builders and category map helpers, content-loader retry/not-found edges, live feed trending via growth surfaces, and submission-gate draft MDX/branch rendering.
- Touch only test files that are not part of currently open PRs, so this can merge cleanly after those land without a rebase.

## Test plan
- [x] `pnpm exec vitest run` on all modified and new test files (pass locally)
- [ ] CI `coverage` + Codecov patch/project
- [ ] CI `required-pr-gate`


Made with [Cursor](https://cursor.com)