### PR TITLE
test(mcp): cover response-builder default branches in registry-handlers-lib

### DIFF
--- a/tests/mcp-registry-handlers-lib.test.ts
+++ b/tests/mcp-registry-handlers-lib.test.ts
@@ -20,7 +20,9 @@ import {
   buildSearchRegistryResponse,
   buildTrendingResourceResponse,
   computeNextOffset,
+  mapRecentUpdateEntries,
   paginateEntries,
+  resolveGraphRelatedEntries,
   sortEntriesByUpdatedAt,
 } from "../packages/mcp/src/registry-handlers-lib.js";
 
@@ -9305,5 +9307,122 @@ describe("registry-handlers-lib response builders", () => {
       entryUpdatedAt,
     });
     expect(response.kind).toBe("registry-recent");
+  });
+});
+
+describe("resource/feed builders default missing payload fields", () => {
+  it("defaults trending resource fields for an empty payload", () => {
+    const response = buildTrendingResourceResponse({
+      payload: {},
+      entries: [],
+    });
+    expect(response.schemaVersion).toBe(1);
+    expect(response.category).toBe("all");
+    expect(response.platform).toBe("all");
+    expect(response.signalsAvailable).toBeNull();
+  });
+
+  it("nulls jobs totalAvailable when the payload omits a numeric count", () => {
+    expect(
+      buildJobsActiveResourceResponse({ payload: {}, entries: [] })
+        .totalAvailable,
+    ).toBeNull();
+  });
+
+  it("falls back to an error uri for an empty resource uri", () => {
+    const payload = buildRegistryResourcePayload(
+      "",
+      { a: 1 },
+      "application/json",
+      (value) => value,
+    );
+    expect(payload.contents[0].uri).toBe("heyclaude://error");
+  });
+
+  it("defaults empty categories/platforms for a bare feed index", () => {
+    const response = buildDistributionFeedsResponse({
+      manifest: { schemaVersion: 1, generatedAt: "2026-01-01", artifacts: [] },
+      feedIndex: {},
+      platformFeedSlug: (platform) => platform,
+    });
+    expect(response.categories).toEqual([]);
+    expect(response.platforms).toEqual([]);
+  });
+});
+
+describe("list/graph builders default missing fields", () => {
+  it("blanks search facets when args and facets are absent", () => {
+    const response = buildSearchRegistryResponse({
+      args: {},
+      entries: [],
+      trustFilters: {},
+    });
+    expect(response.query).toBe("");
+    expect(response.category).toBe("");
+    expect(response.platform).toBe("");
+    expect(response.tag).toBe("");
+  });
+
+  it("computes category-page nextOffset for last and non-last pages", () => {
+    expect(
+      buildCategoryEntriesPageResponse({
+        entries: [{}, {}],
+        offset: 0,
+        limit: 5,
+        page: [{}, {}],
+      }).nextOffset,
+    ).toBeNull();
+    expect(
+      buildCategoryEntriesPageResponse({
+        entries: [{}, {}, {}],
+        offset: 0,
+        limit: 2,
+        page: [{}, {}],
+      }).nextOffset,
+    ).toBe(2);
+  });
+
+  it("breaks equal-date sort ties by title with a blank fallback", () => {
+    const sorted = sortEntriesByUpdatedAt(
+      [{ title: undefined }, { title: "B" }],
+      () => "2026-01-01",
+    );
+    expect(sorted.map((entry) => entry.title)).toEqual([undefined, "B"]);
+  });
+
+  it("blanks the recent-updates category when omitted", () => {
+    expect(
+      buildRecentUpdatesResponse({ since: "2026-01-01", entries: [] }).category,
+    ).toBe("");
+  });
+
+  it("labels update kind from the presence of an upstream timestamp", () => {
+    const kinds = mapRecentUpdateEntries(
+      [{ repoUpdatedAt: "2026-01-01" }, {}],
+      () => ({}),
+      () => "2026-01-01",
+    ).map((entry) => entry.updateKind);
+    expect(kinds).toEqual(["upstream_update", "added"]);
+  });
+
+  it("returns null related entries when the graph row has none", () => {
+    expect(
+      resolveGraphRelatedEntries({
+        graphRow: null,
+        searchIndex: [],
+        toEntrySummary: (entry) => entry,
+        limit: 5,
+      }),
+    ).toBeNull();
+  });
+
+  it("drops unresolved keys and defaults missing related reasons", () => {
+    const related = resolveGraphRelatedEntries({
+      graphRow: { related: [{ key: "a:b" }, { key: "x:y" }] },
+      searchIndex: [{ category: "a", slug: "b" }],
+      toEntrySummary: (entry) => ({ id: entry.slug }),
+      limit: 5,
+    });
+    expect(related).toEqual([{ id: "b", relatedReasons: [] }]);
   });
 });


### PR DESCRIPTION
Covers the missing-payload default branches across `registry-handlers-lib` response builders: trending `schemaVersion ?? 1`/`category`/`platform`/`signalsAvailable`, jobs `totalAvailable`, empty resource-uri `heyclaude://error`, bare feed-index `categories`/`platforms`, blank search facets, category-page `nextOffset` (last vs non-last), equal-date sort tie-break with blank-title fallback, blank recent-updates category, `updateKind` from upstream-timestamp presence, null graph-related result, and dropped unresolved keys with defaulted related reasons. Lib branch coverage 75.0% -> 96.4% (81/84). Test-only change.