### PR TITLE
feat(web): add subscriptions and agent-native navigation analytics

### DIFF
--- a/apps/web/src/components/agent-native-strip.tsx
+++ b/apps/web/src/components/agent-native-strip.tsx
@@ -1,8 +1,19 @@
 import { Link } from "@tanstack/react-router";
 import { Terminal, Command, FileCode } from "lucide-react";
 import { CopyButton } from "./copy-button";
+import { trackEvent } from "@/lib/analytics";
+import {
+  agentNativeStripCopyAnalyticsData,
+  agentNativeStripCopyAnalyticsEvent,
+  agentNativeStripEgressAnalyticsData,
+  agentNativeStripEgressAnalyticsEvent,
+  type AgentNativeStripCardId,
+  type AgentNativeStripDestination,
+} from "@/lib/agent-native-strip-cta-events";
 
 type Card = {
+  id: AgentNativeStripCardId;
+  destination: AgentNativeStripDestination;
   Icon: typeof Terminal;
   eyebrow: string;
   title: string;
@@ -14,6 +25,8 @@ type Card = {
 
 const CARDS: Card[] = [
   {
+    id: "mcp",
+    destination: "integrations-mcp",
     Icon: Terminal,
     eyebrow: "MCP endpoint",
     title: "Use HeyClaude inside Claude Code",
@@ -23,6 +36,8 @@ const CARDS: Card[] = [
     ctaLabel: "MCP setup",
   },
   {
+    id: "raycast",
+    destination: "integrations-raycast",
     Icon: Command,
     eyebrow: "Raycast extension",
     title: "Search from anywhere",
@@ -32,6 +47,8 @@ const CARDS: Card[] = [
     ctaLabel: "Get the extension",
   },
   {
+    id: "llms",
+    destination: "api-docs",
     Icon: FileCode,
     eyebrow: "llms.txt & JSON feeds",
     title: "Pipe the registry into your agent",
@@ -52,14 +69,23 @@ export function AgentNativeStrip() {
             One registry, every surface
           </h2>
         </div>
-        <Link to="/ecosystem" className="text-sm text-ink-muted hover:text-ink">
+        <Link
+          to="/ecosystem"
+          className="text-sm text-ink-muted hover:text-ink"
+          onClick={() =>
+            trackEvent(
+              agentNativeStripEgressAnalyticsEvent(),
+              agentNativeStripEgressAnalyticsData("ecosystem"),
+            )
+          }
+        >
           All integrations →
         </Link>
       </div>
       <div className="mt-6 grid gap-4 lg:grid-cols-3">
         {CARDS.map((c) => (
           <div
-            key={c.eyebrow}
+            key={c.id}
             className="group flex flex-col gap-4 rounded-xl border border-border bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2"
           >
             <div className="flex items-center justify-between">
@@ -74,11 +100,22 @@ export function AgentNativeStrip() {
             </div>
             <div className="flex items-center gap-2 rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-xs text-ink">
               <span className="flex-1 truncate">{c.snippet}</span>
-              <CopyButton value={c.snippet} label="Copy" />
+              <CopyButton
+                value={c.snippet}
+                label="Copy"
+                event={agentNativeStripCopyAnalyticsEvent()}
+                eventData={agentNativeStripCopyAnalyticsData(c.id)}
+              />
             </div>
             <Link
               to={c.to}
               className="story-link mt-auto inline-flex items-center gap-1 text-sm font-medium text-ink hover:text-ink-hover"
+              onClick={() =>
+                trackEvent(
+                  agentNativeStripEgressAnalyticsEvent(),
+                  agentNativeStripEgressAnalyticsData(c.destination),
+                )
+              }
             >
               {c.ctaLabel} <span aria-hidden>→</span>
             </Link>

--- a/apps/web/src/lib/agent-native-strip-cta-events-lib.ts
+++ b/apps/web/src/lib/agent-native-strip-cta-events-lib.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure agent-native strip navigation analytics helpers.
+ *
+ * Maps integration egress and snippet copy actions to privacy-light event names
+ * without embedding full command strings or destination URLs.
+ */
+
+export const AGENT_NATIVE_STRIP_SURFACE = "agent-native-strip";
+
+export type AgentNativeStripCardId = "mcp" | "raycast" | "llms";
+
+export type AgentNativeStripDestination =
+  | "integrations-mcp"
+  | "integrations-raycast"
+  | "api-docs"
+  | "ecosystem";
+
+export function agentNativeStripEgressAnalyticsEvent(): string {
+  return "agent_native_strip_egress_click";
+}
+
+export function agentNativeStripEgressAnalyticsData(destination: AgentNativeStripDestination) {
+  return {
+    surface: AGENT_NATIVE_STRIP_SURFACE,
+    destination,
+  };
+}
+
+export function agentNativeStripCopyAnalyticsEvent(): string {
+  return "agent_native_strip_copy_click";
+}
+
+export function agentNativeStripCopyAnalyticsData(cardId: AgentNativeStripCardId) {
+  return {
+    surface: AGENT_NATIVE_STRIP_SURFACE,
+    cardId,
+  };
+}

--- a/apps/web/src/lib/agent-native-strip-cta-events.ts
+++ b/apps/web/src/lib/agent-native-strip-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Agent-native strip navigation CTA event surface.
+ */
+export {
+  AGENT_NATIVE_STRIP_SURFACE,
+  agentNativeStripCopyAnalyticsData,
+  agentNativeStripCopyAnalyticsEvent,
+  agentNativeStripEgressAnalyticsData,
+  agentNativeStripEgressAnalyticsEvent,
+  type AgentNativeStripCardId,
+  type AgentNativeStripDestination,
+} from "@/lib/agent-native-strip-cta-events-lib";

--- a/apps/web/src/lib/subscriptions-page-cta-events-lib.ts
+++ b/apps/web/src/lib/subscriptions-page-cta-events-lib.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure subscriptions page navigation analytics helpers.
+ *
+ * Maps directory egress, alert manager open, and unsubscribe confirms to
+ * privacy-light event names without embedding emails, labels, or follow IDs.
+ */
+
+export const SUBSCRIPTIONS_PAGE_SURFACE = "subscriptions-page";
+
+export type SubscriptionsPageDestination = "feeds" | "browse";
+
+export type SubscriptionsPageConfirmKind = "follow" | "segment";
+
+export function subscriptionsPageEgressAnalyticsEvent(): string {
+  return "subscriptions_page_egress_click";
+}
+
+export function subscriptionsPageEgressAnalyticsData(destination: SubscriptionsPageDestination) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    destination,
+  };
+}
+
+export function subscriptionsPageManageAlertsAnalyticsEvent(): string {
+  return "subscriptions_page_manage_alerts_click";
+}
+
+export function subscriptionsPageManageAlertsAnalyticsData(alertCount: number, savedCount: number) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    alertCount,
+    savedCount,
+  };
+}
+
+export function subscriptionsPageConfirmAnalyticsEvent(): string {
+  return "subscriptions_page_confirm_click";
+}
+
+export function subscriptionsPageConfirmAnalyticsData(kind: SubscriptionsPageConfirmKind) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    kind,
+  };
+}

--- a/apps/web/src/lib/subscriptions-page-cta-events.ts
+++ b/apps/web/src/lib/subscriptions-page-cta-events.ts
@@ -1,0 +1,14 @@
+/**
+ * Subscriptions page navigation CTA event surface.
+ */
+export {
+  SUBSCRIPTIONS_PAGE_SURFACE,
+  subscriptionsPageConfirmAnalyticsData,
+  subscriptionsPageConfirmAnalyticsEvent,
+  subscriptionsPageEgressAnalyticsData,
+  subscriptionsPageEgressAnalyticsEvent,
+  subscriptionsPageManageAlertsAnalyticsData,
+  subscriptionsPageManageAlertsAnalyticsEvent,
+  type SubscriptionsPageConfirmKind,
+  type SubscriptionsPageDestination,
+} from "@/lib/subscriptions-page-cta-events-lib";

--- a/apps/web/src/routes/subscriptions.tsx
+++ b/apps/web/src/routes/subscriptions.tsx
@@ -6,6 +6,15 @@ import { useRecents } from "@/lib/recents";
 import { SavedSearchManager } from "@/components/saved-search-manager";
 import { EmptyState } from "@/components/empty-state";
 import { unsubscribeFromNewsletter } from "@/lib/api/newsletter";
+import { trackEvent } from "@/lib/analytics";
+import {
+  subscriptionsPageConfirmAnalyticsData,
+  subscriptionsPageConfirmAnalyticsEvent,
+  subscriptionsPageEgressAnalyticsData,
+  subscriptionsPageEgressAnalyticsEvent,
+  subscriptionsPageManageAlertsAnalyticsData,
+  subscriptionsPageManageAlertsAnalyticsEvent,
+} from "@/lib/subscriptions-page-cta-events";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -150,12 +159,24 @@ function SubscriptionsPage() {
                     <Link
                       to="/feeds"
                       className="inline-flex h-8 items-center gap-1.5 rounded-md bg-ink px-3 text-xs font-medium text-background hover:bg-ink/90"
+                      onClick={() =>
+                        trackEvent(
+                          subscriptionsPageEgressAnalyticsEvent(),
+                          subscriptionsPageEgressAnalyticsData("feeds"),
+                        )
+                      }
                     >
                       <Rss className="h-3.5 w-3.5" /> Browse feeds
                     </Link>
                     <Link
                       to="/browse"
                       className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-ink hover:bg-surface-2"
+                      onClick={() =>
+                        trackEvent(
+                          subscriptionsPageEgressAnalyticsEvent(),
+                          subscriptionsPageEgressAnalyticsData("browse"),
+                        )
+                      }
                     >
                       <Compass className="h-3.5 w-3.5" /> Browse directory
                     </Link>
@@ -277,7 +298,13 @@ function SubscriptionsPage() {
           <h2 className="font-display text-base font-semibold text-ink">Saved-search alerts</h2>
           <button
             type="button"
-            onClick={() => setManagerOpen(true)}
+            onClick={() => {
+              trackEvent(
+                subscriptionsPageManageAlertsAnalyticsEvent(),
+                subscriptionsPageManageAlertsAnalyticsData(alertCount, recents.saved.length),
+              );
+              setManagerOpen(true);
+            }}
             className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface px-2.5 text-xs text-ink hover:bg-surface-2"
           >
             <Pencil className="h-3.5 w-3.5" /> Manage
@@ -327,6 +354,10 @@ function SubscriptionsPage() {
             <AlertDialogAction
               onClick={() => {
                 if (!confirm) return;
+                trackEvent(
+                  subscriptionsPageConfirmAnalyticsEvent(),
+                  subscriptionsPageConfirmAnalyticsData(confirm.kind),
+                );
                 if (confirm.kind === "follow") void doRemoveFollow(confirm.id);
                 else void doRemoveSegment(confirm.id);
                 setConfirm(null);

--- a/tests/agent-native-strip-cta-events-lib.test.ts
+++ b/tests/agent-native-strip-cta-events-lib.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_NATIVE_STRIP_SURFACE,
+  agentNativeStripCopyAnalyticsData,
+  agentNativeStripCopyAnalyticsEvent,
+  agentNativeStripEgressAnalyticsData,
+  agentNativeStripEgressAnalyticsEvent,
+} from "@/lib/agent-native-strip-cta-events-lib";
+
+describe("agent native strip cta events lib", () => {
+  it("builds agent-native strip navigation analytics", () => {
+    expect(agentNativeStripEgressAnalyticsEvent()).toBe(
+      "agent_native_strip_egress_click",
+    );
+    expect(agentNativeStripEgressAnalyticsData("ecosystem")).toEqual({
+      surface: AGENT_NATIVE_STRIP_SURFACE,
+      destination: "ecosystem",
+    });
+    expect(agentNativeStripEgressAnalyticsData("integrations-mcp")).toEqual({
+      surface: AGENT_NATIVE_STRIP_SURFACE,
+      destination: "integrations-mcp",
+    });
+    expect(agentNativeStripEgressAnalyticsData("integrations-raycast")).toEqual(
+      {
+        surface: AGENT_NATIVE_STRIP_SURFACE,
+        destination: "integrations-raycast",
+      },
+    );
+    expect(agentNativeStripEgressAnalyticsData("api-docs")).toEqual({
+      surface: AGENT_NATIVE_STRIP_SURFACE,
+      destination: "api-docs",
+    });
+    expect(agentNativeStripCopyAnalyticsEvent()).toBe(
+      "agent_native_strip_copy_click",
+    );
+    expect(agentNativeStripCopyAnalyticsData("mcp")).toEqual({
+      surface: AGENT_NATIVE_STRIP_SURFACE,
+      cardId: "mcp",
+    });
+    expect(agentNativeStripCopyAnalyticsData("raycast")).toEqual({
+      surface: AGENT_NATIVE_STRIP_SURFACE,
+      cardId: "raycast",
+    });
+    expect(agentNativeStripCopyAnalyticsData("llms")).toEqual({
+      surface: AGENT_NATIVE_STRIP_SURFACE,
+      cardId: "llms",
+    });
+  });
+});

--- a/tests/subscriptions-page-cta-events-lib.test.ts
+++ b/tests/subscriptions-page-cta-events-lib.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBSCRIPTIONS_PAGE_SURFACE,
+  subscriptionsPageConfirmAnalyticsData,
+  subscriptionsPageConfirmAnalyticsEvent,
+  subscriptionsPageEgressAnalyticsData,
+  subscriptionsPageEgressAnalyticsEvent,
+  subscriptionsPageManageAlertsAnalyticsData,
+  subscriptionsPageManageAlertsAnalyticsEvent,
+} from "@/lib/subscriptions-page-cta-events-lib";
+
+describe("subscriptions page cta events lib", () => {
+  it("builds subscriptions page navigation analytics", () => {
+    expect(subscriptionsPageEgressAnalyticsEvent()).toBe(
+      "subscriptions_page_egress_click",
+    );
+    expect(subscriptionsPageEgressAnalyticsData("feeds")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      destination: "feeds",
+    });
+    expect(subscriptionsPageEgressAnalyticsData("browse")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      destination: "browse",
+    });
+    expect(subscriptionsPageManageAlertsAnalyticsEvent()).toBe(
+      "subscriptions_page_manage_alerts_click",
+    );
+    expect(subscriptionsPageManageAlertsAnalyticsData(2, 5)).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      alertCount: 2,
+      savedCount: 5,
+    });
+    expect(subscriptionsPageConfirmAnalyticsEvent()).toBe(
+      "subscriptions_page_confirm_click",
+    );
+    expect(subscriptionsPageConfirmAnalyticsData("follow")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      kind: "follow",
+    });
+    expect(subscriptionsPageConfirmAnalyticsData("segment")).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      kind: "segment",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add subscriptions CTA event lib + wrapper for feeds/browse egress, manage alerts, and unfollow/unsubscribe confirm
- Add agent-native strip CTA event lib + wrapper for MCP/Raycast/API docs/ecosystem egress and snippet copy
- Wire both surfaces without embedding emails, follow IDs, or full command strings

Refs #550

## Test plan
- [x] prettier + vitest on new libs
- [x] verified no file overlap with currently open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)


Made with [Cursor](https://cursor.com)