### PR TITLE
feat(web): add app-shell, breadcrumbs, feeds, and downloads analytics

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -7,6 +7,22 @@ import { useShortcuts } from "./shortcuts-dialog";
 import { ScrollProgress } from "./scroll-progress";
 import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  appShellCategoryAnalyticsData,
+  appShellCategoryAnalyticsEvent,
+  appShellFeedChipAnalyticsData,
+  appShellFeedChipAnalyticsEvent,
+  appShellFooterLinkAnalyticsData,
+  appShellFooterLinkAnalyticsEvent,
+  appShellHeaderAnalyticsData,
+  appShellHeaderAnalyticsEvent,
+  appShellLegalAnalyticsData,
+  appShellLegalAnalyticsEvent,
+  appShellNavAnalyticsData,
+  appShellNavAnalyticsEvent,
+  type AppShellFeedChip,
+} from "@/lib/app-shell-cta-events";
 import { NewsletterInline } from "./newsletter-inline";
 import {
   Sheet,
@@ -63,7 +79,13 @@ export function TopBar() {
           <Menu className="h-4 w-4" />
         </button>
 
-        <Link to="/" className="flex items-center gap-2">
+        <Link
+          to="/"
+          className="flex items-center gap-2"
+          onClick={() =>
+            trackEvent(appShellHeaderAnalyticsEvent(), appShellHeaderAnalyticsData("logo"))
+          }
+        >
           <span className="flex h-7 w-7 items-center justify-center rounded-md bg-ink text-background">
             <span className="font-display text-sm font-bold">hc</span>
           </span>
@@ -80,6 +102,12 @@ export function TopBar() {
                 key={item.to}
                 to={item.to}
                 aria-current={active ? "page" : undefined}
+                onClick={() =>
+                  trackEvent(
+                    appShellNavAnalyticsEvent(),
+                    appShellNavAnalyticsData(item.to, "desktop"),
+                  )
+                }
                 className={cn(
                   "relative rounded-md px-2.5 py-1.5 text-sm transition-colors duration-200 ease-out",
                   active ? "text-ink" : "text-ink-muted hover:bg-surface-2 hover:text-ink",
@@ -106,7 +134,10 @@ export function TopBar() {
           <AlertsDropdown />
           <button
             type="button"
-            onClick={toggle}
+            onClick={() => {
+              trackEvent(appShellHeaderAnalyticsEvent(), appShellHeaderAnalyticsData("theme"));
+              toggle();
+            }}
             aria-label="Toggle theme"
             className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-ink-muted hover:text-ink"
           >
@@ -118,12 +149,18 @@ export function TopBar() {
             rel="noreferrer"
             className="hidden h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-ink-muted hover:text-ink sm:inline-flex"
             aria-label="GitHub"
+            onClick={() =>
+              trackEvent(appShellHeaderAnalyticsEvent(), appShellHeaderAnalyticsData("github"))
+            }
           >
             <Github className="h-4 w-4" />
           </a>
           <Link
             to="/submit"
             className="inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-3 text-sm font-medium text-background hover:bg-ink/90"
+            onClick={() =>
+              trackEvent(appShellHeaderAnalyticsEvent(), appShellHeaderAnalyticsData("submit"))
+            }
           >
             <Send className="h-3.5 w-3.5" />
             Submit
@@ -150,7 +187,13 @@ export function TopBar() {
                       <Link
                         key={item.to}
                         to={item.to}
-                        onClick={() => setMobileNavOpen(false)}
+                        onClick={() => {
+                          trackEvent(
+                            appShellNavAnalyticsEvent(),
+                            appShellNavAnalyticsData(item.to, "mobile", section.id),
+                          );
+                          setMobileNavOpen(false);
+                        }}
                         aria-current={active ? "page" : undefined}
                         className={cn(
                           "rounded-md px-3 py-2 text-sm transition-colors duration-200 ease-out",
@@ -194,26 +237,38 @@ export function Footer() {
             reviewed before installing.
           </p>
           <div className="mt-4 flex flex-wrap items-center gap-1.5 text-[11px]">
-            <FeedChip href="/feed.xml" label="RSS" />
-            <FeedChip href="/atom.xml" label="Atom" />
-            <FeedChip href="/data/feeds/index.json" label="JSON Feed" />
-            <FeedChip href="/llms.txt" label="llms.txt" />
+            <FeedChip href="/feed.xml" label="RSS" feed="rss" />
+            <FeedChip href="/atom.xml" label="Atom" feed="atom" />
+            <FeedChip href="/data/feeds/index.json" label="JSON Feed" feed="json" />
+            <FeedChip href="/llms.txt" label="llms.txt" feed="llms" />
           </div>
         </div>
         {SHELL_FOOTER_COLUMNS.map((column) => (
-          <FooterCol key={column.id} title={column.title} links={column.links} span={column.span} />
+          <FooterCol
+            key={column.id}
+            title={column.title}
+            links={column.links}
+            span={column.span}
+            columnId={column.id}
+          />
         ))}
       </div>
       <div className="border-t border-border">
         <div className="mx-auto max-w-page px-4 py-4 sm:px-6">
           <div className="eyebrow mb-2">Categories</div>
           <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm text-ink-muted">
-            {CATEGORIES.map((c) => (
+            {CATEGORIES.map((c, i) => (
               <Link
                 key={c.id}
                 to="/$category"
                 params={{ category: c.id }}
                 className="hover:text-ink"
+                onClick={() =>
+                  trackEvent(
+                    appShellCategoryAnalyticsEvent(),
+                    appShellCategoryAnalyticsData(c.id, i, CATEGORIES.length),
+                  )
+                }
               >
                 {c.label}
               </Link>
@@ -225,13 +280,26 @@ export function Footer() {
         <div className="mx-auto flex max-w-page flex-col items-start gap-3 px-4 py-5 text-xs text-ink-subtle sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <span>© {new Date().getFullYear()} HeyClaude · heyclau.de</span>
           <nav aria-label="Legal" className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <Link to="/legal" className="hover:text-ink">
+            <Link
+              to="/legal"
+              className="hover:text-ink"
+              onClick={() =>
+                trackEvent(appShellLegalAnalyticsEvent(), appShellLegalAnalyticsData("legal"))
+              }
+            >
               Legal
             </Link>
             <span aria-hidden className="text-ink-subtle/60">
               ·
             </span>
-            <Link to="/legal" hash="privacy" className="hover:text-ink">
+            <Link
+              to="/legal"
+              hash="privacy"
+              className="hover:text-ink"
+              onClick={() =>
+                trackEvent(appShellLegalAnalyticsEvent(), appShellLegalAnalyticsData("privacy"))
+              }
+            >
               Privacy
             </Link>
             <span aria-hidden className="text-ink-subtle/60">
@@ -249,13 +317,16 @@ export function Footer() {
   );
 }
 
-function FeedChip({ href, label }: { href: string; label: string }) {
+function FeedChip({ href, label, feed }: { href: string; label: string; feed: AppShellFeedChip }) {
   return (
     <a
       href={href}
       target="_blank"
       rel="noreferrer"
       className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-1.5 py-0.5 font-mono text-ink-muted hover:text-ink"
+      onClick={() =>
+        trackEvent(appShellFeedChipAnalyticsEvent(), appShellFeedChipAnalyticsData(feed))
+      }
     >
       <Rss className="h-2.5 w-2.5" aria-hidden />
       {label}
@@ -266,7 +337,14 @@ function FeedChip({ href, label }: { href: string; label: string }) {
 function ShortcutsFooterLink() {
   const shortcuts = useShortcuts();
   return (
-    <button type="button" onClick={() => shortcuts?.open()} className="hover:text-ink">
+    <button
+      type="button"
+      onClick={() => {
+        trackEvent(appShellHeaderAnalyticsEvent(), appShellHeaderAnalyticsData("shortcuts"));
+        shortcuts?.open();
+      }}
+      className="hover:text-ink"
+    >
       Keyboard shortcuts
     </button>
   );
@@ -276,10 +354,12 @@ function FooterCol({
   title,
   links,
   span = 2,
+  columnId,
 }: {
   title: string;
   links: { to: string; label: string }[];
   span?: 2 | 3 | 4;
+  columnId: string;
 }) {
   return (
     <div className={footerColumnSpanClass(span)}>
@@ -287,7 +367,16 @@ function FooterCol({
       <ul className="flex flex-col gap-2">
         {links.map((l) => (
           <li key={l.to}>
-            <Link to={l.to} className="text-sm text-ink-muted hover:text-ink">
+            <Link
+              to={l.to}
+              className="text-sm text-ink-muted hover:text-ink"
+              onClick={() =>
+                trackEvent(
+                  appShellFooterLinkAnalyticsEvent(),
+                  appShellFooterLinkAnalyticsData(columnId, l.to),
+                )
+              }
+            >
               {l.label}
             </Link>
           </li>

--- a/apps/web/src/components/breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs.tsx
@@ -1,6 +1,13 @@
 import { Link } from "@tanstack/react-router";
 import { ChevronRight, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  breadcrumbsCrumbAnalyticsData,
+  breadcrumbsCrumbAnalyticsEvent,
+  breadcrumbsHomeAnalyticsData,
+  breadcrumbsHomeAnalyticsEvent,
+} from "@/lib/breadcrumbs-cta-events";
 import { Fragment } from "react";
 
 export interface Crumb {
@@ -34,6 +41,12 @@ export function Breadcrumbs({
               to="/"
               className="inline-flex h-6 w-6 items-center justify-center rounded-md text-ink-subtle transition-colors duration-200 ease-out hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               aria-label="Home"
+              onClick={() =>
+                trackEvent(
+                  breadcrumbsHomeAnalyticsEvent(),
+                  breadcrumbsHomeAnalyticsData(items.length),
+                )
+              }
             >
               <Home className="h-3 w-3" />
             </Link>
@@ -51,7 +64,13 @@ export function Breadcrumbs({
                     to={c.to}
                     params={c.params}
                     search={c.search}
-                    onClick={c.onClick}
+                    onClick={() => {
+                      trackEvent(
+                        breadcrumbsCrumbAnalyticsEvent(),
+                        breadcrumbsCrumbAnalyticsData(i, items.length),
+                      );
+                      c.onClick?.();
+                    }}
                     className="rounded-md px-1.5 py-0.5 text-ink-muted transition-colors duration-200 ease-out hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   >
                     {c.label}

--- a/apps/web/src/components/feed-health-panel.tsx
+++ b/apps/web/src/components/feed-health-panel.tsx
@@ -3,6 +3,17 @@ import { CheckCircle2, AlertTriangle, ExternalLink, Loader2 } from "lucide-react
 import { CopyButton } from "@/components/copy-button";
 import { timeAgo } from "@/lib/format-lib";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  feedHealthCopyAnalyticsData,
+  feedHealthCopyAnalyticsEvent,
+  feedHealthFeedOpenAnalyticsData,
+  feedHealthFeedOpenAnalyticsEvent,
+  feedHealthJsonAnalyticsData,
+  feedHealthJsonAnalyticsEvent,
+  feedHealthSeeAllAnalyticsData,
+  feedHealthSeeAllAnalyticsEvent,
+} from "@/lib/feed-health-panel-cta-events";
 
 interface FeedHealth {
   id: string;
@@ -73,12 +84,15 @@ export function FeedHealthPanel({ compact = false }: { compact?: boolean }) {
           target="_blank"
           rel="noreferrer"
           className="inline-flex items-center gap-1 text-xs text-ink-muted hover:text-ink"
+          onClick={() =>
+            trackEvent(feedHealthJsonAnalyticsEvent(), feedHealthJsonAnalyticsData(total, current))
+          }
         >
           JSON <ExternalLink className="h-3 w-3" />
         </a>
       </div>
       <div className="divide-y divide-border">
-        {visible.map((f) => (
+        {visible.map((f, i) => (
           <div
             key={f.id}
             className={cn(
@@ -105,7 +119,16 @@ export function FeedHealthPanel({ compact = false }: { compact?: boolean }) {
                 )}
                 {f.isCurrent ? "Current" : "Stale"}
               </span>
-              <a href={f.url} className="truncate font-medium text-ink hover:underline">
+              <a
+                href={f.url}
+                className="truncate font-medium text-ink hover:underline"
+                onClick={() =>
+                  trackEvent(
+                    feedHealthFeedOpenAnalyticsEvent(),
+                    feedHealthFeedOpenAnalyticsData(f.id, f.isCurrent, i, visible.length),
+                  )
+                }
+              >
                 {f.title}
               </a>
             </div>
@@ -115,13 +138,27 @@ export function FeedHealthPanel({ compact = false }: { compact?: boolean }) {
             <div className="truncate font-mono text-ink-subtle" title={f.etag}>
               {f.etag.replace(/"/g, "")}
             </div>
-            <CopyButton value={f.url} label="Copy" />
+            <CopyButton
+              value={f.url}
+              label="Copy"
+              event={feedHealthCopyAnalyticsEvent()}
+              eventData={feedHealthCopyAnalyticsData(f.id, f.isCurrent)}
+            />
           </div>
         ))}
       </div>
       {compact && data.feeds.length > visible.length && (
         <div className="border-t border-border px-4 py-2 text-right text-xs">
-          <a href="/feeds" className="text-ink-muted hover:text-ink">
+          <a
+            href="/feeds"
+            className="text-ink-muted hover:text-ink"
+            onClick={() =>
+              trackEvent(
+                feedHealthSeeAllAnalyticsEvent(),
+                feedHealthSeeAllAnalyticsData(data.feeds.length, visible.length),
+              )
+            }
+          >
             See all {data.feeds.length} feeds →
           </a>
         </div>

--- a/apps/web/src/components/report-downloads.tsx
+++ b/apps/web/src/components/report-downloads.tsx
@@ -1,6 +1,11 @@
 import { Download } from "lucide-react";
 
 import { reportExportUrl } from "@/lib/data-reports";
+import { trackEvent } from "@/lib/analytics";
+import {
+  reportDownloadsExportAnalyticsData,
+  reportDownloadsExportAnalyticsEvent,
+} from "@/lib/report-downloads-cta-events";
 
 const LINK_CLASS =
   "inline-flex items-center gap-2 rounded-lg border border-border bg-surface-2 px-4 py-2 text-sm font-medium text-ink hover:bg-surface";
@@ -21,10 +26,28 @@ export function ReportDownloads({ exportSlug }: { exportSlug: string }) {
         registry. Free to reuse under CC BY 4.0 with attribution.
       </p>
       <div className="mt-4 flex flex-wrap gap-3">
-        <a href={reportExportUrl(exportSlug, "json")} className={LINK_CLASS}>
+        <a
+          href={reportExportUrl(exportSlug, "json")}
+          className={LINK_CLASS}
+          onClick={() =>
+            trackEvent(
+              reportDownloadsExportAnalyticsEvent(),
+              reportDownloadsExportAnalyticsData(exportSlug, "json"),
+            )
+          }
+        >
           <Download className="h-4 w-4" aria-hidden /> JSON
         </a>
-        <a href={reportExportUrl(exportSlug, "csv")} className={LINK_CLASS}>
+        <a
+          href={reportExportUrl(exportSlug, "csv")}
+          className={LINK_CLASS}
+          onClick={() =>
+            trackEvent(
+              reportDownloadsExportAnalyticsEvent(),
+              reportDownloadsExportAnalyticsData(exportSlug, "csv"),
+            )
+          }
+        >
           <Download className="h-4 w-4" aria-hidden /> CSV
         </a>
       </div>

--- a/apps/web/src/lib/app-shell-cta-events-lib.ts
+++ b/apps/web/src/lib/app-shell-cta-events-lib.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure app-shell navigation analytics helpers.
+ *
+ * Maps top-bar, mobile menu, footer, and feed-chip egress to privacy-light
+ * event names without embedding button labels or free text.
+ */
+
+export const APP_SHELL_SURFACE = "app-shell";
+
+export type AppShellNavSource = "desktop" | "mobile";
+
+export type AppShellFeedChip = "rss" | "atom" | "json" | "llms";
+
+export type AppShellLegalDestination = "legal" | "privacy";
+
+export type AppShellHeaderAction = "submit" | "github" | "theme" | "logo" | "shortcuts";
+
+export function appShellNavAnalyticsEvent(): string {
+  return "app_shell_nav_click";
+}
+
+export function appShellNavAnalyticsData(
+  destination: string,
+  source: AppShellNavSource,
+  sectionId: string | null = null,
+) {
+  return {
+    surface: APP_SHELL_SURFACE,
+    destination,
+    source,
+    sectionId,
+  };
+}
+
+export function appShellHeaderAnalyticsEvent(): string {
+  return "app_shell_header_click";
+}
+
+export function appShellHeaderAnalyticsData(action: AppShellHeaderAction) {
+  return {
+    surface: APP_SHELL_SURFACE,
+    action,
+  };
+}
+
+export function appShellFeedChipAnalyticsEvent(): string {
+  return "app_shell_feed_chip_click";
+}
+
+export function appShellFeedChipAnalyticsData(feed: AppShellFeedChip) {
+  return {
+    surface: APP_SHELL_SURFACE,
+    feed,
+  };
+}
+
+export function appShellFooterLinkAnalyticsEvent(): string {
+  return "app_shell_footer_link_click";
+}
+
+export function appShellFooterLinkAnalyticsData(columnId: string, destination: string) {
+  return {
+    surface: APP_SHELL_SURFACE,
+    columnId,
+    destination,
+  };
+}
+
+export function appShellCategoryAnalyticsEvent(): string {
+  return "app_shell_category_click";
+}
+
+export function appShellCategoryAnalyticsData(
+  category: string,
+  rowIndex: number,
+  categoryCount: number,
+) {
+  return {
+    surface: APP_SHELL_SURFACE,
+    category,
+    rowIndex,
+    categoryCount,
+  };
+}
+
+export function appShellLegalAnalyticsEvent(): string {
+  return "app_shell_legal_click";
+}
+
+export function appShellLegalAnalyticsData(destination: AppShellLegalDestination) {
+  return {
+    surface: APP_SHELL_SURFACE,
+    destination,
+  };
+}

--- a/apps/web/src/lib/app-shell-cta-events.ts
+++ b/apps/web/src/lib/app-shell-cta-events.ts
@@ -1,0 +1,22 @@
+/**
+ * App shell navigation CTA event surface.
+ */
+export {
+  APP_SHELL_SURFACE,
+  appShellCategoryAnalyticsData,
+  appShellCategoryAnalyticsEvent,
+  appShellFeedChipAnalyticsData,
+  appShellFeedChipAnalyticsEvent,
+  appShellFooterLinkAnalyticsData,
+  appShellFooterLinkAnalyticsEvent,
+  appShellHeaderAnalyticsData,
+  appShellHeaderAnalyticsEvent,
+  appShellLegalAnalyticsData,
+  appShellLegalAnalyticsEvent,
+  appShellNavAnalyticsData,
+  appShellNavAnalyticsEvent,
+  type AppShellFeedChip,
+  type AppShellHeaderAction,
+  type AppShellLegalDestination,
+  type AppShellNavSource,
+} from "@/lib/app-shell-cta-events-lib";

--- a/apps/web/src/lib/breadcrumbs-cta-events-lib.ts
+++ b/apps/web/src/lib/breadcrumbs-cta-events-lib.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure breadcrumbs navigation analytics helpers.
+ *
+ * Maps home and ancestor crumb egress to privacy-light event names without
+ * embedding crumb labels or route params.
+ */
+
+export const BREADCRUMBS_SURFACE = "breadcrumbs";
+
+export function breadcrumbsHomeAnalyticsEvent(): string {
+  return "breadcrumbs_home_click";
+}
+
+export function breadcrumbsHomeAnalyticsData(crumbCount: number) {
+  return {
+    surface: BREADCRUMBS_SURFACE,
+    crumbCount,
+  };
+}
+
+export function breadcrumbsCrumbAnalyticsEvent(): string {
+  return "breadcrumbs_crumb_click";
+}
+
+export function breadcrumbsCrumbAnalyticsData(rowIndex: number, crumbCount: number) {
+  return {
+    surface: BREADCRUMBS_SURFACE,
+    rowIndex,
+    crumbCount,
+  };
+}

--- a/apps/web/src/lib/breadcrumbs-cta-events.ts
+++ b/apps/web/src/lib/breadcrumbs-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Breadcrumbs navigation CTA event surface.
+ */
+export {
+  BREADCRUMBS_SURFACE,
+  breadcrumbsCrumbAnalyticsData,
+  breadcrumbsCrumbAnalyticsEvent,
+  breadcrumbsHomeAnalyticsData,
+  breadcrumbsHomeAnalyticsEvent,
+} from "@/lib/breadcrumbs-cta-events-lib";

--- a/apps/web/src/lib/feed-health-panel-cta-events-lib.ts
+++ b/apps/web/src/lib/feed-health-panel-cta-events-lib.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure feed health panel navigation analytics helpers.
+ *
+ * Maps health JSON egress, per-feed open/copy, and see-all navigation to
+ * privacy-light event names without embedding full feed URLs or etags.
+ */
+
+export const FEED_HEALTH_PANEL_SURFACE = "feed-health-panel";
+
+export function feedHealthJsonAnalyticsEvent(): string {
+  return "feed_health_json_click";
+}
+
+export function feedHealthJsonAnalyticsData(feedCount: number, currentCount: number) {
+  return {
+    surface: FEED_HEALTH_PANEL_SURFACE,
+    feedCount,
+    currentCount,
+  };
+}
+
+export function feedHealthFeedOpenAnalyticsEvent(): string {
+  return "feed_health_feed_open_click";
+}
+
+export function feedHealthFeedOpenAnalyticsData(
+  feedId: string,
+  isCurrent: boolean,
+  rowIndex: number,
+  visibleCount: number,
+) {
+  return {
+    surface: FEED_HEALTH_PANEL_SURFACE,
+    feedId,
+    isCurrent,
+    rowIndex,
+    visibleCount,
+  };
+}
+
+export function feedHealthCopyAnalyticsEvent(): string {
+  return "feed_health_copy_click";
+}
+
+export function feedHealthCopyAnalyticsData(feedId: string, isCurrent: boolean) {
+  return {
+    surface: FEED_HEALTH_PANEL_SURFACE,
+    feedId,
+    isCurrent,
+  };
+}
+
+export function feedHealthSeeAllAnalyticsEvent(): string {
+  return "feed_health_see_all_click";
+}
+
+export function feedHealthSeeAllAnalyticsData(feedCount: number, visibleCount: number) {
+  return {
+    surface: FEED_HEALTH_PANEL_SURFACE,
+    feedCount,
+    visibleCount,
+  };
+}

--- a/apps/web/src/lib/feed-health-panel-cta-events.ts
+++ b/apps/web/src/lib/feed-health-panel-cta-events.ts
@@ -1,0 +1,14 @@
+/**
+ * Feed health panel navigation CTA event surface.
+ */
+export {
+  FEED_HEALTH_PANEL_SURFACE,
+  feedHealthCopyAnalyticsData,
+  feedHealthCopyAnalyticsEvent,
+  feedHealthFeedOpenAnalyticsData,
+  feedHealthFeedOpenAnalyticsEvent,
+  feedHealthJsonAnalyticsData,
+  feedHealthJsonAnalyticsEvent,
+  feedHealthSeeAllAnalyticsData,
+  feedHealthSeeAllAnalyticsEvent,
+} from "@/lib/feed-health-panel-cta-events-lib";

--- a/apps/web/src/lib/report-downloads-cta-events-lib.ts
+++ b/apps/web/src/lib/report-downloads-cta-events-lib.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure report downloads navigation analytics helpers.
+ *
+ * Maps JSON/CSV export egress to privacy-light event names without embedding
+ * file bytes or regenerated report contents.
+ */
+
+export const REPORT_DOWNLOADS_SURFACE = "report-downloads";
+
+export type ReportDownloadsFormat = "json" | "csv";
+
+export function reportDownloadsExportAnalyticsEvent(): string {
+  return "report_downloads_export_click";
+}
+
+export function reportDownloadsExportAnalyticsData(
+  exportSlug: string,
+  format: ReportDownloadsFormat,
+) {
+  return {
+    surface: REPORT_DOWNLOADS_SURFACE,
+    exportSlug,
+    format,
+  };
+}

--- a/apps/web/src/lib/report-downloads-cta-events.ts
+++ b/apps/web/src/lib/report-downloads-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Report downloads navigation CTA event surface.
+ */
+export {
+  REPORT_DOWNLOADS_SURFACE,
+  reportDownloadsExportAnalyticsData,
+  reportDownloadsExportAnalyticsEvent,
+  type ReportDownloadsFormat,
+} from "@/lib/report-downloads-cta-events-lib";

--- a/tests/app-shell-cta-events-lib.test.ts
+++ b/tests/app-shell-cta-events-lib.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_SHELL_SURFACE,
+  appShellCategoryAnalyticsData,
+  appShellCategoryAnalyticsEvent,
+  appShellFeedChipAnalyticsData,
+  appShellFeedChipAnalyticsEvent,
+  appShellFooterLinkAnalyticsData,
+  appShellFooterLinkAnalyticsEvent,
+  appShellHeaderAnalyticsData,
+  appShellHeaderAnalyticsEvent,
+  appShellLegalAnalyticsData,
+  appShellLegalAnalyticsEvent,
+  appShellNavAnalyticsData,
+  appShellNavAnalyticsEvent,
+} from "@/lib/app-shell-cta-events-lib";
+
+describe("app shell cta events lib", () => {
+  it("builds app shell navigation analytics", () => {
+    expect(appShellNavAnalyticsEvent()).toBe("app_shell_nav_click");
+    expect(appShellNavAnalyticsData("/browse", "desktop")).toEqual({
+      surface: APP_SHELL_SURFACE,
+      destination: "/browse",
+      source: "desktop",
+      sectionId: null,
+    });
+    expect(appShellNavAnalyticsData("/feeds", "mobile", "api-mcp")).toEqual({
+      surface: APP_SHELL_SURFACE,
+      destination: "/feeds",
+      source: "mobile",
+      sectionId: "api-mcp",
+    });
+    expect(appShellHeaderAnalyticsEvent()).toBe("app_shell_header_click");
+    expect(appShellHeaderAnalyticsData("submit")).toEqual({
+      surface: APP_SHELL_SURFACE,
+      action: "submit",
+    });
+    expect(appShellFeedChipAnalyticsEvent()).toBe("app_shell_feed_chip_click");
+    expect(appShellFeedChipAnalyticsData("llms")).toEqual({
+      surface: APP_SHELL_SURFACE,
+      feed: "llms",
+    });
+    expect(appShellFooterLinkAnalyticsEvent()).toBe(
+      "app_shell_footer_link_click",
+    );
+    expect(appShellFooterLinkAnalyticsData("product", "/trending")).toEqual({
+      surface: APP_SHELL_SURFACE,
+      columnId: "product",
+      destination: "/trending",
+    });
+    expect(appShellCategoryAnalyticsEvent()).toBe("app_shell_category_click");
+    expect(appShellCategoryAnalyticsData("mcp", 2, 9)).toEqual({
+      surface: APP_SHELL_SURFACE,
+      category: "mcp",
+      rowIndex: 2,
+      categoryCount: 9,
+    });
+    expect(appShellLegalAnalyticsEvent()).toBe("app_shell_legal_click");
+    expect(appShellLegalAnalyticsData("privacy")).toEqual({
+      surface: APP_SHELL_SURFACE,
+      destination: "privacy",
+    });
+  });
+});

--- a/tests/breadcrumbs-cta-events-lib.test.ts
+++ b/tests/breadcrumbs-cta-events-lib.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  BREADCRUMBS_SURFACE,
+  breadcrumbsCrumbAnalyticsData,
+  breadcrumbsCrumbAnalyticsEvent,
+  breadcrumbsHomeAnalyticsData,
+  breadcrumbsHomeAnalyticsEvent,
+} from "@/lib/breadcrumbs-cta-events-lib";
+
+describe("breadcrumbs cta events lib", () => {
+  it("builds breadcrumbs navigation analytics", () => {
+    expect(breadcrumbsHomeAnalyticsEvent()).toBe("breadcrumbs_home_click");
+    expect(breadcrumbsHomeAnalyticsData(3)).toEqual({
+      surface: BREADCRUMBS_SURFACE,
+      crumbCount: 3,
+    });
+    expect(breadcrumbsCrumbAnalyticsEvent()).toBe("breadcrumbs_crumb_click");
+    expect(breadcrumbsCrumbAnalyticsData(1, 4)).toEqual({
+      surface: BREADCRUMBS_SURFACE,
+      rowIndex: 1,
+      crumbCount: 4,
+    });
+  });
+});

--- a/tests/feed-health-panel-cta-events-lib.test.ts
+++ b/tests/feed-health-panel-cta-events-lib.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  FEED_HEALTH_PANEL_SURFACE,
+  feedHealthCopyAnalyticsData,
+  feedHealthCopyAnalyticsEvent,
+  feedHealthFeedOpenAnalyticsData,
+  feedHealthFeedOpenAnalyticsEvent,
+  feedHealthJsonAnalyticsData,
+  feedHealthJsonAnalyticsEvent,
+  feedHealthSeeAllAnalyticsData,
+  feedHealthSeeAllAnalyticsEvent,
+} from "@/lib/feed-health-panel-cta-events-lib";
+
+describe("feed health panel cta events lib", () => {
+  it("builds feed health panel navigation analytics", () => {
+    expect(feedHealthJsonAnalyticsEvent()).toBe("feed_health_json_click");
+    expect(feedHealthJsonAnalyticsData(12, 10)).toEqual({
+      surface: FEED_HEALTH_PANEL_SURFACE,
+      feedCount: 12,
+      currentCount: 10,
+    });
+    expect(feedHealthFeedOpenAnalyticsEvent()).toBe(
+      "feed_health_feed_open_click",
+    );
+    expect(feedHealthFeedOpenAnalyticsData("site", true, 0, 5)).toEqual({
+      surface: FEED_HEALTH_PANEL_SURFACE,
+      feedId: "site",
+      isCurrent: true,
+      rowIndex: 0,
+      visibleCount: 5,
+    });
+    expect(feedHealthCopyAnalyticsEvent()).toBe("feed_health_copy_click");
+    expect(feedHealthCopyAnalyticsData("changelog", false)).toEqual({
+      surface: FEED_HEALTH_PANEL_SURFACE,
+      feedId: "changelog",
+      isCurrent: false,
+    });
+    expect(feedHealthSeeAllAnalyticsEvent()).toBe("feed_health_see_all_click");
+    expect(feedHealthSeeAllAnalyticsData(12, 5)).toEqual({
+      surface: FEED_HEALTH_PANEL_SURFACE,
+      feedCount: 12,
+      visibleCount: 5,
+    });
+  });
+});

--- a/tests/report-downloads-cta-events-lib.test.ts
+++ b/tests/report-downloads-cta-events-lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  REPORT_DOWNLOADS_SURFACE,
+  reportDownloadsExportAnalyticsData,
+  reportDownloadsExportAnalyticsEvent,
+} from "@/lib/report-downloads-cta-events-lib";
+
+describe("report downloads cta events lib", () => {
+  it("builds report downloads navigation analytics", () => {
+    expect(reportDownloadsExportAnalyticsEvent()).toBe(
+      "report_downloads_export_click",
+    );
+    expect(
+      reportDownloadsExportAnalyticsData("state-of-mcp-servers", "json"),
+    ).toEqual({
+      surface: REPORT_DOWNLOADS_SURFACE,
+      exportSlug: "state-of-mcp-servers",
+      format: "json",
+    });
+    expect(
+      reportDownloadsExportAnalyticsData("state-of-ai-agents", "csv"),
+    ).toEqual({
+      surface: REPORT_DOWNLOADS_SURFACE,
+      exportSlug: "state-of-ai-agents",
+      format: "csv",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add app-shell CTA events for logo/nav/submit/github/theme, mobile menu, footer columns, category rail, legal/privacy, feed chips, and shortcuts
- Add breadcrumbs CTA events for home and ancestor crumb egress
- Add feed-health panel CTA events for JSON egress, feed open/copy, and see-all
- Add report-downloads CTA events for JSON/CSV exports
- Privacy-light payloads only (no crumb labels, URLs, etags, or free text)

Refs #550

## Test plan
- [x] prettier + vitest on four new libs
- [x] verified no file overlap with currently open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)


Made with [Cursor](https://cursor.com)