### PR TITLE
test(web): cover divergence and banner branches in compare-curated-summary-lib

### DIFF
--- a/tests/compare-curated-summary-lib.test.ts
+++ b/tests/compare-curated-summary-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   compareCuratedActionBannerText,
+  compareCuratedBannerTexts,
   compareCuratedDecisionBannerText,
   compareCuratedSummary,
 } from "../apps/web/src/lib/compare-curated-summary-lib";
@@ -4809,5 +4810,41 @@ describe("compare-curated-summary-lib", () => {
         comparedCount: 1,
       }),
     ).toBeNull();
+  });
+});
+
+describe("compare-curated-summary-lib divergence and banner branches", () => {
+  it("compareCuratedActionBannerText returns copy when actions diverge", () => {
+    expect(compareCuratedActionBannerText(true)).toContain("Next steps differ");
+  });
+
+  it("compareCuratedDecisionBannerText uses the singular for one diverging signal", () => {
+    const text = compareCuratedDecisionBannerText({
+      divergingCount: 1,
+      divergingLabels: ["trust"],
+      comparedCount: 2,
+    });
+    expect(text).toBe("1 trust signal differ across this comparison (trust).");
+  });
+
+  it("compareCuratedDecisionBannerText uses the plural for multiple diverging signals", () => {
+    const text = compareCuratedDecisionBannerText({
+      divergingCount: 2,
+      divergingLabels: ["trust", "safety"],
+      comparedCount: 2,
+    });
+    expect(text).toBe(
+      "2 trust signals differ across this comparison (trust, safety).",
+    );
+  });
+
+  it("compareCuratedBannerTexts returns an array of banner strings", () => {
+    const entries = [
+      { category: "mcp", slug: "a", title: "A" },
+      { category: "mcp", slug: "b", title: "B" },
+    ];
+    const texts = compareCuratedBannerTexts(entries as never);
+    expect(Array.isArray(texts)).toBe(true);
+    expect(texts.every((text) => typeof text === "string")).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Covers the untested divergence/banner branches in `apps/web/src/lib/compare-curated-summary-lib.ts`. The existing suite only passed `divergingCount: 0` and `actionsDiverge: false`, so every non-null banner path plus the whole `compareCuratedBannerTexts` export was uncovered.

New cases:
- `compareCuratedActionBannerText` — returns the "Next steps differ" copy when actions diverge.
- `compareCuratedDecisionBannerText` — singular wording for one diverging signal and plural wording for multiple.
- `compareCuratedBannerTexts` — returns an array of banner strings.

## Coverage

Scoped to the file: statements **60% → 100%**, branch **33.33% → 100%**, lines **50% → 100%**.

## Validation

- `pnpm exec vitest run tests/compare-curated-summary-lib.test.ts` — 805 passed
- `pnpm exec prettier --check tests/compare-curated-summary-lib.test.ts`
- Test-only change; no source or generated-artifact edits.
