### PR TITLE
feat(web): add signals, attribution, platform, and setup analytics

### DIFF
--- a/apps/web/src/components/badges.tsx
+++ b/apps/web/src/components/badges.tsx
@@ -24,6 +24,11 @@ import {
   EyeOff,
 } from "lucide-react";
 import { IntegrationMark, platformMark } from "./integration-marks";
+import { trackEvent } from "@/lib/analytics";
+import {
+  platformChipAnalyticsData,
+  platformChipAnalyticsEvent,
+} from "@/lib/platform-chip-cta-events";
 import {
   installRiskLevel,
   INSTALL_RISK_LABEL,
@@ -102,6 +107,7 @@ export function PlatformChip({ id, asLink = false }: { id: Platform; asLink?: bo
         to="/for/$platform"
         params={{ platform: id }}
         className={cn(base, "transition-colors hover:border-ink/20 hover:text-ink")}
+        onClick={() => trackEvent(platformChipAnalyticsEvent(), platformChipAnalyticsData(id))}
       >
         {content}
       </Link>

--- a/apps/web/src/components/contributor-attribution.tsx
+++ b/apps/web/src/components/contributor-attribution.tsx
@@ -7,18 +7,36 @@ import {
   contributorForVerifiedAuthor,
   findContributorForIdentity,
 } from "@/data/contributors";
+import { trackEvent } from "@/lib/analytics";
+import {
+  contributorAttributionAnalyticsData,
+  contributorAttributionAnalyticsEvent,
+  type ContributorAttributionRole,
+} from "@/lib/contributor-attribution-cta-events";
 
 function ContributorProfileLink({
   contributor,
   label,
+  role,
   className = "text-ink hover:underline",
 }: {
   contributor: Contributor;
   label: string;
+  role: ContributorAttributionRole;
   className?: string;
 }) {
   return (
-    <Link to="/contributors/$slug" params={{ slug: contributor.slug }} className={className}>
+    <Link
+      to="/contributors/$slug"
+      params={{ slug: contributor.slug }}
+      className={className}
+      onClick={() =>
+        trackEvent(
+          contributorAttributionAnalyticsEvent(),
+          contributorAttributionAnalyticsData("profile", role, contributor.slug),
+        )
+      }
+    >
       {label}
     </Link>
   );
@@ -34,7 +52,18 @@ function ExternalSubmitterLink({
   if (!entry.submittedBy) return null;
   const href = entry.submittedByUrl ?? `https://github.com/${entry.submittedBy}`;
   return (
-    <a href={href} target="_blank" rel="noreferrer" className={className}>
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className={className}
+      onClick={() =>
+        trackEvent(
+          contributorAttributionAnalyticsEvent(),
+          contributorAttributionAnalyticsData("external", "submitter"),
+        )
+      }
+    >
       {entry.submittedBy}
     </a>
   );
@@ -49,7 +78,18 @@ function UnverifiedAuthorLabel({
 }) {
   if (entry.authorProfileUrl) {
     return (
-      <a href={entry.authorProfileUrl} target="_blank" rel="noreferrer" className={className}>
+      <a
+        href={entry.authorProfileUrl}
+        target="_blank"
+        rel="noreferrer"
+        className={className}
+        onClick={() =>
+          trackEvent(
+            contributorAttributionAnalyticsEvent(),
+            contributorAttributionAnalyticsData("external", "author"),
+          )
+        }
+      >
         {entry.author}
       </a>
     );
@@ -67,13 +107,14 @@ export function EntryAuthorAttribution({ entry, className }: { entry: Entry; cla
   if (verifiedAuthor) {
     return (
       <span className={className}>
-        by <ContributorProfileLink contributor={verifiedAuthor} label={entry.author} />
+        by{" "}
+        <ContributorProfileLink contributor={verifiedAuthor} label={entry.author} role="author" />
       </span>
     );
   }
 
   const authorLabel = authorContributor ? (
-    <ContributorProfileLink contributor={authorContributor} label={entry.author} />
+    <ContributorProfileLink contributor={authorContributor} label={entry.author} role="author" />
   ) : (
     <UnverifiedAuthorLabel entry={entry} />
   );
@@ -87,7 +128,11 @@ export function EntryAuthorAttribution({ entry, className }: { entry: Entry; cla
       by {authorLabel}
       {" · submitted by "}
       {submitterContributor ? (
-        <ContributorProfileLink contributor={submitterContributor} label={entry.submittedBy} />
+        <ContributorProfileLink
+          contributor={submitterContributor}
+          label={entry.submittedBy}
+          role="submitter"
+        />
       ) : (
         <ExternalSubmitterLink entry={entry} />
       )}
@@ -110,6 +155,7 @@ export function ProvenanceAuthorAttribution({
       <ContributorProfileLink
         contributor={verifiedAuthor}
         label={entry.author}
+        role="author"
         className={className}
       />
     );
@@ -120,6 +166,7 @@ export function ProvenanceAuthorAttribution({
       <ContributorProfileLink
         contributor={authorContributor}
         label={entry.author}
+        role="author"
         className={className}
       />
     );
@@ -139,11 +186,29 @@ export function ContributorIdentityLink({
 }) {
   const contributor = findContributorForIdentity(name, profileUrl);
   if (contributor) {
-    return <ContributorProfileLink contributor={contributor} label={name} className={className} />;
+    return (
+      <ContributorProfileLink
+        contributor={contributor}
+        label={name}
+        role="identity"
+        className={className}
+      />
+    );
   }
   if (profileUrl) {
     return (
-      <a href={profileUrl} target="_blank" rel="noreferrer" className={className}>
+      <a
+        href={profileUrl}
+        target="_blank"
+        rel="noreferrer"
+        className={className}
+        onClick={() =>
+          trackEvent(
+            contributorAttributionAnalyticsEvent(),
+            contributorAttributionAnalyticsData("external", "identity"),
+          )
+        }
+      >
         {name}
       </a>
     );

--- a/apps/web/src/components/drop-in-setup.tsx
+++ b/apps/web/src/components/drop-in-setup.tsx
@@ -2,6 +2,10 @@ import * as React from "react";
 import { CopyButton } from "@/components/copy-button";
 import { IntegrationMark, platformMark } from "@/components/integration-marks";
 import { cn } from "@/lib/utils";
+import {
+  dropInSetupCopyAnalyticsData,
+  dropInSetupCopyAnalyticsEvent,
+} from "@/lib/drop-in-setup-cta-events";
 
 interface ClientSetup {
   id: string;
@@ -232,6 +236,8 @@ export function DropInSetup({
               label={`Copy ${active.label} config`}
               size="md"
               className="w-full justify-center"
+              event={dropInSetupCopyAnalyticsEvent()}
+              eventData={dropInSetupCopyAnalyticsData(active.id, active.surface, "config")}
             />
           </div>
         </div>
@@ -243,7 +249,13 @@ export function DropInSetup({
               <code className="flex-1 truncate font-mono text-[11px] text-ink">
                 {active.verify}
               </code>
-              <CopyButton value={active.verify} label="Copy" size="sm" />
+              <CopyButton
+                value={active.verify}
+                label="Copy"
+                size="sm"
+                event={dropInSetupCopyAnalyticsEvent()}
+                eventData={dropInSetupCopyAnalyticsData(active.id, active.surface, "verify")}
+              />
             </div>
           </div>
         )}

--- a/apps/web/src/components/entry-signals-panel.tsx
+++ b/apps/web/src/components/entry-signals-panel.tsx
@@ -14,6 +14,13 @@ import {
   readActiveCommunity,
   writeActiveCommunity,
 } from "@/lib/entry-signals-storage-lib";
+import { trackEvent } from "@/lib/analytics";
+import {
+  entrySignalsCommunityAnalyticsData,
+  entrySignalsCommunityAnalyticsEvent,
+  entrySignalsVoteAnalyticsData,
+  entrySignalsVoteAnalyticsEvent,
+} from "@/lib/entry-signals-panel-cta-events";
 import { cn } from "@/lib/utils";
 
 type SignalState = {
@@ -100,6 +107,15 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
   const toggleVote = async () => {
     const clientId = getClientId(defaultLocalStorage());
     const nextVote = !state.voted;
+    trackEvent(
+      entrySignalsVoteAnalyticsEvent(),
+      entrySignalsVoteAnalyticsData(
+        category,
+        slug,
+        nextVote,
+        Math.max(0, state.voteCount + (nextVote ? 1 : -1)),
+      ),
+    );
     setState((current) => ({
       ...current,
       voted: nextVote,
@@ -130,6 +146,10 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
   const toggleCommunity = async (signalType: keyof CommunityCounts) => {
     const clientId = getClientId(defaultLocalStorage());
     const active = !state.activeCommunity[signalType];
+    trackEvent(
+      entrySignalsCommunityAnalyticsEvent(),
+      entrySignalsCommunityAnalyticsData(category, slug, signalType, active),
+    );
     const nextActive = { ...state.activeCommunity, [signalType]: active };
     writeActiveCommunity(defaultLocalStorage(), targetKey, nextActive);
     setState((current) => ({

--- a/apps/web/src/components/hover-chevrons.tsx
+++ b/apps/web/src/components/hover-chevrons.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  hoverChevronsScrollAnalyticsData,
+  hoverChevronsScrollAnalyticsEvent,
+  type HoverChevronsDirection,
+} from "@/lib/hover-chevrons-cta-events";
 
 /**
  * Hover-revealed left/right scroll chevrons for a horizontal scroller.
@@ -55,6 +61,8 @@ export function HoverChevrons({
   const nudge = (dir: 1 | -1) => {
     const el = scroller();
     if (!el) return;
+    const direction: HoverChevronsDirection = dir === -1 ? "left" : "right";
+    trackEvent(hoverChevronsScrollAnalyticsEvent(), hoverChevronsScrollAnalyticsData(direction));
     el.scrollBy({ left: dir * el.clientWidth * 0.85, behavior: "smooth" });
   };
 

--- a/apps/web/src/lib/contributor-attribution-cta-events-lib.ts
+++ b/apps/web/src/lib/contributor-attribution-cta-events-lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure contributor attribution navigation analytics helpers.
+ *
+ * Maps profile and external attribution egress to privacy-light event names
+ * without embedding display names or free-text URLs.
+ */
+
+export const CONTRIBUTOR_ATTRIBUTION_SURFACE = "contributor-attribution";
+
+export type ContributorAttributionKind = "profile" | "external";
+
+export type ContributorAttributionRole = "author" | "submitter" | "identity";
+
+export function contributorAttributionAnalyticsEvent(): string {
+  return "contributor_attribution_click";
+}
+
+export function contributorAttributionAnalyticsData(
+  kind: ContributorAttributionKind,
+  role: ContributorAttributionRole,
+  contributorSlug: string | null = null,
+) {
+  return {
+    surface: CONTRIBUTOR_ATTRIBUTION_SURFACE,
+    kind,
+    role,
+    contributorSlug,
+  };
+}

--- a/apps/web/src/lib/contributor-attribution-cta-events.ts
+++ b/apps/web/src/lib/contributor-attribution-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Contributor attribution navigation CTA event surface.
+ */
+export {
+  CONTRIBUTOR_ATTRIBUTION_SURFACE,
+  contributorAttributionAnalyticsData,
+  contributorAttributionAnalyticsEvent,
+  type ContributorAttributionKind,
+  type ContributorAttributionRole,
+} from "@/lib/contributor-attribution-cta-events-lib";

--- a/apps/web/src/lib/drop-in-setup-cta-events-lib.ts
+++ b/apps/web/src/lib/drop-in-setup-cta-events-lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure drop-in setup navigation analytics helpers.
+ *
+ * Maps config and verify snippet copy actions to privacy-light event names
+ * without embedding snippet contents.
+ */
+
+export const DROP_IN_SETUP_SURFACE = "drop-in-setup";
+
+export type DropInSetupCopyKind = "config" | "verify";
+
+export type DropInSetupSurfaceType = "mcp-host" | "adapter" | "extension" | "web";
+
+export function dropInSetupCopyAnalyticsEvent(): string {
+  return "drop_in_setup_copy_click";
+}
+
+export function dropInSetupCopyAnalyticsData(
+  clientId: string,
+  surfaceType: DropInSetupSurfaceType,
+  copyKind: DropInSetupCopyKind,
+) {
+  return {
+    surface: DROP_IN_SETUP_SURFACE,
+    clientId,
+    surfaceType,
+    copyKind,
+  };
+}

--- a/apps/web/src/lib/drop-in-setup-cta-events.ts
+++ b/apps/web/src/lib/drop-in-setup-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Drop-in setup navigation CTA event surface.
+ */
+export {
+  DROP_IN_SETUP_SURFACE,
+  dropInSetupCopyAnalyticsData,
+  dropInSetupCopyAnalyticsEvent,
+  type DropInSetupCopyKind,
+  type DropInSetupSurfaceType,
+} from "@/lib/drop-in-setup-cta-events-lib";

--- a/apps/web/src/lib/entry-signals-panel-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-signals-panel-cta-events-lib.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure entry signals panel navigation analytics helpers.
+ *
+ * Maps upvote and community-signal toggles to privacy-light event names
+ * without embedding free-text reasons or client identifiers.
+ */
+
+export const ENTRY_SIGNALS_PANEL_SURFACE = "entry-signals-panel";
+
+export type EntrySignalsCommunityType = "used" | "works" | "broken";
+
+export function entrySignalsEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entrySignalsVoteAnalyticsEvent(): string {
+  return "entry_signals_vote_click";
+}
+
+export function entrySignalsVoteAnalyticsData(
+  category: string,
+  slug: string,
+  voted: boolean,
+  voteCount: number,
+) {
+  return {
+    surface: ENTRY_SIGNALS_PANEL_SURFACE,
+    entry: entrySignalsEntryKey(category, slug),
+    voted,
+    voteCount,
+  };
+}
+
+export function entrySignalsCommunityAnalyticsEvent(): string {
+  return "entry_signals_community_click";
+}
+
+export function entrySignalsCommunityAnalyticsData(
+  category: string,
+  slug: string,
+  signalType: EntrySignalsCommunityType,
+  active: boolean,
+) {
+  return {
+    surface: ENTRY_SIGNALS_PANEL_SURFACE,
+    entry: entrySignalsEntryKey(category, slug),
+    signalType,
+    active,
+  };
+}

--- a/apps/web/src/lib/entry-signals-panel-cta-events.ts
+++ b/apps/web/src/lib/entry-signals-panel-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Entry signals panel navigation CTA event surface.
+ */
+export {
+  ENTRY_SIGNALS_PANEL_SURFACE,
+  entrySignalsCommunityAnalyticsData,
+  entrySignalsCommunityAnalyticsEvent,
+  entrySignalsEntryKey,
+  entrySignalsVoteAnalyticsData,
+  entrySignalsVoteAnalyticsEvent,
+  type EntrySignalsCommunityType,
+} from "@/lib/entry-signals-panel-cta-events-lib";

--- a/apps/web/src/lib/hover-chevrons-cta-events-lib.ts
+++ b/apps/web/src/lib/hover-chevrons-cta-events-lib.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure hover chevrons navigation analytics helpers.
+ *
+ * Maps horizontal scroll nudges to privacy-light event names without embedding
+ * page path or scrolled child content.
+ */
+
+export const HOVER_CHEVRONS_SURFACE = "hover-chevrons";
+
+export type HoverChevronsDirection = "left" | "right";
+
+export function hoverChevronsScrollAnalyticsEvent(): string {
+  return "hover_chevrons_scroll_click";
+}
+
+export function hoverChevronsScrollAnalyticsData(direction: HoverChevronsDirection) {
+  return {
+    surface: HOVER_CHEVRONS_SURFACE,
+    direction,
+  };
+}

--- a/apps/web/src/lib/hover-chevrons-cta-events.ts
+++ b/apps/web/src/lib/hover-chevrons-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Hover chevrons navigation CTA event surface.
+ */
+export {
+  HOVER_CHEVRONS_SURFACE,
+  hoverChevronsScrollAnalyticsData,
+  hoverChevronsScrollAnalyticsEvent,
+  type HoverChevronsDirection,
+} from "@/lib/hover-chevrons-cta-events-lib";

--- a/apps/web/src/lib/platform-chip-cta-events-lib.ts
+++ b/apps/web/src/lib/platform-chip-cta-events-lib.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure platform chip navigation analytics helpers.
+ *
+ * Maps platform browse egress to privacy-light event names without embedding
+ * display labels.
+ */
+
+export const PLATFORM_CHIP_SURFACE = "platform-chip";
+
+export function platformChipAnalyticsEvent(): string {
+  return "platform_chip_click";
+}
+
+export function platformChipAnalyticsData(platform: string) {
+  return {
+    surface: PLATFORM_CHIP_SURFACE,
+    platform,
+  };
+}

--- a/apps/web/src/lib/platform-chip-cta-events.ts
+++ b/apps/web/src/lib/platform-chip-cta-events.ts
@@ -1,0 +1,8 @@
+/**
+ * Platform chip navigation CTA event surface.
+ */
+export {
+  PLATFORM_CHIP_SURFACE,
+  platformChipAnalyticsData,
+  platformChipAnalyticsEvent,
+} from "@/lib/platform-chip-cta-events-lib";

--- a/tests/contributor-attribution-cta-events-lib.test.ts
+++ b/tests/contributor-attribution-cta-events-lib.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTRIBUTOR_ATTRIBUTION_SURFACE,
+  contributorAttributionAnalyticsData,
+  contributorAttributionAnalyticsEvent,
+} from "@/lib/contributor-attribution-cta-events-lib";
+
+describe("contributor attribution cta events lib", () => {
+  it("builds contributor attribution navigation analytics", () => {
+    expect(contributorAttributionAnalyticsEvent()).toBe(
+      "contributor_attribution_click",
+    );
+    expect(
+      contributorAttributionAnalyticsData("profile", "author", "alice"),
+    ).toEqual({
+      surface: CONTRIBUTOR_ATTRIBUTION_SURFACE,
+      kind: "profile",
+      role: "author",
+      contributorSlug: "alice",
+    });
+    expect(
+      contributorAttributionAnalyticsData("external", "submitter"),
+    ).toEqual({
+      surface: CONTRIBUTOR_ATTRIBUTION_SURFACE,
+      kind: "external",
+      role: "submitter",
+      contributorSlug: null,
+    });
+    expect(
+      contributorAttributionAnalyticsData("external", "identity", null),
+    ).toEqual({
+      surface: CONTRIBUTOR_ATTRIBUTION_SURFACE,
+      kind: "external",
+      role: "identity",
+      contributorSlug: null,
+    });
+  });
+});

--- a/tests/drop-in-setup-cta-events-lib.test.ts
+++ b/tests/drop-in-setup-cta-events-lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  DROP_IN_SETUP_SURFACE,
+  dropInSetupCopyAnalyticsData,
+  dropInSetupCopyAnalyticsEvent,
+} from "@/lib/drop-in-setup-cta-events-lib";
+
+describe("drop in setup cta events lib", () => {
+  it("builds drop-in setup navigation analytics", () => {
+    expect(dropInSetupCopyAnalyticsEvent()).toBe("drop_in_setup_copy_click");
+    expect(
+      dropInSetupCopyAnalyticsData("claude-code", "mcp-host", "config"),
+    ).toEqual({
+      surface: DROP_IN_SETUP_SURFACE,
+      clientId: "claude-code",
+      surfaceType: "mcp-host",
+      copyKind: "config",
+    });
+    expect(dropInSetupCopyAnalyticsData("cursor", "adapter", "verify")).toEqual(
+      {
+        surface: DROP_IN_SETUP_SURFACE,
+        clientId: "cursor",
+        surfaceType: "adapter",
+        copyKind: "verify",
+      },
+    );
+  });
+});

--- a/tests/entry-signals-panel-cta-events-lib.test.ts
+++ b/tests/entry-signals-panel-cta-events-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_SIGNALS_PANEL_SURFACE,
+  entrySignalsCommunityAnalyticsData,
+  entrySignalsCommunityAnalyticsEvent,
+  entrySignalsVoteAnalyticsData,
+  entrySignalsVoteAnalyticsEvent,
+} from "@/lib/entry-signals-panel-cta-events-lib";
+
+describe("entry signals panel cta events lib", () => {
+  it("builds entry signals panel navigation analytics", () => {
+    expect(entrySignalsVoteAnalyticsEvent()).toBe("entry_signals_vote_click");
+    expect(entrySignalsVoteAnalyticsData("mcp", "browser", true, 12)).toEqual({
+      surface: ENTRY_SIGNALS_PANEL_SURFACE,
+      entry: "mcp/browser",
+      voted: true,
+      voteCount: 12,
+    });
+    expect(entrySignalsCommunityAnalyticsEvent()).toBe(
+      "entry_signals_community_click",
+    );
+    expect(
+      entrySignalsCommunityAnalyticsData("skills", "foo", "works", false),
+    ).toEqual({
+      surface: ENTRY_SIGNALS_PANEL_SURFACE,
+      entry: "skills/foo",
+      signalType: "works",
+      active: false,
+    });
+  });
+});

--- a/tests/hover-chevrons-cta-events-lib.test.ts
+++ b/tests/hover-chevrons-cta-events-lib.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOVER_CHEVRONS_SURFACE,
+  hoverChevronsScrollAnalyticsData,
+  hoverChevronsScrollAnalyticsEvent,
+} from "@/lib/hover-chevrons-cta-events-lib";
+
+describe("hover chevrons cta events lib", () => {
+  it("builds hover chevrons navigation analytics", () => {
+    expect(hoverChevronsScrollAnalyticsEvent()).toBe(
+      "hover_chevrons_scroll_click",
+    );
+    expect(hoverChevronsScrollAnalyticsData("left")).toEqual({
+      surface: HOVER_CHEVRONS_SURFACE,
+      direction: "left",
+    });
+    expect(hoverChevronsScrollAnalyticsData("right")).toEqual({
+      surface: HOVER_CHEVRONS_SURFACE,
+      direction: "right",
+    });
+  });
+});

--- a/tests/platform-chip-cta-events-lib.test.ts
+++ b/tests/platform-chip-cta-events-lib.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import {
+  PLATFORM_CHIP_SURFACE,
+  platformChipAnalyticsData,
+  platformChipAnalyticsEvent,
+} from "@/lib/platform-chip-cta-events-lib";
+
+describe("platform chip cta events lib", () => {
+  it("builds platform chip navigation analytics", () => {
+    expect(platformChipAnalyticsEvent()).toBe("platform_chip_click");
+    expect(platformChipAnalyticsData("claude-code")).toEqual({
+      surface: PLATFORM_CHIP_SURFACE,
+      platform: "claude-code",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add entry-signals panel CTA events for upvote and used/works/broken toggles
- Add contributor-attribution CTA events for profile and external egress
- Add platform-chip CTA events for `/for/$platform` browse links
- Add drop-in-setup CTA events for config/verify snippet copies
- Add hover-chevrons CTA events for left/right scroll nudges
- Privacy-light payloads only (no display names, snippet contents, or URLs)

Refs #550

## Test plan
- [x] prettier + vitest on five new libs
- [x] verified no file overlap with currently open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)


Made with [Cursor](https://cursor.com)