### PR TITLE
test(web): cover global fetch fallback and asset error branches in mcp-artifact-readers-lib

### DIFF
--- a/tests/mcp-artifact-readers-lib.test.ts
+++ b/tests/mcp-artifact-readers-lib.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/content.server", () => ({
   loadTextDataFile: vi.fn(),
@@ -15,6 +15,10 @@ describe("mcp-artifact-readers-lib", () => {
   beforeEach(() => {
     loadTextDataFileMock.mockReset();
     loadJsonDataFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("rejects unsafe artifact paths before loading or falling back to assets", async () => {
@@ -69,5 +73,40 @@ describe("mcp-artifact-readers-lib", () => {
     });
     expect(loadJsonDataFileMock).toHaveBeenCalledWith("search-index.json");
     expect(assetsFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the global fetch when no assets binding is provided", async () => {
+    loadTextDataFileMock.mockRejectedValue(new Error("local file missing"));
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      expect(url).toBe("https://heyclau.de/data/search-index.json");
+      return new Response("global-fetch-text", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const readers = createMcpArtifactReaders("https://heyclau.de");
+
+    await expect(readers.readTextArtifact("search-index.json")).resolves.toBe(
+      "global-fetch-text",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the asset fallback response is not ok", async () => {
+    loadTextDataFileMock.mockRejectedValue(new Error("local file missing"));
+    const assetsFetch = vi.fn(
+      async () => new Response("not found", { status: 404 }),
+    );
+    const readers = createMcpArtifactReaders("https://heyclau.de", {
+      fetch: assetsFetch,
+    });
+
+    await expect(readers.readTextArtifact("search-index.json")).rejects.toThrow(
+      /Failed to load search-index\.json asset \(404\)/,
+    );
   });
 });


### PR DESCRIPTION
## What

Brings `apps/web/src/lib/mcp-artifact-readers-lib.ts` to **100% branch coverage** (was 50%, 2/4) by covering its two previously-untested branches:

- `loadAssetText` falling back to the **global `fetch`** when no `assets` binding is passed to `createMcpArtifactReaders` (the `assets?.fetch(...) ?? fetch(...)` optional-chaining branch — every existing test always supplied an `assets` binding).
- `loadAssetText` throwing `"Failed to load <file> asset (<status>)"` when the asset fallback response is **not ok** (every existing test only exercised the `ok: true` path).

## Notes

- **Test-only change** — no source behaviour is modified.
- Mirrors the existing mock style in this suite (`vi.stubGlobal("fetch", ...)` + `afterEach(() => vi.unstubAllGlobals())`, same pattern as `compare-entry-actions.test.ts`; non-ok `Response` shape matches the file's existing JSON-fallback test).
- Verified locally: `vitest run tests/mcp-artifact-readers-lib.test.ts --coverage` → 5 tests pass, 100% statements/branches/functions/lines on the source; `prettier --check` and `pnpm --filter web type-check` clean.