### PR TITLE
feat(web): add sponsors, trust drilldown, and hero status analytics

### DIFF
--- a/apps/web/src/components/hero-status-row.tsx
+++ b/apps/web/src/components/hero-status-row.tsx
@@ -1,5 +1,10 @@
 import { Link } from "@tanstack/react-router";
 import { LiveVersionBadge } from "./live-version-badge";
+import { trackEvent } from "@/lib/analytics";
+import {
+  heroStatusRowEgressAnalyticsData,
+  heroStatusRowEgressAnalyticsEvent,
+} from "@/lib/hero-status-row-cta-events";
 
 /**
  * Hero status row: live-ish signals stitched together as a single line.
@@ -21,6 +26,9 @@ export function HeroStatusRow({
   indexedAt: string;
 }) {
   const indexedLabel = indexedAt ? indexedAt.slice(0, 16).replace("T", " ") : "latest build";
+  const egressData = (destination: "mcp-server" | "brief") =>
+    heroStatusRowEgressAnalyticsData(destination, resourceCount, reviewedCount, briefNumber);
+
   return (
     <div className="flex flex-wrap items-center gap-2 text-xs">
       <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-2.5 py-1 font-mono text-ink-muted">
@@ -34,16 +42,14 @@ export function HeroStatusRow({
         to="/integrations/$slug"
         params={{ slug: "mcp-server" }}
         className="hidden sm:inline-flex"
+        onClick={() => trackEvent(heroStatusRowEgressAnalyticsEvent(), egressData("mcp-server"))}
       >
-        <LiveVersionBadge
-          pkg="@heyclaude/mcp"
-          fallbackVersion="0.3.1"
-          showDownloads={false}
-        />
+        <LiveVersionBadge pkg="@heyclaude/mcp" fallbackVersion="0.3.1" showDownloads={false} />
       </Link>
       <Link
         to="/brief"
         className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-2.5 py-1 text-ink-muted hover:text-ink"
+        onClick={() => trackEvent(heroStatusRowEgressAnalyticsEvent(), egressData("brief"))}
       >
         <span className="font-mono text-ink">Brief #{briefNumber}</span>
         <span className="text-ink-subtle">·</span>

--- a/apps/web/src/components/sponsors-section.tsx
+++ b/apps/web/src/components/sponsors-section.tsx
@@ -18,6 +18,20 @@ import { Label } from "@/components/ui/label";
 import { IntegrationMark } from "@/components/integration-marks";
 import { PARTNER_ROLE_LABEL, PARTNERS, SPONSORS, type Partner } from "@/data/sponsors";
 import { sponsorKindLabel } from "@/lib/sponsor-kind-lib";
+import { trackEvent } from "@/lib/analytics";
+import {
+  sponsorsSectionCreditAnalyticsData,
+  sponsorsSectionCreditAnalyticsEvent,
+  sponsorsSectionEgressAnalyticsData,
+  sponsorsSectionEgressAnalyticsEvent,
+  sponsorsSectionInquiryOpenAnalyticsData,
+  sponsorsSectionInquiryOpenAnalyticsEvent,
+  sponsorsSectionPartnerAnalyticsData,
+  sponsorsSectionPartnerAnalyticsEvent,
+  sponsorsSectionSubmitAnalyticsData,
+  sponsorsSectionSubmitAnalyticsEvent,
+  type SponsorsSectionInquirySource,
+} from "@/lib/sponsors-section-cta-events";
 import { cn } from "@/lib/utils";
 
 export function SponsorsSection() {
@@ -35,18 +49,33 @@ export function SponsorsSection() {
               Credits + infrastructure
             </h3>
           </div>
-          <Link to="/legal" className="text-xs font-medium text-ink-muted hover:text-ink">
+          <Link
+            to="/legal"
+            className="text-xs font-medium text-ink-muted hover:text-ink"
+            onClick={() =>
+              trackEvent(
+                sponsorsSectionEgressAnalyticsEvent(),
+                sponsorsSectionEgressAnalyticsData("legal"),
+              )
+            }
+          >
             Sponsorship policy →
           </Link>
         </div>
         <ul className="mt-4 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3 lg:grid-cols-6">
-          {SPONSORS.map((s) => (
+          {SPONSORS.map((s, i) => (
             <li key={s.slug}>
               <a
                 href={s.url}
                 target="_blank"
                 rel="sponsored noopener noreferrer"
                 title={s.note}
+                onClick={() =>
+                  trackEvent(
+                    sponsorsSectionCreditAnalyticsEvent(),
+                    sponsorsSectionCreditAnalyticsData(s.slug, s.kind, i, SPONSORS.length),
+                  )
+                }
                 className="group flex h-full flex-col items-center justify-center gap-1.5 bg-surface px-3 py-5 text-center text-ink-muted transition-colors duration-200 ease-out hover:bg-surface-2 hover:text-ink"
               >
                 {s.mark ? (
@@ -80,6 +109,7 @@ export function SponsorsSection() {
             </h3>
           </div>
           <PartnerDrawer
+            inquirySource="header"
             trigger={
               <Button variant="outline" size="sm" className="gap-1.5">
                 <Mail className="h-3.5 w-3.5" /> Become a partner
@@ -89,8 +119,8 @@ export function SponsorsSection() {
         </div>
 
         <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {filled.map((p) => (
-            <PartnerCard key={p.slug} partner={p} />
+          {filled.map((p, i) => (
+            <PartnerCard key={p.slug} partner={p} rowIndex={i} partnerCount={filled.length} />
           ))}
           {open.map((p) => (
             <OpenSlotCard key={p.slug} partner={p} />
@@ -110,7 +140,16 @@ export function SponsorsSection() {
               <li>Every paid placement carries a visible "Sponsor" label.</li>
               <li>
                 Paid featured listings and Brief sponsorships are handled separately on{" "}
-                <Link to="/advertise" className="text-ink underline-offset-2 hover:underline">
+                <Link
+                  to="/advertise"
+                  className="text-ink underline-offset-2 hover:underline"
+                  onClick={() =>
+                    trackEvent(
+                      sponsorsSectionEgressAnalyticsEvent(),
+                      sponsorsSectionEgressAnalyticsData("advertise"),
+                    )
+                  }
+                >
                   /advertise
                 </Link>
                 .
@@ -123,12 +162,26 @@ export function SponsorsSection() {
   );
 }
 
-function PartnerCard({ partner }: { partner: Partner }) {
+function PartnerCard({
+  partner,
+  rowIndex,
+  partnerCount,
+}: {
+  partner: Partner;
+  rowIndex: number;
+  partnerCount: number;
+}) {
   return (
     <a
       href={partner.url}
       target="_blank"
       rel="sponsored noopener noreferrer"
+      onClick={() =>
+        trackEvent(
+          sponsorsSectionPartnerAnalyticsEvent(),
+          sponsorsSectionPartnerAnalyticsData(partner.slug, partner.role, rowIndex, partnerCount),
+        )
+      }
       className="group flex flex-col gap-3 rounded-xl border border-border bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2"
     >
       <div className="flex items-center justify-between gap-2">
@@ -163,7 +216,9 @@ function PartnerCard({ partner }: { partner: Partner }) {
 function OpenSlotCard({ partner }: { partner: Partner }) {
   return (
     <PartnerDrawer
+      inquirySource="open-slot"
       defaultRole={PARTNER_ROLE_LABEL[partner.role]}
+      role={partner.role}
       trigger={
         <button
           type="button"
@@ -195,12 +250,27 @@ function OpenSlotCard({ partner }: { partner: Partner }) {
 function PartnerDrawer({
   trigger,
   defaultRole,
+  inquirySource,
+  role = null,
 }: {
-  trigger: React.ReactNode;
+  trigger: React.ReactElement;
   defaultRole?: string;
+  inquirySource: SponsorsSectionInquirySource;
+  role?: string | null;
 }) {
   const [submitting, setSubmitting] = React.useState(false);
   const formRef = React.useRef<HTMLFormElement>(null);
+
+  const trackedTrigger = React.cloneElement(trigger, {
+    onClick: (e: React.MouseEvent) => {
+      trackEvent(
+        sponsorsSectionInquiryOpenAnalyticsEvent(),
+        sponsorsSectionInquiryOpenAnalyticsData(inquirySource, role),
+      );
+      const prior = (trigger.props as { onClick?: (ev: React.MouseEvent) => void }).onClick;
+      prior?.(e);
+    },
+  });
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -209,9 +279,14 @@ function PartnerDrawer({
     const company = String(data.get("company") ?? "").trim();
     const website = String(data.get("website") ?? "").trim();
     const email = String(data.get("email") ?? "").trim();
-    const role = String(data.get("role") ?? "").trim();
+    const roleValue = String(data.get("role") ?? "").trim();
     const offer = String(data.get("offer") ?? "").trim();
     const notes = String(data.get("notes") ?? "").trim();
+
+    trackEvent(
+      sponsorsSectionSubmitAnalyticsEvent(),
+      sponsorsSectionSubmitAnalyticsData(Boolean(roleValue)),
+    );
 
     try {
       const response = await fetch("/api/listing-leads", {
@@ -223,9 +298,9 @@ function PartnerDrawer({
           contactName: company,
           contactEmail: email,
           companyName: company,
-          listingTitle: offer || role || "Ecosystem partnership",
+          listingTitle: offer || roleValue || "Ecosystem partnership",
           websiteUrl: website,
-          message: [role ? `Role: ${role}` : "", notes].filter(Boolean).join("\n\n"),
+          message: [roleValue ? `Role: ${roleValue}` : "", notes].filter(Boolean).join("\n\n"),
         }),
       });
       if (!response.ok) throw new Error(`Lead intake returned ${response.status}`);
@@ -245,7 +320,7 @@ function PartnerDrawer({
 
   return (
     <Drawer>
-      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+      <DrawerTrigger asChild>{trackedTrigger}</DrawerTrigger>
       <DrawerContent>
         <div className="mx-auto w-full max-w-xl">
           <DrawerHeader>

--- a/apps/web/src/components/sponsors-section.tsx
+++ b/apps/web/src/components/sponsors-section.tsx
@@ -261,16 +261,13 @@ function PartnerDrawer({
   const [submitting, setSubmitting] = React.useState(false);
   const formRef = React.useRef<HTMLFormElement>(null);
 
-  const trackedTrigger = React.cloneElement(trigger, {
-    onClick: (e: React.MouseEvent) => {
-      trackEvent(
-        sponsorsSectionInquiryOpenAnalyticsEvent(),
-        sponsorsSectionInquiryOpenAnalyticsData(inquirySource, role),
-      );
-      const prior = (trigger.props as { onClick?: (ev: React.MouseEvent) => void }).onClick;
-      prior?.(e);
-    },
-  });
+  const onOpenChange = (open: boolean) => {
+    if (!open) return;
+    trackEvent(
+      sponsorsSectionInquiryOpenAnalyticsEvent(),
+      sponsorsSectionInquiryOpenAnalyticsData(inquirySource, role),
+    );
+  };
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -319,8 +316,8 @@ function PartnerDrawer({
   };
 
   return (
-    <Drawer>
-      <DrawerTrigger asChild>{trackedTrigger}</DrawerTrigger>
+    <Drawer onOpenChange={onOpenChange}>
+      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
       <DrawerContent>
         <div className="mx-auto w-full max-w-xl">
           <DrawerHeader>

--- a/apps/web/src/components/trust-drilldown.tsx
+++ b/apps/web/src/components/trust-drilldown.tsx
@@ -14,6 +14,17 @@ import {
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  trustDrilldownDocAnalyticsData,
+  trustDrilldownDocAnalyticsEvent,
+  trustDrilldownMethodologyAnalyticsData,
+  trustDrilldownMethodologyAnalyticsEvent,
+  trustDrilldownOpenAnalyticsData,
+  trustDrilldownOpenAnalyticsEvent,
+  trustDrilldownSourceAnalyticsData,
+  trustDrilldownSourceAnalyticsEvent,
+} from "@/lib/trust-drilldown-cta-events";
 
 const SEV_META = {
   ok: { Icon: CheckCircle2, className: "text-trust-trusted" },
@@ -40,6 +51,17 @@ export function TrustDrilldown({
           type="button"
           aria-label={`Trust ${entry.trust}${summary ? `: ${summary}` : ""}. Open trust drilldown.`}
           className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+          onClick={() =>
+            trackEvent(
+              trustDrilldownOpenAnalyticsEvent(),
+              trustDrilldownOpenAnalyticsData(
+                entry.category,
+                entry.slug,
+                entry.trust,
+                reasons.length,
+              ),
+            )
+          }
         >
           <TrustBadge level={entry.trust} />
         </button>
@@ -54,6 +76,12 @@ export function TrustDrilldown({
             to="/quality"
             hash="methodology"
             className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] font-medium text-ink hover:bg-surface-2"
+            onClick={() =>
+              trackEvent(
+                trustDrilldownMethodologyAnalyticsEvent(),
+                trustDrilldownMethodologyAnalyticsData(entry.category, entry.slug),
+              )
+            }
           >
             Methodology
             <ArrowUpRight className="h-3 w-3" />
@@ -61,7 +89,7 @@ export function TrustDrilldown({
         </header>
         <ul className="max-h-[60vh] divide-y divide-border overflow-y-auto">
           {reasons.map((r) => (
-            <TrustReasonRow key={r.id} reason={r} />
+            <TrustReasonRow key={r.id} reason={r} category={entry.category} slug={entry.slug} />
           ))}
         </ul>
       </PopoverContent>
@@ -69,7 +97,15 @@ export function TrustDrilldown({
   );
 }
 
-function TrustReasonRow({ reason }: { reason: TrustReason }) {
+function TrustReasonRow({
+  reason,
+  category,
+  slug,
+}: {
+  reason: TrustReason;
+  category: string;
+  slug: string;
+}) {
   const meta = SEV_META[reason.severity];
   const { Icon } = meta;
   return (
@@ -91,7 +127,16 @@ function TrustReasonRow({ reason }: { reason: TrustReason }) {
         <p className="mt-1 text-xs leading-relaxed text-ink-muted">{reason.detail}</p>
         <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
           {reason.docHref && (
-            <Link to={reason.docHref} className="text-ink-muted hover:text-ink">
+            <Link
+              to={reason.docHref}
+              className="text-ink-muted hover:text-ink"
+              onClick={() =>
+                trackEvent(
+                  trustDrilldownDocAnalyticsEvent(),
+                  trustDrilldownDocAnalyticsData(category, slug, reason.id, reason.severity),
+                )
+              }
+            >
               Why this matters →
             </Link>
           )}
@@ -101,6 +146,12 @@ function TrustReasonRow({ reason }: { reason: TrustReason }) {
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-1 text-ink-muted hover:text-ink"
+              onClick={() =>
+                trackEvent(
+                  trustDrilldownSourceAnalyticsEvent(),
+                  trustDrilldownSourceAnalyticsData(category, slug, reason.id, reason.severity),
+                )
+              }
             >
               {reason.sourceLabel ?? "Source"} <ExternalLink className="h-3 w-3" />
             </a>

--- a/apps/web/src/lib/hero-status-row-cta-events-lib.ts
+++ b/apps/web/src/lib/hero-status-row-cta-events-lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure hero status row navigation analytics helpers.
+ *
+ * Maps MCP badge and weekly brief egress to privacy-light event names without
+ * embedding package versions or calendar strings.
+ */
+
+export const HERO_STATUS_ROW_SURFACE = "hero-status-row";
+
+export type HeroStatusRowDestination = "mcp-server" | "brief";
+
+export function heroStatusRowEgressAnalyticsEvent(): string {
+  return "hero_status_row_egress_click";
+}
+
+export function heroStatusRowEgressAnalyticsData(
+  destination: HeroStatusRowDestination,
+  resourceCount: number,
+  reviewedCount: number,
+  briefNumber: number,
+) {
+  return {
+    surface: HERO_STATUS_ROW_SURFACE,
+    destination,
+    resourceCount,
+    reviewedCount,
+    briefNumber,
+  };
+}

--- a/apps/web/src/lib/hero-status-row-cta-events.ts
+++ b/apps/web/src/lib/hero-status-row-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Hero status row navigation CTA event surface.
+ */
+export {
+  HERO_STATUS_ROW_SURFACE,
+  heroStatusRowEgressAnalyticsData,
+  heroStatusRowEgressAnalyticsEvent,
+  type HeroStatusRowDestination,
+} from "@/lib/hero-status-row-cta-events-lib";

--- a/apps/web/src/lib/sponsors-section-cta-events-lib.ts
+++ b/apps/web/src/lib/sponsors-section-cta-events-lib.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure sponsors section navigation analytics helpers.
+ *
+ * Maps credit/partner egress, policy cross-links, open-slot inquiry open,
+ * and partner form submit to privacy-light event names without embedding
+ * URLs, company names, emails, or form free text.
+ */
+
+export const SPONSORS_SECTION_SURFACE = "sponsors-section";
+
+export type SponsorsSectionDestination = "legal" | "advertise";
+
+export type SponsorsSectionInquirySource = "header" | "open-slot";
+
+export function sponsorsSectionEgressAnalyticsEvent(): string {
+  return "sponsors_section_egress_click";
+}
+
+export function sponsorsSectionEgressAnalyticsData(destination: SponsorsSectionDestination) {
+  return {
+    surface: SPONSORS_SECTION_SURFACE,
+    destination,
+  };
+}
+
+export function sponsorsSectionCreditAnalyticsEvent(): string {
+  return "sponsors_section_credit_click";
+}
+
+export function sponsorsSectionCreditAnalyticsData(
+  sponsorSlug: string,
+  kind: string,
+  rowIndex: number,
+  sponsorCount: number,
+) {
+  return {
+    surface: SPONSORS_SECTION_SURFACE,
+    sponsorSlug,
+    kind,
+    rowIndex,
+    sponsorCount,
+  };
+}
+
+export function sponsorsSectionPartnerAnalyticsEvent(): string {
+  return "sponsors_section_partner_click";
+}
+
+export function sponsorsSectionPartnerAnalyticsData(
+  partnerSlug: string,
+  role: string,
+  rowIndex: number,
+  partnerCount: number,
+) {
+  return {
+    surface: SPONSORS_SECTION_SURFACE,
+    partnerSlug,
+    role,
+    rowIndex,
+    partnerCount,
+  };
+}
+
+export function sponsorsSectionInquiryOpenAnalyticsEvent(): string {
+  return "sponsors_section_inquiry_open_click";
+}
+
+export function sponsorsSectionInquiryOpenAnalyticsData(
+  source: SponsorsSectionInquirySource,
+  role: string | null,
+) {
+  return {
+    surface: SPONSORS_SECTION_SURFACE,
+    source,
+    role,
+  };
+}
+
+export function sponsorsSectionSubmitAnalyticsEvent(): string {
+  return "sponsors_section_submit_click";
+}
+
+export function sponsorsSectionSubmitAnalyticsData(hasRole: boolean) {
+  return {
+    surface: SPONSORS_SECTION_SURFACE,
+    hasRole,
+  };
+}

--- a/apps/web/src/lib/sponsors-section-cta-events.ts
+++ b/apps/web/src/lib/sponsors-section-cta-events.ts
@@ -1,0 +1,18 @@
+/**
+ * Sponsors section navigation CTA event surface.
+ */
+export {
+  SPONSORS_SECTION_SURFACE,
+  sponsorsSectionCreditAnalyticsData,
+  sponsorsSectionCreditAnalyticsEvent,
+  sponsorsSectionEgressAnalyticsData,
+  sponsorsSectionEgressAnalyticsEvent,
+  sponsorsSectionInquiryOpenAnalyticsData,
+  sponsorsSectionInquiryOpenAnalyticsEvent,
+  sponsorsSectionPartnerAnalyticsData,
+  sponsorsSectionPartnerAnalyticsEvent,
+  sponsorsSectionSubmitAnalyticsData,
+  sponsorsSectionSubmitAnalyticsEvent,
+  type SponsorsSectionDestination,
+  type SponsorsSectionInquirySource,
+} from "@/lib/sponsors-section-cta-events-lib";

--- a/apps/web/src/lib/trust-drilldown-cta-events-lib.ts
+++ b/apps/web/src/lib/trust-drilldown-cta-events-lib.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure trust drilldown navigation analytics helpers.
+ *
+ * Maps methodology egress, reason doc links, and external source opens to
+ * privacy-light event names without embedding titles, URLs, or free text.
+ */
+
+export const TRUST_DRILLDOWN_SURFACE = "trust-drilldown";
+
+export function trustDrilldownEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function trustDrilldownOpenAnalyticsEvent(): string {
+  return "trust_drilldown_open_click";
+}
+
+export function trustDrilldownOpenAnalyticsData(
+  category: string,
+  slug: string,
+  trust: string,
+  reasonCount: number,
+) {
+  return {
+    surface: TRUST_DRILLDOWN_SURFACE,
+    entry: trustDrilldownEntryKey(category, slug),
+    trust,
+    reasonCount,
+  };
+}
+
+export function trustDrilldownMethodologyAnalyticsEvent(): string {
+  return "trust_drilldown_methodology_click";
+}
+
+export function trustDrilldownMethodologyAnalyticsData(category: string, slug: string) {
+  return {
+    surface: TRUST_DRILLDOWN_SURFACE,
+    entry: trustDrilldownEntryKey(category, slug),
+  };
+}
+
+export function trustDrilldownDocAnalyticsEvent(): string {
+  return "trust_drilldown_doc_click";
+}
+
+export function trustDrilldownDocAnalyticsData(
+  category: string,
+  slug: string,
+  reasonId: string,
+  severity: string,
+) {
+  return {
+    surface: TRUST_DRILLDOWN_SURFACE,
+    entry: trustDrilldownEntryKey(category, slug),
+    reasonId,
+    severity,
+  };
+}
+
+export function trustDrilldownSourceAnalyticsEvent(): string {
+  return "trust_drilldown_source_click";
+}
+
+export function trustDrilldownSourceAnalyticsData(
+  category: string,
+  slug: string,
+  reasonId: string,
+  severity: string,
+) {
+  return {
+    surface: TRUST_DRILLDOWN_SURFACE,
+    entry: trustDrilldownEntryKey(category, slug),
+    reasonId,
+    severity,
+  };
+}

--- a/apps/web/src/lib/trust-drilldown-cta-events.ts
+++ b/apps/web/src/lib/trust-drilldown-cta-events.ts
@@ -1,0 +1,15 @@
+/**
+ * Trust drilldown navigation CTA event surface.
+ */
+export {
+  TRUST_DRILLDOWN_SURFACE,
+  trustDrilldownDocAnalyticsData,
+  trustDrilldownDocAnalyticsEvent,
+  trustDrilldownEntryKey,
+  trustDrilldownMethodologyAnalyticsData,
+  trustDrilldownMethodologyAnalyticsEvent,
+  trustDrilldownOpenAnalyticsData,
+  trustDrilldownOpenAnalyticsEvent,
+  trustDrilldownSourceAnalyticsData,
+  trustDrilldownSourceAnalyticsEvent,
+} from "@/lib/trust-drilldown-cta-events-lib";

--- a/tests/hero-status-row-cta-events-lib.test.ts
+++ b/tests/hero-status-row-cta-events-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  HERO_STATUS_ROW_SURFACE,
+  heroStatusRowEgressAnalyticsData,
+  heroStatusRowEgressAnalyticsEvent,
+} from "@/lib/hero-status-row-cta-events-lib";
+
+describe("hero status row cta events lib", () => {
+  it("builds hero status row navigation analytics", () => {
+    expect(heroStatusRowEgressAnalyticsEvent()).toBe(
+      "hero_status_row_egress_click",
+    );
+    expect(
+      heroStatusRowEgressAnalyticsData("mcp-server", 1200, 900, 42),
+    ).toEqual({
+      surface: HERO_STATUS_ROW_SURFACE,
+      destination: "mcp-server",
+      resourceCount: 1200,
+      reviewedCount: 900,
+      briefNumber: 42,
+    });
+    expect(heroStatusRowEgressAnalyticsData("brief", 10, 8, 1)).toEqual({
+      surface: HERO_STATUS_ROW_SURFACE,
+      destination: "brief",
+      resourceCount: 10,
+      reviewedCount: 8,
+      briefNumber: 1,
+    });
+  });
+});

--- a/tests/sponsors-section-cta-events-lib.test.ts
+++ b/tests/sponsors-section-cta-events-lib.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  SPONSORS_SECTION_SURFACE,
+  sponsorsSectionCreditAnalyticsData,
+  sponsorsSectionCreditAnalyticsEvent,
+  sponsorsSectionEgressAnalyticsData,
+  sponsorsSectionEgressAnalyticsEvent,
+  sponsorsSectionInquiryOpenAnalyticsData,
+  sponsorsSectionInquiryOpenAnalyticsEvent,
+  sponsorsSectionPartnerAnalyticsData,
+  sponsorsSectionPartnerAnalyticsEvent,
+  sponsorsSectionSubmitAnalyticsData,
+  sponsorsSectionSubmitAnalyticsEvent,
+} from "@/lib/sponsors-section-cta-events-lib";
+
+describe("sponsors section cta events lib", () => {
+  it("builds sponsors section navigation analytics", () => {
+    expect(sponsorsSectionEgressAnalyticsEvent()).toBe(
+      "sponsors_section_egress_click",
+    );
+    expect(sponsorsSectionEgressAnalyticsData("legal")).toEqual({
+      surface: SPONSORS_SECTION_SURFACE,
+      destination: "legal",
+    });
+    expect(sponsorsSectionEgressAnalyticsData("advertise")).toEqual({
+      surface: SPONSORS_SECTION_SURFACE,
+      destination: "advertise",
+    });
+    expect(sponsorsSectionCreditAnalyticsEvent()).toBe(
+      "sponsors_section_credit_click",
+    );
+    expect(sponsorsSectionCreditAnalyticsData("vercel", "infra", 2, 6)).toEqual(
+      {
+        surface: SPONSORS_SECTION_SURFACE,
+        sponsorSlug: "vercel",
+        kind: "infra",
+        rowIndex: 2,
+        sponsorCount: 6,
+      },
+    );
+    expect(sponsorsSectionPartnerAnalyticsEvent()).toBe(
+      "sponsors_section_partner_click",
+    );
+    expect(
+      sponsorsSectionPartnerAnalyticsData("acme", "compute", 0, 3),
+    ).toEqual({
+      surface: SPONSORS_SECTION_SURFACE,
+      partnerSlug: "acme",
+      role: "compute",
+      rowIndex: 0,
+      partnerCount: 3,
+    });
+    expect(sponsorsSectionInquiryOpenAnalyticsEvent()).toBe(
+      "sponsors_section_inquiry_open_click",
+    );
+    expect(sponsorsSectionInquiryOpenAnalyticsData("header", null)).toEqual({
+      surface: SPONSORS_SECTION_SURFACE,
+      source: "header",
+      role: null,
+    });
+    expect(
+      sponsorsSectionInquiryOpenAnalyticsData("open-slot", "tooling"),
+    ).toEqual({
+      surface: SPONSORS_SECTION_SURFACE,
+      source: "open-slot",
+      role: "tooling",
+    });
+    expect(sponsorsSectionSubmitAnalyticsEvent()).toBe(
+      "sponsors_section_submit_click",
+    );
+    expect(sponsorsSectionSubmitAnalyticsData(true)).toEqual({
+      surface: SPONSORS_SECTION_SURFACE,
+      hasRole: true,
+    });
+  });
+});

--- a/tests/trust-drilldown-cta-events-lib.test.ts
+++ b/tests/trust-drilldown-cta-events-lib.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  TRUST_DRILLDOWN_SURFACE,
+  trustDrilldownDocAnalyticsData,
+  trustDrilldownDocAnalyticsEvent,
+  trustDrilldownEntryKey,
+  trustDrilldownMethodologyAnalyticsData,
+  trustDrilldownMethodologyAnalyticsEvent,
+  trustDrilldownOpenAnalyticsData,
+  trustDrilldownOpenAnalyticsEvent,
+  trustDrilldownSourceAnalyticsData,
+  trustDrilldownSourceAnalyticsEvent,
+} from "@/lib/trust-drilldown-cta-events-lib";
+
+describe("trust drilldown cta events lib", () => {
+  it("builds trust drilldown navigation analytics", () => {
+    expect(trustDrilldownEntryKey("mcp", "browser")).toBe("mcp/browser");
+    expect(trustDrilldownOpenAnalyticsEvent()).toBe(
+      "trust_drilldown_open_click",
+    );
+    expect(
+      trustDrilldownOpenAnalyticsData("mcp", "browser", "trusted", 4),
+    ).toEqual({
+      surface: TRUST_DRILLDOWN_SURFACE,
+      entry: "mcp/browser",
+      trust: "trusted",
+      reasonCount: 4,
+    });
+    expect(trustDrilldownMethodologyAnalyticsEvent()).toBe(
+      "trust_drilldown_methodology_click",
+    );
+    expect(trustDrilldownMethodologyAnalyticsData("mcp", "browser")).toEqual({
+      surface: TRUST_DRILLDOWN_SURFACE,
+      entry: "mcp/browser",
+    });
+    expect(trustDrilldownDocAnalyticsEvent()).toBe("trust_drilldown_doc_click");
+    expect(
+      trustDrilldownDocAnalyticsData("mcp", "browser", "source-ok", "ok"),
+    ).toEqual({
+      surface: TRUST_DRILLDOWN_SURFACE,
+      entry: "mcp/browser",
+      reasonId: "source-ok",
+      severity: "ok",
+    });
+    expect(trustDrilldownSourceAnalyticsEvent()).toBe(
+      "trust_drilldown_source_click",
+    );
+    expect(
+      trustDrilldownSourceAnalyticsData("mcp", "browser", "repo-stars", "info"),
+    ).toEqual({
+      surface: TRUST_DRILLDOWN_SURFACE,
+      entry: "mcp/browser",
+      reasonId: "repo-stars",
+      severity: "info",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add sponsors-section CTA events for credit/partner egress, legal/advertise links, inquiry open, and form submit
- Add trust-drilldown CTA events for open, methodology, reason docs, and external sources
- Add hero-status-row CTA events for MCP badge and weekly brief egress
- Privacy-light payloads only (no emails, company names, or full URLs)

Refs #550

## Test plan
- [x] prettier + vitest on three new libs
- [x] rebased onto current main; no file overlap with open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)


Made with [Cursor](https://cursor.com)