### PR TITLE
feat(web): add jobs post and subscriptions navigation analytics

### DIFF
--- a/apps/web/src/lib/jobs-post-page-cta-events-lib.ts
+++ b/apps/web/src/lib/jobs-post-page-cta-events-lib.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure jobs post page navigation analytics helpers.
+ *
+ * Maps tier selection, waitlist submit, and jobs hub egress to privacy-light
+ * event names without embedding form fields, company details, or URLs.
+ */
+
+export const JOBS_POST_PAGE_SURFACE = "jobs-post-page";
+
+export type JobsPostPageTierId = "free" | "standard" | "featured" | "sponsored";
+
+export type JobsPostPageDestination = "jobs" | "retry";
+
+export function jobsPostPageTierSelectAnalyticsEvent(): string {
+  return "jobs_post_page_tier_select";
+}
+
+export function jobsPostPageTierSelectAnalyticsData(tierId: JobsPostPageTierId) {
+  return {
+    surface: JOBS_POST_PAGE_SURFACE,
+    tierId,
+  };
+}
+
+export function jobsPostPageSubmitAnalyticsEvent(): string {
+  return "jobs_post_page_submit_click";
+}
+
+export function jobsPostPageSubmitAnalyticsData(tierId: JobsPostPageTierId) {
+  return {
+    surface: JOBS_POST_PAGE_SURFACE,
+    tierId,
+  };
+}
+
+export function jobsPostPageEgressAnalyticsEvent(): string {
+  return "jobs_post_page_egress_click";
+}
+
+export function jobsPostPageEgressAnalyticsData(destination: JobsPostPageDestination) {
+  return {
+    surface: JOBS_POST_PAGE_SURFACE,
+    destination,
+  };
+}

--- a/apps/web/src/lib/jobs-post-page-cta-events.ts
+++ b/apps/web/src/lib/jobs-post-page-cta-events.ts
@@ -1,0 +1,14 @@
+/**
+ * Jobs post page navigation CTA event surface.
+ */
+export {
+  JOBS_POST_PAGE_SURFACE,
+  jobsPostPageEgressAnalyticsData,
+  jobsPostPageEgressAnalyticsEvent,
+  jobsPostPageSubmitAnalyticsData,
+  jobsPostPageSubmitAnalyticsEvent,
+  jobsPostPageTierSelectAnalyticsData,
+  jobsPostPageTierSelectAnalyticsEvent,
+  type JobsPostPageDestination,
+  type JobsPostPageTierId,
+} from "@/lib/jobs-post-page-cta-events-lib";

--- a/apps/web/src/lib/subscriptions-page-cta-events-lib.ts
+++ b/apps/web/src/lib/subscriptions-page-cta-events-lib.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure subscriptions page navigation analytics helpers.
+ *
+ * Maps directory egress, alert manager open, and unsubscribe confirms to
+ * privacy-light event names without embedding emails, labels, or follow IDs.
+ */
+
+export const SUBSCRIPTIONS_PAGE_SURFACE = "subscriptions-page";
+
+export type SubscriptionsPageDestination = "feeds" | "browse";
+
+export type SubscriptionsPageConfirmKind = "follow" | "segment";
+
+export function subscriptionsPageEgressAnalyticsEvent(): string {
+  return "subscriptions_page_egress_click";
+}
+
+export function subscriptionsPageEgressAnalyticsData(destination: SubscriptionsPageDestination) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    destination,
+  };
+}
+
+export function subscriptionsPageManageAlertsAnalyticsEvent(): string {
+  return "subscriptions_page_manage_alerts_click";
+}
+
+export function subscriptionsPageManageAlertsAnalyticsData(alertCount: number, savedCount: number) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    alertCount,
+    savedCount,
+  };
+}
+
+export function subscriptionsPageConfirmAnalyticsEvent(): string {
+  return "subscriptions_page_confirm_click";
+}
+
+export function subscriptionsPageConfirmAnalyticsData(kind: SubscriptionsPageConfirmKind) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    kind,
+  };
+}

--- a/apps/web/src/lib/subscriptions-page-cta-events.ts
+++ b/apps/web/src/lib/subscriptions-page-cta-events.ts
@@ -1,0 +1,14 @@
+/**
+ * Subscriptions page navigation CTA event surface.
+ */
+export {
+  SUBSCRIPTIONS_PAGE_SURFACE,
+  subscriptionsPageConfirmAnalyticsData,
+  subscriptionsPageConfirmAnalyticsEvent,
+  subscriptionsPageEgressAnalyticsData,
+  subscriptionsPageEgressAnalyticsEvent,
+  subscriptionsPageManageAlertsAnalyticsData,
+  subscriptionsPageManageAlertsAnalyticsEvent,
+  type SubscriptionsPageConfirmKind,
+  type SubscriptionsPageDestination,
+} from "@/lib/subscriptions-page-cta-events-lib";

--- a/apps/web/src/routes/jobs.post.tsx
+++ b/apps/web/src/routes/jobs.post.tsx
@@ -5,7 +5,16 @@ import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { CommercialDisclosure } from "@/components/commercial-disclosure";
-import type { JobTier } from "@/types/registry";
+import { trackEvent } from "@/lib/analytics";
+import {
+  jobsPostPageEgressAnalyticsData,
+  jobsPostPageEgressAnalyticsEvent,
+  jobsPostPageSubmitAnalyticsData,
+  jobsPostPageSubmitAnalyticsEvent,
+  jobsPostPageTierSelectAnalyticsData,
+  jobsPostPageTierSelectAnalyticsEvent,
+  type JobsPostPageTierId,
+} from "@/lib/jobs-post-page-cta-events";
 
 export const Route = createFileRoute("/jobs/post")({
   head: () => ({
@@ -23,7 +32,7 @@ export const Route = createFileRoute("/jobs/post")({
   component: PostJobPage,
 });
 
-const TIERS: { id: JobTier; label: string; price: string; bullets: string[] }[] = [
+const TIERS: { id: JobsPostPageTierId; label: string; price: string; bullets: string[] }[] = [
   {
     id: "free",
     label: "Community",
@@ -51,7 +60,7 @@ const TIERS: { id: JobTier; label: string; price: string; bullets: string[] }[] 
 ];
 
 function PostJobPage() {
-  const [tier, setTier] = useState<JobTier>("free");
+  const [tier, setTier] = useState<JobsPostPageTierId>("free");
   const [done, setDone] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
@@ -59,6 +68,7 @@ function PostJobPage() {
   async function submitJob(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (submitting) return;
+    trackEvent(jobsPostPageSubmitAnalyticsEvent(), jobsPostPageSubmitAnalyticsData(tier));
     setSubmitting(true);
     setError("");
     const form = new FormData(e.currentTarget);
@@ -113,6 +123,9 @@ function PostJobPage() {
         <Link
           to="/jobs"
           className="mt-6 inline-flex h-10 items-center rounded-md border border-border bg-surface px-4 text-sm text-ink hover:bg-surface-2"
+          onClick={() =>
+            trackEvent(jobsPostPageEgressAnalyticsEvent(), jobsPostPageEgressAnalyticsData("jobs"))
+          }
         >
           Back to jobs
         </Link>
@@ -134,7 +147,13 @@ function PostJobPage() {
           <button
             key={t.id}
             type="button"
-            onClick={() => setTier(t.id)}
+            onClick={() => {
+              setTier(t.id);
+              trackEvent(
+                jobsPostPageTierSelectAnalyticsEvent(),
+                jobsPostPageTierSelectAnalyticsData(t.id),
+              );
+            }}
             className={cn(
               "flex flex-col gap-2 rounded-xl border p-4 text-left transition-colors duration-200 ease-out",
               tier === t.id

--- a/apps/web/src/routes/subscriptions.tsx
+++ b/apps/web/src/routes/subscriptions.tsx
@@ -6,6 +6,15 @@ import { useRecents } from "@/lib/recents";
 import { SavedSearchManager } from "@/components/saved-search-manager";
 import { EmptyState } from "@/components/empty-state";
 import { unsubscribeFromNewsletter } from "@/lib/api/newsletter";
+import { trackEvent } from "@/lib/analytics";
+import {
+  subscriptionsPageConfirmAnalyticsData,
+  subscriptionsPageConfirmAnalyticsEvent,
+  subscriptionsPageEgressAnalyticsData,
+  subscriptionsPageEgressAnalyticsEvent,
+  subscriptionsPageManageAlertsAnalyticsData,
+  subscriptionsPageManageAlertsAnalyticsEvent,
+} from "@/lib/subscriptions-page-cta-events";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -150,12 +159,24 @@ function SubscriptionsPage() {
                     <Link
                       to="/feeds"
                       className="inline-flex h-8 items-center gap-1.5 rounded-md bg-ink px-3 text-xs font-medium text-background hover:bg-ink/90"
+                      onClick={() =>
+                        trackEvent(
+                          subscriptionsPageEgressAnalyticsEvent(),
+                          subscriptionsPageEgressAnalyticsData("feeds"),
+                        )
+                      }
                     >
                       <Rss className="h-3.5 w-3.5" /> Browse feeds
                     </Link>
                     <Link
                       to="/browse"
                       className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-ink hover:bg-surface-2"
+                      onClick={() =>
+                        trackEvent(
+                          subscriptionsPageEgressAnalyticsEvent(),
+                          subscriptionsPageEgressAnalyticsData("browse"),
+                        )
+                      }
                     >
                       <Compass className="h-3.5 w-3.5" /> Browse directory
                     </Link>
@@ -277,7 +298,13 @@ function SubscriptionsPage() {
           <h2 className="font-display text-base font-semibold text-ink">Saved-search alerts</h2>
           <button
             type="button"
-            onClick={() => setManagerOpen(true)}
+            onClick={() => {
+              trackEvent(
+                subscriptionsPageManageAlertsAnalyticsEvent(),
+                subscriptionsPageManageAlertsAnalyticsData(alertCount, recents.saved.length),
+              );
+              setManagerOpen(true);
+            }}
             className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface px-2.5 text-xs text-ink hover:bg-surface-2"
           >
             <Pencil className="h-3.5 w-3.5" /> Manage
@@ -327,6 +354,10 @@ function SubscriptionsPage() {
             <AlertDialogAction
               onClick={() => {
                 if (!confirm) return;
+                trackEvent(
+                  subscriptionsPageConfirmAnalyticsEvent(),
+                  subscriptionsPageConfirmAnalyticsData(confirm.kind),
+                );
                 if (confirm.kind === "follow") void doRemoveFollow(confirm.id);
                 else void doRemoveSegment(confirm.id);
                 setConfirm(null);

--- a/tests/jobs-post-page-cta-events-lib.test.ts
+++ b/tests/jobs-post-page-cta-events-lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  JOBS_POST_PAGE_SURFACE,
+  jobsPostPageEgressAnalyticsData,
+  jobsPostPageEgressAnalyticsEvent,
+  jobsPostPageSubmitAnalyticsData,
+  jobsPostPageSubmitAnalyticsEvent,
+  jobsPostPageTierSelectAnalyticsData,
+  jobsPostPageTierSelectAnalyticsEvent,
+} from "@/lib/jobs-post-page-cta-events-lib";
+
+describe("jobs post page cta events lib", () => {
+  it("builds jobs post page navigation analytics", () => {
+    expect(jobsPostPageTierSelectAnalyticsEvent()).toBe(
+      "jobs_post_page_tier_select",
+    );
+    expect(jobsPostPageTierSelectAnalyticsData("featured")).toEqual({
+      surface: JOBS_POST_PAGE_SURFACE,
+      tierId: "featured",
+    });
+    expect(jobsPostPageSubmitAnalyticsEvent()).toBe(
+      "jobs_post_page_submit_click",
+    );
+    expect(jobsPostPageSubmitAnalyticsData("sponsored")).toEqual({
+      surface: JOBS_POST_PAGE_SURFACE,
+      tierId: "sponsored",
+    });
+    expect(jobsPostPageEgressAnalyticsEvent()).toBe(
+      "jobs_post_page_egress_click",
+    );
+    expect(jobsPostPageEgressAnalyticsData("jobs")).toEqual({
+      surface: JOBS_POST_PAGE_SURFACE,
+      destination: "jobs",
+    });
+    expect(jobsPostPageEgressAnalyticsData("retry")).toEqual({
+      surface: JOBS_POST_PAGE_SURFACE,
+      destination: "retry",
+    });
+  });
+});

--- a/tests/subscriptions-page-cta-events-lib.test.ts
+++ b/tests/subscriptions-page-cta-events-lib.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBSCRIPTIONS_PAGE_SURFACE,
+  subscriptionsPageConfirmAnalyticsData,
+  subscriptionsPageConfirmAnalyticsEvent,
+  subscriptionsPageEgressAnalyticsData,
+  subscriptionsPageEgressAnalyticsEvent,
+  subscriptionsPageManageAlertsAnalyticsData,
+  subscriptionsPageManageAlertsAnalyticsEvent,
+} from "@/lib/subscriptions-page-cta-events-lib";
+
+describe("subscriptions page cta events lib", () => {
+  it("builds subscriptions page navigation analytics", () => {
+    expect(subscriptionsPageEgressAnalyticsEvent()).toBe(
+      "subscriptions_page_egress_click",
+    );
+    expect(subscriptionsPageEgressAnalyticsData("feeds")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      destination: "feeds",
+    });
+    expect(subscriptionsPageEgressAnalyticsData("browse")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      destination: "browse",
+    });
+    expect(subscriptionsPageManageAlertsAnalyticsEvent()).toBe(
+      "subscriptions_page_manage_alerts_click",
+    );
+    expect(subscriptionsPageManageAlertsAnalyticsData(2, 5)).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      alertCount: 2,
+      savedCount: 5,
+    });
+    expect(subscriptionsPageConfirmAnalyticsEvent()).toBe(
+      "subscriptions_page_confirm_click",
+    );
+    expect(subscriptionsPageConfirmAnalyticsData("follow")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      kind: "follow",
+    });
+    expect(subscriptionsPageConfirmAnalyticsData("segment")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      kind: "segment",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add jobs-post CTA event lib + wrapper for tier select, submit, and jobs egress
- Add subscriptions CTA event lib + wrapper for feeds/browse egress, manage alerts, and unfollow/unsubscribe confirm
- Wire both surfaces on `/jobs/post` and `/subscriptions` without embedding form fields or emails

Refs #550

## Test plan
- [x] prettier + vitest on new libs
- [x] type-check locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)


Made with [Cursor](https://cursor.com)