### PR TITLE
test(web): cover search, compare, signals, and token branch edges

### DIFF
--- a/tests/ai-signals-branch-coverage.test.ts
+++ b/tests/ai-signals-branch-coverage.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MAX_REFERRALS_PER_WINDOW,
+  __aiSignalsTestHooks,
+  consumeReferralQuota,
+  getClientKey,
+  getDataset,
+  isPageLikeRequest,
+  isVerifiedCloudflareBot,
+  normalizePath,
+  pruneExpiredSignalBuckets,
+} from "../apps/web/src/lib/ai-signals-lib";
+
+beforeEach(() => {
+  __aiSignalsTestHooks.reset();
+});
+
+describe("ai-signals-lib branch edges", () => {
+  it("normalizes invalid URLs to slash and truncates long paths", () => {
+    expect(normalizePath("not a url")).toBe("/");
+    expect(normalizePath(`https://example.com/${"a".repeat(300)}`).length).toBe(
+      256,
+    );
+  });
+
+  it("rejects non-GET, API, assets, downloads, and extension paths", () => {
+    expect(
+      isPageLikeRequest(
+        new Request("https://example.com/browse", { method: "POST" }),
+      ),
+    ).toBe(false);
+    expect(isPageLikeRequest(new Request("https://example.com/api"))).toBe(
+      false,
+    );
+    expect(
+      isPageLikeRequest(new Request("https://example.com/api/votes")),
+    ).toBe(false);
+    expect(
+      isPageLikeRequest(new Request("https://example.com/assets/app.js")),
+    ).toBe(false);
+    expect(
+      isPageLikeRequest(new Request("https://example.com/downloads/pkg.zip")),
+    ).toBe(false);
+    expect(
+      isPageLikeRequest(new Request("https://example.com/favicon.ico")),
+    ).toBe(false);
+    expect(isPageLikeRequest(new Request("https://example.com/browse"))).toBe(
+      true,
+    );
+  });
+
+  it("detects verified bot management and category signals", () => {
+    const plain = new Request("https://example.com/");
+    expect(isVerifiedCloudflareBot(plain)).toBe(false);
+
+    const verified = new Request("https://example.com/") as Request & {
+      cf?: { botManagement?: { verifiedBot?: boolean } };
+    };
+    Object.defineProperty(verified, "cf", {
+      value: { botManagement: { verifiedBot: true } },
+    });
+    expect(isVerifiedCloudflareBot(verified)).toBe(true);
+
+    const categorized = new Request("https://example.com/") as Request & {
+      cf?: { verifiedBotCategory?: string };
+    };
+    Object.defineProperty(categorized, "cf", {
+      value: { verifiedBotCategory: "search_engine" },
+    });
+    expect(isVerifiedCloudflareBot(categorized)).toBe(true);
+  });
+
+  it("falls back to unknown client keys and accepts analytics datasets", () => {
+    expect(getClientKey(new Request("https://example.com/"))).toBe("unknown");
+    expect(getDataset(null)).toBeNull();
+    expect(getDataset({ AI_SIGNALS: { writeDataPoint: "nope" } })).toBeNull();
+    expect(
+      getDataset({ AI_SIGNALS: { writeDataPoint: () => undefined } }),
+    ).toBeTruthy();
+  });
+
+  it("rejects referral traffic after the window quota is exhausted", () => {
+    const request = new Request("https://example.com/browse", {
+      headers: { "cf-connecting-ip": "203.0.113.10" },
+    });
+
+    for (let i = 0; i < MAX_REFERRALS_PER_WINDOW; i += 1) {
+      expect(consumeReferralQuota(request, "chatgpt")).toBe(true);
+    }
+    expect(consumeReferralQuota(request, "chatgpt")).toBe(false);
+  });
+
+  it("prunes expired referral buckets once the window passes", () => {
+    const request = new Request("https://example.com/browse", {
+      headers: { "cf-connecting-ip": "203.0.113.11" },
+    });
+    expect(consumeReferralQuota(request, "claude")).toBe(true);
+    pruneExpiredSignalBuckets(Date.now() + 120_000);
+    expect(consumeReferralQuota(request, "claude")).toBe(true);
+  });
+});

--- a/tests/compare-decision-brief-lib.test.ts
+++ b/tests/compare-decision-brief-lib.test.ts
@@ -309,4 +309,97 @@ describe("compare decision brief lib", () => {
     const state = compareDecisionBriefState([ready]);
     expect(state.entryBriefs[0].recommendation).toContain("Best candidate");
   });
+
+  it("asks for source and safety work when two required checklist items are missing", () => {
+    const sparse = entry({
+      trust: "trusted",
+      source: "unverified",
+      sourceUrl: undefined,
+      safetyNotes: undefined,
+      privacyNotes: "present",
+      reviewed: true,
+    });
+    const state = compareDecisionBriefState([sparse]);
+    expect(state.entryBriefs[0].recommendation).toContain(
+      "Complete source, safety, and privacy checks",
+    );
+  });
+
+  it("keeps review-trust guidance when posture is mixed but not blocked", () => {
+    const review = entry({
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/review",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      reviewed: true,
+      installCommand: "npm i review",
+    });
+    const state = compareDecisionBriefState([review]);
+    expect(state.entryBriefs[0].recommendation).toMatch(
+      /compare remaining trust differences|confirm fit/i,
+    );
+  });
+
+  it("reports action-only divergence when trust signals match", () => {
+    const installable = entry({
+      slug: "installable",
+      title: "Installable",
+      trust: "review",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/installable",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      installCommand: "npm i installable",
+    });
+    const docsOnly = entry({
+      slug: "docs",
+      title: "Docs",
+      trust: "review",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/docs",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      installCommand: undefined,
+      configSnippet: undefined,
+      fullCopy: undefined,
+      copySnippet: undefined,
+    });
+    const state = compareDecisionBriefState([installable, docsOnly]);
+    expect(state.hasActionDivergence).toBe(true);
+    expect(state.summary).toMatch(/next-step actions differ|Signals diverge/i);
+  });
+
+  it("reports score parity when two briefs land on the same score", () => {
+    const a = entry({
+      slug: "a",
+      title: "A",
+      trust: "review",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/a",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      installCommand: "npm i a",
+    });
+    const b = entry({
+      slug: "b",
+      title: "B",
+      trust: "review",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/b",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      installCommand: "npm i b",
+    });
+    const state = compareDecisionBriefState([a, b]);
+    expect(
+      state.entryBriefs.some((brief) =>
+        brief.compareDeltaSummary.includes("Score parity"),
+      ) || state.entryBriefs[0].score === state.entryBriefs[1].score,
+    ).toBe(true);
+  });
 });

--- a/tests/entry-compare-benchmark-lib.test.ts
+++ b/tests/entry-compare-benchmark-lib.test.ts
@@ -210,4 +210,72 @@ describe("entry compare benchmark lib", () => {
     const row = state.rows[0];
     expect(row.summary).toContain("points");
   });
+
+  it("treats blocked trust, list-based notes, and config payloads as score signals", () => {
+    const blocked = entry({
+      slug: "blocked",
+      title: "Blocked",
+      trust: "blocked",
+      source: "unverified",
+    });
+    const listed = entry({
+      slug: "listed",
+      title: "Listed",
+      trust: "limited",
+      source: "unverified",
+      safetyNotesList: ["Runs locally"],
+      privacyNotesList: ["No telemetry"],
+      configSnippet: '{ "enabled": true }',
+    });
+    const blockedState = entryCompareBenchmarkState(blocked, "balanced", [
+      listed,
+    ]);
+    expect(blockedState.targetScore).toBeLessThan(
+      entryCompareBenchmarkState(listed, "balanced", []).targetScore,
+    );
+    expect(
+      blockedState.rows.find((row) => row.entryRef === "tools/listed")
+        ?.dimensions.length,
+    ).toBe(4);
+  });
+
+  it("marks near-tied peers as aligned and reports mixed benchmark summaries", () => {
+    const left = entry({
+      slug: "left",
+      title: "Left",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/left",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      installCommand: "npm i left",
+    });
+    const right = entry({
+      slug: "right",
+      title: "Right",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/right",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      installCommand: "npm i right",
+    });
+    const aligned = entryCompareBenchmarkState(left, "balanced", [right]);
+    expect(aligned.rows[0]?.verdict).toBe("aligned");
+    expect(aligned.benchmarkSummary).toContain("aligned");
+
+    const mixed = entryCompareBenchmarkState(target, "balanced", [
+      strong,
+      weak,
+    ]);
+    expect(mixed.benchmarkSummary).toMatch(/stronger|weaker|mixed/);
+  });
+
+  it("prompts tray membership when the compare list is empty", () => {
+    const empty = entryCompareBenchmarkState(target, "balanced", []);
+    expect(empty.summary).toContain("Add other entries");
+    expect(empty.benchmarkSummary).toBeNull();
+  });
 });

--- a/tests/search-lib-branch-coverage.test.ts
+++ b/tests/search-lib-branch-coverage.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { ENTRIES } from "@/data/entries";
+import {
+  entryMatchesTrustSignal,
+  filterSearchEntries,
+  matchesSearchFilters,
+  related,
+  relatedBySimilarity,
+  relatedGroups,
+  relatedGuides,
+  search,
+} from "@/data/search";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture Skill",
+    description: "A searchable description about memory workflows",
+    author: "Author",
+    tags: ["memory"],
+    keywords: ["rag"],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("search lib branch coverage", () => {
+  it("matches trust signals from trustSignals metadata fallbacks", () => {
+    const viaSignals = entry({
+      safetyNotes: undefined,
+      privacyNotes: undefined,
+      source: "unverified",
+      reviewed: false,
+      reviewedBy: undefined,
+      claimed: false,
+      claimStatus: undefined,
+      packageVerified: false,
+      downloadSha256: undefined,
+      trustSignals: {
+        hasSafetyNotes: true,
+        hasPrivacyNotes: true,
+        sourceStatus: "available",
+        packageVerified: true,
+        checksumPresent: true,
+      },
+    });
+
+    expect(entryMatchesTrustSignal(viaSignals, "safety-notes")).toBe(true);
+    expect(entryMatchesTrustSignal(viaSignals, "privacy-notes")).toBe(true);
+    expect(entryMatchesTrustSignal(viaSignals, "source-backed")).toBe(true);
+    expect(entryMatchesTrustSignal(viaSignals, "trusted-package")).toBe(true);
+    expect(entryMatchesTrustSignal(viaSignals, "checksums")).toBe(true);
+    expect(
+      entryMatchesTrustSignal(
+        entry({ ...viaSignals, claimStatus: "verified" }),
+        "reviewed",
+      ),
+    ).toBe(true);
+    expect(entryMatchesTrustSignal(viaSignals, "not-a-signal" as never)).toBe(
+      false,
+    );
+  });
+
+  it("filters installable, trust, source, and safety-note rows", () => {
+    const catalog = [
+      entry({
+        slug: "installable",
+        trust: "trusted",
+        source: "source-backed",
+        installCommand: "npm i fixture",
+        safetyNotes: "Careful",
+      }),
+      entry({
+        slug: "docs-only",
+        trust: "limited",
+        source: "unverified",
+        installCommand: undefined,
+        configSnippet: undefined,
+        fullCopy: undefined,
+        safetyNotes: undefined,
+      }),
+    ];
+
+    expect(
+      filterSearchEntries({ installable: true }, catalog).map(
+        (row) => row.slug,
+      ),
+    ).toEqual(["installable"]);
+    expect(
+      filterSearchEntries({ hasSafetyNotes: true }, catalog).map(
+        (row) => row.slug,
+      ),
+    ).toEqual(["installable"]);
+    expect(
+      filterSearchEntries({ trust: ["trusted"] }, catalog).map(
+        (row) => row.slug,
+      ),
+    ).toEqual(["installable"]);
+    expect(
+      filterSearchEntries({ source: ["source-backed"] }, catalog).map(
+        (row) => row.slug,
+      ),
+    ).toEqual(["installable"]);
+    expect(
+      matchesSearchFilters(catalog[1]!, {
+        categories: ["mcp"],
+      }),
+    ).toBe(false);
+    expect(
+      matchesSearchFilters(catalog[0]!, {
+        platforms: ["cursor"],
+      }),
+    ).toBe(false);
+  });
+
+  it("scores query relevance through title, slug, and sort paths", () => {
+    const catalog = [
+      entry({
+        slug: "memory-pack",
+        title: "Memory Pack",
+        tags: ["memory"],
+        keywords: ["vector"],
+        description: "Implements retrieval augmentation",
+        dateAdded: "2026-06-01",
+      }),
+      entry({
+        slug: "other",
+        title: "Other",
+        tags: ["hooks"],
+        description: "Unrelated tooling",
+        dateAdded: "2025-01-01",
+      }),
+    ];
+
+    const ranked = search({ q: "memory", sort: "popular" }, catalog);
+    expect(ranked[0]?.slug).toBe("memory-pack");
+
+    const byTitle = search({ sort: "title" }, catalog);
+    expect(byTitle.map((row) => row.title)).toEqual(["Memory Pack", "Other"]);
+
+    const byNewest = search({ sort: "newest" }, catalog);
+    expect(byNewest[0]?.slug).toBe("memory-pack");
+
+    const shortToken = search({ q: "me" }, catalog);
+    expect(shortToken.some((row) => row.slug === "memory-pack")).toBe(true);
+  });
+
+  it("ranks similarity by shared category and tags", () => {
+    const target = entry({ slug: "target", tags: ["memory", "rag"] });
+    const sameCategory = entry({
+      slug: "same-category",
+      tags: ["hooks"],
+    });
+    const sharedTags = entry({
+      category: "mcp",
+      slug: "shared-tags",
+      tags: ["memory", "rag"],
+    });
+
+    expect(
+      relatedBySimilarity(target, [target, sameCategory, sharedTags], 2).map(
+        (row) => row.slug,
+      ),
+    ).toEqual(["shared-tags", "same-category"]);
+  });
+
+  it("returns empty related groups when no typed relations exist", () => {
+    const target = entry({ slug: "target", relatedEntries: [] });
+    expect(relatedGroups(target, 2)).toEqual([]);
+    expect(Array.isArray(related(target, 2))).toBe(true);
+    expect(ENTRIES.length).toBeGreaterThan(0);
+  });
+
+  it("returns no related guides when tags are empty or never overlap", () => {
+    expect(relatedGuides(entry({ tags: [] }))).toEqual([]);
+    expect(relatedGuides(entry({ tags: ["zzz-nonexistent-tag-zzz"] }))).toEqual(
+      [],
+    );
+  });
+});

--- a/tests/validator-config-token-branch-coverage.test.ts
+++ b/tests/validator-config-token-branch-coverage.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { validateMcpConfigText } from "@/lib/mcp-config-validator";
+import {
+  buildIndexNowPayload,
+  normalizeSubmittedUrls,
+} from "../scripts/lib/indexnow.mjs";
+import {
+  claimStatusValue,
+  entryMatchesFilters,
+  hasPrivacyNotes,
+  matchesPlatform,
+  packageTrustValue,
+  sourceStatusValue,
+  type RegistrySearchFilterState,
+} from "../apps/web/src/lib/api/registry-search-filters-lib";
+import { REVIEW_SUMMARY } from "../apps/web/src/data/validators";
+import {
+  signConfirmToken,
+  verifyConfirmToken,
+} from "../apps/web/src/lib/newsletter-token-lib";
+
+describe("mcp-config-validator paste and JSON edges", () => {
+  it("requires pasted JSON and reports invalid JSON parse errors", () => {
+    const empty = validateMcpConfigText("   ");
+    expect(empty.ok).toBe(false);
+    expect(empty.errors).toEqual(["Paste a JSON MCP configuration."]);
+    expect(empty.reportText).toContain("Errors: 1");
+
+    const invalid = validateMcpConfigText("{not-json");
+    expect(invalid.ok).toBe(false);
+    expect(invalid.errors[0]).toMatch(/^Invalid JSON:/);
+  });
+
+  it("wraps bare server maps into mcpServers output", () => {
+    const result = validateMcpConfigText(
+      JSON.stringify({
+        demo: {
+          command: "npx",
+          args: ["-y", "@example/mcp"],
+        },
+      }),
+    );
+
+    expect(result.warnings).toContain(
+      "Input looked like a bare servers object; output wraps it in mcpServers.",
+    );
+    expect(result.fixedConfigText).toContain("mcpServers");
+    expect(result.fixedConfigText).toContain("demo");
+  });
+});
+
+describe("indexnow payload branch edges", () => {
+  it("requires host, https keyLocation, and a non-empty url list", () => {
+    expect(() =>
+      buildIndexNowPayload({
+        host: "",
+        key: "48486ebc7ddc47af875118345161ae70",
+        keyLocation: "https://heyclau.de/key.txt",
+        urlList: ["https://heyclau.de/skills"],
+      }),
+    ).toThrow(/host is required/i);
+
+    expect(() =>
+      buildIndexNowPayload({
+        host: "heyclau.de",
+        key: "48486ebc7ddc47af875118345161ae70",
+        keyLocation: "http://heyclau.de/key.txt",
+        urlList: ["https://heyclau.de/skills"],
+      }),
+    ).toThrow(/keyLocation must be an HTTPS URL/i);
+
+    expect(() =>
+      buildIndexNowPayload({
+        host: "heyclau.de",
+        key: "48486ebc7ddc47af875118345161ae70",
+        keyLocation: "https://heyclau.de/key.txt",
+        urlList: [],
+      }),
+    ).toThrow(/urlList cannot be empty/i);
+
+    expect(
+      normalizeSubmittedUrls(
+        ["https://heyclau.de/a", "not-a-url", "https://heyclau.de/a"],
+        "heyclau.de",
+      ),
+    ).toEqual(["https://heyclau.de/a"]);
+  });
+});
+
+describe("registry-search-filters branch edges", () => {
+  const baseFilters: RegistrySearchFilterState = {
+    query: "",
+    category: "",
+    platform: "",
+    installable: "all",
+    hasSafetyNotes: "all",
+    hasPrivacyNotes: "all",
+    downloadTrust: "all",
+    claimStatus: "all",
+    sourceStatus: "all",
+  };
+
+  const entry = {
+    category: "mcp",
+    slug: "browser-bridge",
+    title: "Browser Bridge",
+    description: "Playwright automation",
+    tags: ["browser"],
+    keywords: ["playwright"],
+    author: "example",
+    platforms: ["claude-code"],
+    dateAdded: "2026-01-01",
+    privacyNotes: "Local only",
+    claimStatus: "verified",
+    downloadTrust: "first-party",
+    downloadUrl: "https://example.com/pkg.zip",
+    sourceUrl: "https://github.com/example/browser-bridge",
+  } as never;
+
+  it("rejects platform, privacy, claim, and source mismatches", () => {
+    expect(matchesPlatform(entry, "cursor")).toBe(false);
+    expect(hasPrivacyNotes(entry)).toBe(true);
+    expect(
+      entryMatchesFilters(entry, {
+        ...baseFilters,
+        hasPrivacyNotes: "false",
+      }),
+    ).toBe(false);
+    expect(claimStatusValue(entry)).toBe("verified");
+    expect(
+      entryMatchesFilters(entry, {
+        ...baseFilters,
+        claimStatus: "pending",
+      }),
+    ).toBe(false);
+    expect(sourceStatusValue(entry)).toBe("available");
+    expect(
+      entryMatchesFilters(entry, {
+        ...baseFilters,
+        sourceStatus: "missing",
+      }),
+    ).toBe(false);
+    expect(packageTrustValue(entry)).toBe("first-party");
+    expect(
+      entryMatchesFilters(entry, {
+        ...baseFilters,
+        downloadTrust: "external",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("validators review summary helpers", () => {
+  it("exposes review totals and a zero-safe percentage helper", () => {
+    expect(REVIEW_SUMMARY.total).toBeGreaterThan(0);
+    expect(REVIEW_SUMMARY.pct(0, 0)).toBe(0);
+    expect(REVIEW_SUMMARY.pct(1, 2)).toBe(50);
+    expect(REVIEW_SUMMARY.needsAttention).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("newsletter-token verification branch edges", () => {
+  const secret = "unit-test-newsletter-signing-key";
+
+  it("rejects empty secrets, malformed tokens, bad signatures, and expiry", async () => {
+    const payload = {
+      email: "user@example.com",
+      segments: ["weekly"],
+      source: "test",
+      exp: Date.now() + 60_000,
+    };
+    const token = await signConfirmToken(secret, payload);
+
+    expect(await verifyConfirmToken("", token, Date.now())).toBeNull();
+    expect(await verifyConfirmToken(secret, "no-dot", Date.now())).toBeNull();
+    expect(await verifyConfirmToken(secret, ".sig", Date.now())).toBeNull();
+    expect(await verifyConfirmToken(secret, "body.", Date.now())).toBeNull();
+    expect(
+      await verifyConfirmToken(secret, `${token}tampered`, Date.now()),
+    ).toBeNull();
+    expect(
+      await verifyConfirmToken("other-secret", token, Date.now()),
+    ).toBeNull();
+    expect(await verifyConfirmToken(secret, token, payload.exp + 1)).toBeNull();
+  });
+
+  it("rejects tokens whose payload is missing required fields", async () => {
+    expect(
+      await verifyConfirmToken(secret, null as never, Date.now()),
+    ).toBeNull();
+    expect(await verifyConfirmToken(secret, "bad.%", Date.now())).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Cover catalog search trust-signal fallbacks, installable/source/trust filters, relevance sorting, and similarity ranking.
- Extend compare benchmark and decision-brief edges for blocked/aligned/mixed trays and checklist-driven recommendations.
- Add focused coverage for AI referral quota/path/bot helpers, MCP config paste/JSON edges, IndexNow payload validation, registry search filter mismatches, review summary helpers, and newsletter token rejection paths.
- Touch only test files outside currently open PRs so this can merge cleanly after those land.

## Test plan
- [x] `pnpm exec vitest run` on all new and updated test files
- [ ] CI `coverage` + Codecov patch/project
- [ ] CI `required-pr-gate`


Made with [Cursor](https://cursor.com)