### PR TITLE
feat(web): add OpenAPI, filter summary, and integration analytics

### DIFF
--- a/apps/web/src/components/commercial-disclosure.tsx
+++ b/apps/web/src/components/commercial-disclosure.tsx
@@ -1,6 +1,11 @@
 import { Link } from "@tanstack/react-router";
 import { ShieldCheck } from "lucide-react";
 import type { ReactNode } from "react";
+import { trackEvent } from "@/lib/analytics";
+import {
+  commercialDisclosureEgressAnalyticsData,
+  commercialDisclosureEgressAnalyticsEvent,
+} from "@/lib/commercial-disclosure-cta-events";
 
 export function CommercialDisclosure({ className = "" }: { className?: string }) {
   return (
@@ -26,7 +31,16 @@ export function CommercialDisclosure({ className = "" }: { className?: string })
           </ul>
           <p className="text-xs">
             Policy details live on{" "}
-            <Link to="/legal" className="text-ink underline-offset-2 hover:underline">
+            <Link
+              to="/legal"
+              className="text-ink underline-offset-2 hover:underline"
+              onClick={() =>
+                trackEvent(
+                  commercialDisclosureEgressAnalyticsEvent(),
+                  commercialDisclosureEgressAnalyticsData("legal"),
+                )
+              }
+            >
               /legal
             </Link>
             .

--- a/apps/web/src/components/filter-summary-bar.tsx
+++ b/apps/web/src/components/filter-summary-bar.tsx
@@ -1,5 +1,12 @@
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  filterSummaryClearAllAnalyticsData,
+  filterSummaryClearAllAnalyticsEvent,
+  filterSummaryClearAnalyticsData,
+  filterSummaryClearAnalyticsEvent,
+} from "@/lib/filter-summary-bar-cta-events";
 
 export interface ActiveFilter {
   key: string;
@@ -30,7 +37,13 @@ export function FilterSummaryBar({
         <button
           key={f.key}
           type="button"
-          onClick={f.onClear}
+          onClick={() => {
+            trackEvent(
+              filterSummaryClearAnalyticsEvent(),
+              filterSummaryClearAnalyticsData(f.key, filters.length),
+            );
+            f.onClear();
+          }}
           className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-background pl-2 pr-1 text-[11px] text-ink hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
           aria-label={`Remove filter ${f.label}: ${f.value}`}
         >
@@ -41,7 +54,13 @@ export function FilterSummaryBar({
       ))}
       <button
         type="button"
-        onClick={onClearAll}
+        onClick={() => {
+          trackEvent(
+            filterSummaryClearAllAnalyticsEvent(),
+            filterSummaryClearAllAnalyticsData(filters.length),
+          );
+          onClearAll();
+        }}
         className="ml-1 inline-flex h-6 items-center gap-1 rounded-full border border-dashed border-border px-2 text-[11px] text-ink-muted hover:bg-surface-2 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
       >
         Clear all

--- a/apps/web/src/components/integration-card.tsx
+++ b/apps/web/src/components/integration-card.tsx
@@ -5,6 +5,10 @@ import { IntegrationMarkTile } from "./integration-marks";
 import { LiveVersionBadge } from "./live-version-badge";
 import { CopyButton } from "./copy-button";
 import { cn } from "@/lib/utils";
+import {
+  integrationCardCopyAnalyticsData,
+  integrationCardCopyAnalyticsEvent,
+} from "@/lib/integration-card-cta-events";
 
 const STATUS_STYLES: Record<Integration["status"], string> = {
   live: "text-trust-trusted",
@@ -74,7 +78,17 @@ export function IntegrationCard({
           <code className="min-w-0 flex-1 truncate font-mono text-[11px] text-ink">
             {surface.snippet}
           </code>
-          <CopyButton value={surface.snippet} label="Copy" size="sm" />
+          <CopyButton
+            value={surface.snippet}
+            label="Copy"
+            size="sm"
+            event={integrationCardCopyAnalyticsEvent()}
+            eventData={integrationCardCopyAnalyticsData(
+              integration.slug,
+              surface.kind,
+              integration.status,
+            )}
+          />
         </div>
       )}
       {!compact && (

--- a/apps/web/src/components/openapi.tsx
+++ b/apps/web/src/components/openapi.tsx
@@ -3,6 +3,15 @@ import { Send, Loader2, ChevronDown } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import type { OpenApiEndpoint, OpenApiParam } from "@/data/openapi";
 import { buildRequestUrl } from "@/lib/openapi-request-lib";
+import { trackEvent } from "@/lib/analytics";
+import {
+  openApiAdvancedToggleAnalyticsData,
+  openApiAdvancedToggleAnalyticsEvent,
+  openApiCopyAnalyticsData,
+  openApiCopyAnalyticsEvent,
+  openApiSendAnalyticsData,
+  openApiSendAnalyticsEvent,
+} from "@/lib/openapi-cta-events";
 import { cn } from "@/lib/utils";
 
 const METHOD_STYLES: Record<OpenApiEndpoint["method"], string> = {
@@ -115,7 +124,12 @@ function CurlBlock({ endpoint }: { endpoint: OpenApiEndpoint }) {
     <div>
       <div className="mb-2 flex items-center justify-between">
         <div className="eyebrow">curl</div>
-        <CopyButton value={curl} label="Copy" />
+        <CopyButton
+          value={curl}
+          label="Copy"
+          event={openApiCopyAnalyticsEvent()}
+          eventData={openApiCopyAnalyticsData(endpoint.id, endpoint.method, "curl")}
+        />
       </div>
       <pre className="overflow-auto rounded-md bg-background p-3 font-mono text-[11px] text-ink">
         <code>{curl}</code>
@@ -137,6 +151,10 @@ export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
   const [showAdvanced, setShowAdvanced] = useState(false);
 
   const send = async () => {
+    trackEvent(
+      openApiSendAnalyticsEvent(),
+      openApiSendAnalyticsData(endpoint.id, endpoint.method, Boolean(endpoint.liveRequest)),
+    );
     setSending(true);
     setResponse(null);
     setError(null);
@@ -213,7 +231,12 @@ export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
         <div>
           <div className="mb-1.5 flex items-center justify-between">
             <div className="eyebrow">Response</div>
-            <CopyButton value={response} label="Copy" />
+            <CopyButton
+              value={response}
+              label="Copy"
+              event={openApiCopyAnalyticsEvent()}
+              eventData={openApiCopyAnalyticsData(endpoint.id, endpoint.method, "response")}
+            />
           </div>
           <pre className="overflow-auto rounded-md border border-border bg-background p-3 font-mono text-[11px] text-ink">
             <code>{response}</code>
@@ -224,7 +247,19 @@ export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
         <>
           <button
             type="button"
-            onClick={() => setShowAdvanced((s) => !s)}
+            onClick={() => {
+              const next = !showAdvanced;
+              trackEvent(
+                openApiAdvancedToggleAnalyticsEvent(),
+                openApiAdvancedToggleAnalyticsData(
+                  endpoint.id,
+                  endpoint.method,
+                  next,
+                  endpoint.clientExamples?.length ?? 0,
+                ),
+              );
+              setShowAdvanced(next);
+            }}
             className="inline-flex items-center gap-1 text-[11px] text-ink-muted hover:text-ink"
           >
             <ChevronDown

--- a/apps/web/src/lib/commercial-disclosure-cta-events-lib.ts
+++ b/apps/web/src/lib/commercial-disclosure-cta-events-lib.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure commercial disclosure navigation analytics helpers.
+ *
+ * Maps legal-policy egress to privacy-light event names without embedding
+ * disclosure copy.
+ */
+
+export const COMMERCIAL_DISCLOSURE_SURFACE = "commercial-disclosure";
+
+export type CommercialDisclosureDestination = "legal";
+
+export function commercialDisclosureEgressAnalyticsEvent(): string {
+  return "commercial_disclosure_egress_click";
+}
+
+export function commercialDisclosureEgressAnalyticsData(
+  destination: CommercialDisclosureDestination,
+) {
+  return {
+    surface: COMMERCIAL_DISCLOSURE_SURFACE,
+    destination,
+  };
+}

--- a/apps/web/src/lib/commercial-disclosure-cta-events.ts
+++ b/apps/web/src/lib/commercial-disclosure-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Commercial disclosure navigation CTA event surface.
+ */
+export {
+  COMMERCIAL_DISCLOSURE_SURFACE,
+  commercialDisclosureEgressAnalyticsData,
+  commercialDisclosureEgressAnalyticsEvent,
+  type CommercialDisclosureDestination,
+} from "@/lib/commercial-disclosure-cta-events-lib";

--- a/apps/web/src/lib/filter-summary-bar-cta-events-lib.ts
+++ b/apps/web/src/lib/filter-summary-bar-cta-events-lib.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure filter summary bar navigation analytics helpers.
+ *
+ * Maps per-filter clear and clear-all actions to privacy-light event names
+ * without embedding filter labels or free-text values.
+ */
+
+export const FILTER_SUMMARY_BAR_SURFACE = "filter-summary-bar";
+
+export function filterSummaryClearAnalyticsEvent(): string {
+  return "filter_summary_clear_click";
+}
+
+export function filterSummaryClearAnalyticsData(filterKey: string, activeCount: number) {
+  return {
+    surface: FILTER_SUMMARY_BAR_SURFACE,
+    filterKey,
+    activeCount,
+  };
+}
+
+export function filterSummaryClearAllAnalyticsEvent(): string {
+  return "filter_summary_clear_all_click";
+}
+
+export function filterSummaryClearAllAnalyticsData(activeCount: number) {
+  return {
+    surface: FILTER_SUMMARY_BAR_SURFACE,
+    activeCount,
+  };
+}

--- a/apps/web/src/lib/filter-summary-bar-cta-events.ts
+++ b/apps/web/src/lib/filter-summary-bar-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Filter summary bar navigation CTA event surface.
+ */
+export {
+  FILTER_SUMMARY_BAR_SURFACE,
+  filterSummaryClearAllAnalyticsData,
+  filterSummaryClearAllAnalyticsEvent,
+  filterSummaryClearAnalyticsData,
+  filterSummaryClearAnalyticsEvent,
+} from "@/lib/filter-summary-bar-cta-events-lib";

--- a/apps/web/src/lib/integration-card-cta-events-lib.ts
+++ b/apps/web/src/lib/integration-card-cta-events-lib.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure integration card navigation analytics helpers.
+ *
+ * Maps surface snippet copy actions to privacy-light event names without
+ * embedding snippet contents or taglines.
+ */
+
+export const INTEGRATION_CARD_SURFACE = "integration-card";
+
+export function integrationCardCopyAnalyticsEvent(): string {
+  return "integration_card_copy_click";
+}
+
+export function integrationCardCopyAnalyticsData(
+  integrationSlug: string,
+  surfaceKind: string,
+  status: string,
+) {
+  return {
+    surface: INTEGRATION_CARD_SURFACE,
+    integrationSlug,
+    surfaceKind,
+    status,
+  };
+}

--- a/apps/web/src/lib/integration-card-cta-events.ts
+++ b/apps/web/src/lib/integration-card-cta-events.ts
@@ -1,0 +1,8 @@
+/**
+ * Integration card navigation CTA event surface.
+ */
+export {
+  INTEGRATION_CARD_SURFACE,
+  integrationCardCopyAnalyticsData,
+  integrationCardCopyAnalyticsEvent,
+} from "@/lib/integration-card-cta-events-lib";

--- a/apps/web/src/lib/openapi-cta-events-lib.ts
+++ b/apps/web/src/lib/openapi-cta-events-lib.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure OpenAPI docs playground navigation analytics helpers.
+ *
+ * Maps curl copy, send/sample, response copy, and client-example toggles to
+ * privacy-light event names without embedding request bodies or response text.
+ */
+
+export const OPENAPI_SURFACE = "openapi";
+
+export type OpenApiCopyKind = "curl" | "response";
+
+export function openApiCopyAnalyticsEvent(): string {
+  return "openapi_copy_click";
+}
+
+export function openApiCopyAnalyticsData(
+  endpointId: string,
+  method: string,
+  copyKind: OpenApiCopyKind,
+) {
+  return {
+    surface: OPENAPI_SURFACE,
+    endpointId,
+    method,
+    copyKind,
+  };
+}
+
+export function openApiSendAnalyticsEvent(): string {
+  return "openapi_send_click";
+}
+
+export function openApiSendAnalyticsData(endpointId: string, method: string, liveRequest: boolean) {
+  return {
+    surface: OPENAPI_SURFACE,
+    endpointId,
+    method,
+    liveRequest,
+  };
+}
+
+export function openApiAdvancedToggleAnalyticsEvent(): string {
+  return "openapi_advanced_toggle_click";
+}
+
+export function openApiAdvancedToggleAnalyticsData(
+  endpointId: string,
+  method: string,
+  open: boolean,
+  exampleCount: number,
+) {
+  return {
+    surface: OPENAPI_SURFACE,
+    endpointId,
+    method,
+    open,
+    exampleCount,
+  };
+}

--- a/apps/web/src/lib/openapi-cta-events.ts
+++ b/apps/web/src/lib/openapi-cta-events.ts
@@ -1,0 +1,13 @@
+/**
+ * OpenAPI playground navigation CTA event surface.
+ */
+export {
+  OPENAPI_SURFACE,
+  openApiAdvancedToggleAnalyticsData,
+  openApiAdvancedToggleAnalyticsEvent,
+  openApiCopyAnalyticsData,
+  openApiCopyAnalyticsEvent,
+  openApiSendAnalyticsData,
+  openApiSendAnalyticsEvent,
+  type OpenApiCopyKind,
+} from "@/lib/openapi-cta-events-lib";

--- a/tests/commercial-disclosure-cta-events-lib.test.ts
+++ b/tests/commercial-disclosure-cta-events-lib.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMMERCIAL_DISCLOSURE_SURFACE,
+  commercialDisclosureEgressAnalyticsData,
+  commercialDisclosureEgressAnalyticsEvent,
+} from "@/lib/commercial-disclosure-cta-events-lib";
+
+describe("commercial disclosure cta events lib", () => {
+  it("builds commercial disclosure navigation analytics", () => {
+    expect(commercialDisclosureEgressAnalyticsEvent()).toBe(
+      "commercial_disclosure_egress_click",
+    );
+    expect(commercialDisclosureEgressAnalyticsData("legal")).toEqual({
+      surface: COMMERCIAL_DISCLOSURE_SURFACE,
+      destination: "legal",
+    });
+  });
+});

--- a/tests/filter-summary-bar-cta-events-lib.test.ts
+++ b/tests/filter-summary-bar-cta-events-lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  FILTER_SUMMARY_BAR_SURFACE,
+  filterSummaryClearAllAnalyticsData,
+  filterSummaryClearAllAnalyticsEvent,
+  filterSummaryClearAnalyticsData,
+  filterSummaryClearAnalyticsEvent,
+} from "@/lib/filter-summary-bar-cta-events-lib";
+
+describe("filter summary bar cta events lib", () => {
+  it("builds filter summary bar navigation analytics", () => {
+    expect(filterSummaryClearAnalyticsEvent()).toBe(
+      "filter_summary_clear_click",
+    );
+    expect(filterSummaryClearAnalyticsData("platform", 3)).toEqual({
+      surface: FILTER_SUMMARY_BAR_SURFACE,
+      filterKey: "platform",
+      activeCount: 3,
+    });
+    expect(filterSummaryClearAllAnalyticsEvent()).toBe(
+      "filter_summary_clear_all_click",
+    );
+    expect(filterSummaryClearAllAnalyticsData(4)).toEqual({
+      surface: FILTER_SUMMARY_BAR_SURFACE,
+      activeCount: 4,
+    });
+  });
+});

--- a/tests/integration-card-cta-events-lib.test.ts
+++ b/tests/integration-card-cta-events-lib.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  INTEGRATION_CARD_SURFACE,
+  integrationCardCopyAnalyticsData,
+  integrationCardCopyAnalyticsEvent,
+} from "@/lib/integration-card-cta-events-lib";
+
+describe("integration card cta events lib", () => {
+  it("builds integration card navigation analytics", () => {
+    expect(integrationCardCopyAnalyticsEvent()).toBe(
+      "integration_card_copy_click",
+    );
+    expect(
+      integrationCardCopyAnalyticsData("mcp-server", "mcp", "live"),
+    ).toEqual({
+      surface: INTEGRATION_CARD_SURFACE,
+      integrationSlug: "mcp-server",
+      surfaceKind: "mcp",
+      status: "live",
+    });
+  });
+});

--- a/tests/openapi-cta-events-lib.test.ts
+++ b/tests/openapi-cta-events-lib.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  OPENAPI_SURFACE,
+  openApiAdvancedToggleAnalyticsData,
+  openApiAdvancedToggleAnalyticsEvent,
+  openApiCopyAnalyticsData,
+  openApiCopyAnalyticsEvent,
+  openApiSendAnalyticsData,
+  openApiSendAnalyticsEvent,
+} from "@/lib/openapi-cta-events-lib";
+
+describe("openapi cta events lib", () => {
+  it("builds openapi playground navigation analytics", () => {
+    expect(openApiCopyAnalyticsEvent()).toBe("openapi_copy_click");
+    expect(openApiCopyAnalyticsData("list-entries", "GET", "curl")).toEqual({
+      surface: OPENAPI_SURFACE,
+      endpointId: "list-entries",
+      method: "GET",
+      copyKind: "curl",
+    });
+    expect(openApiCopyAnalyticsData("list-entries", "GET", "response")).toEqual(
+      {
+        surface: OPENAPI_SURFACE,
+        endpointId: "list-entries",
+        method: "GET",
+        copyKind: "response",
+      },
+    );
+    expect(openApiSendAnalyticsEvent()).toBe("openapi_send_click");
+    expect(openApiSendAnalyticsData("search", "GET", true)).toEqual({
+      surface: OPENAPI_SURFACE,
+      endpointId: "search",
+      method: "GET",
+      liveRequest: true,
+    });
+    expect(openApiAdvancedToggleAnalyticsEvent()).toBe(
+      "openapi_advanced_toggle_click",
+    );
+    expect(
+      openApiAdvancedToggleAnalyticsData("search", "GET", true, 2),
+    ).toEqual({
+      surface: OPENAPI_SURFACE,
+      endpointId: "search",
+      method: "GET",
+      open: true,
+      exampleCount: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add OpenAPI playground CTA events for curl copy, send/sample, response copy, and client-example toggle
- Add filter-summary-bar CTA events for per-filter clear and clear-all
- Add integration-card CTA events for surface snippet copy
- Add commercial-disclosure CTA events for `/legal` egress
- Privacy-light payloads only (no request bodies, responses, or filter values)

Refs #550

### Why no new issue
Continues the Growth Sprint 1 (#550) decision-layer analytics work already merged in the same pattern today (#5064, #5066, #5068): pure `*-cta-events-lib` helpers + thin wrappers + component `trackEvent` wiring. Splitting each surface into its own `-lib` / wrapper pair follows the established repo convention for coverage isolation.

## Test plan
- [x] prettier + vitest on four new libs
- [x] verified no file overlap with currently open PRs
- [x] CI green (validate-web, coverage, codecov/patch, codecov/project, required-pr-gate)