### PR TITLE
test(mcp): cover duplicate search, review actions, and guidance in submissions-lib

### DIFF
--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -369,3 +369,104 @@ describe("submissions re-export compatibility", () => {
     );
   });
 });
+
+describe("submissions-lib duplicate search matching", () => {
+  const entry = indexedEntry({
+    brandDomain: "asana.com",
+    githubUrl: "https://github.com/x/y",
+    canonicalUrl: "https://heyclau.de/mcp/airtable",
+  });
+
+  it("matches on slug, title, brand domain, and source url", () => {
+    expect(
+      searchDuplicateEntries([entry], {
+        category: "mcp",
+        slug: "airtable-mcp-server",
+      }).matches[0].reasons,
+    ).toEqual(["slug"]);
+    expect(
+      searchDuplicateEntries([entry], {
+        category: "mcp",
+        title: "Airtable MCP",
+      }).matches[0].reasons,
+    ).toEqual(["title"]);
+    expect(
+      searchDuplicateEntries([entry], {
+        category: "mcp",
+        brandDomain: "asana.com",
+      }).matches[0].reasons,
+    ).toEqual(["brand_domain"]);
+    expect(
+      searchDuplicateEntries([entry], {
+        category: "mcp",
+        sourceUrls: ["https://github.com/x/y"],
+      }).matches[0].reasons,
+    ).toEqual(["source_url"]);
+  });
+
+  it("skips entries in other categories and reports when nothing matches", () => {
+    expect(
+      searchDuplicateEntries([entry], {
+        category: "skills",
+        slug: "airtable-mcp-server",
+      }).count,
+    ).toBe(0);
+    expect(
+      searchDuplicateEntries([entry], { category: "mcp", slug: "other" })
+        .reviewNote,
+    ).toMatch(/No obvious registry duplicate/);
+  });
+});
+
+describe("submissions-lib review recommendations", () => {
+  it("recommends opening a review PR for a clean valid draft", () => {
+    expect(
+      reviewSubmissionDraftFromSpec(
+        submissionSpec,
+        { fields: validMcpFields },
+        [],
+      ).recommendedAction,
+    ).toBe("open_review_pr");
+  });
+
+  it("flags a possible duplicate when the index has a slug match", () => {
+    expect(
+      reviewSubmissionDraftFromSpec(
+        submissionSpec,
+        { fields: validMcpFields },
+        [indexedEntry({ slug: "example-protocol-mcp" })],
+      ).recommendedAction,
+    ).toBe("review_possible_duplicate");
+  });
+
+  it("requires fixes when the draft fails validation", () => {
+    expect(
+      reviewSubmissionDraftFromSpec(
+        submissionSpec,
+        { fields: { category: "mcp", name: "x" } },
+        [],
+      ).recommendedAction,
+    ).toBe("fix_required_fields");
+  });
+});
+
+describe("submissions-lib category guidance", () => {
+  it("returns guidance for a single category and for all categories", () => {
+    expect(
+      getCategorySubmissionGuidanceFromSpec(submissionSpec, { category: "mcp" })
+        .categories[0].category,
+    ).toBe("mcp");
+    expect(
+      getCategorySubmissionGuidanceFromSpec(submissionSpec, {}).categories
+        .length,
+    ).toBe(Object.keys(submissionSpec.categories).length);
+  });
+
+  it("returns a not-found error for an unknown guidance category", () => {
+    expect(
+      getCategorySubmissionGuidanceFromSpec(submissionSpec, {
+        category: "nope",
+      }),
+    ).toMatchObject({ ok: false, error: { code: "not_found" } });
+  });
+});


### PR DESCRIPTION
Adds focused coverage for the previously-untested submissions-lib review surface: `searchDuplicateEntries` matching by slug/title/brand_domain/source_url, the cross-category skip, and the no-match review note; `reviewSubmissionDraftFromSpec` recommendedAction across clean-valid, duplicate-found, and invalid drafts; and `getCategorySubmissionGuidanceFromSpec` for a single category, all categories, and the unknown-category not-found path. Test-only change.