### PR TITLE
feat(web): add trending, citation facts, and validators analytics

### DIFF
--- a/apps/web/src/components/citation-facts.tsx
+++ b/apps/web/src/components/citation-facts.tsx
@@ -1,6 +1,11 @@
 import { entryCitationFacts } from "@heyclaude/registry";
 
 import type { Entry } from "@/types/registry";
+import { trackEvent, outboundHost } from "@/lib/analytics";
+import {
+  citationFactsEgressAnalyticsData,
+  citationFactsEgressAnalyticsEvent,
+} from "@/lib/citation-facts-cta-events";
 
 // `Robots` is a crawler directive, not a human/AI citation fact — keep it in the
 // machine LLMS endpoint but hide it from the visible block.
@@ -31,6 +36,17 @@ export function CitationFacts({ entry }: { entry: Entry }) {
                 href={value}
                 target="_blank"
                 rel="noreferrer"
+                onClick={() =>
+                  trackEvent(
+                    citationFactsEgressAnalyticsEvent(),
+                    citationFactsEgressAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      label,
+                      outboundHost(value),
+                    ),
+                  )
+                }
                 className="text-ink underline-offset-2 hover:underline"
               >
                 {value}

--- a/apps/web/src/lib/citation-facts-cta-events-lib.ts
+++ b/apps/web/src/lib/citation-facts-cta-events-lib.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure citation-facts egress analytics helpers.
+ *
+ * Maps single-URL citation fact clicks to privacy-light event names without
+ * embedding full URLs, author names, or free-text fact values.
+ */
+
+export const CITATION_FACTS_SURFACE = "citation-facts";
+
+export function citationFactLabelKey(label: string): string {
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function citationFactsEgressAnalyticsEvent(): string {
+  return "citation_facts_egress_click";
+}
+
+export function citationFactsEgressAnalyticsData(
+  category: string,
+  slug: string,
+  label: string,
+  host: string,
+) {
+  return {
+    entry: `${category}/${slug}`,
+    surface: CITATION_FACTS_SURFACE,
+    factLabel: citationFactLabelKey(label),
+    host,
+  };
+}

--- a/apps/web/src/lib/citation-facts-cta-events.ts
+++ b/apps/web/src/lib/citation-facts-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Citation facts egress CTA event surface.
+ */
+export {
+  CITATION_FACTS_SURFACE,
+  citationFactLabelKey,
+  citationFactsEgressAnalyticsData,
+  citationFactsEgressAnalyticsEvent,
+} from "@/lib/citation-facts-cta-events-lib";

--- a/apps/web/src/lib/trending-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/trending-entry-cta-events-lib.ts
@@ -1,14 +1,18 @@
 /**
- * Pure trending page entry egress analytics helpers.
+ * Pure trending page navigation analytics helpers.
  *
- * Maps trending list navigation below the podium to privacy-light event names
- * without embedding entry titles or signal reason copy.
+ * Maps trending list navigation, category filter chips, reset, RSS, and footer
+ * cross-links to privacy-light event names without embedding entry titles or
+ * signal reason copy.
  */
 
 export const TRENDING_LIST_SURFACE = "trending-list";
+export const TRENDING_PAGE_SURFACE = "trending-page";
 
 export type TrendingListWindow = "7d" | "30d" | "all";
 export type TrendingListMode = "live" | "fallback" | "unavailable";
+export type TrendingChromeDestination = "rss" | "brief" | "browse";
+export type TrendingChromePlacement = "header" | "footer" | "empty";
 
 export function trendingListEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;
@@ -32,6 +36,67 @@ export function trendingListEntryAnalyticsData(
     surface: TRENDING_LIST_SURFACE,
     rank,
     listCount,
+    window,
+    categoryFilter,
+    mode,
+  };
+}
+
+export function trendingCategoryFilterAnalyticsEvent(): string {
+  return "trending_category_filter_click";
+}
+
+export function trendingCategoryFilterAnalyticsData(
+  categoryFilter: string,
+  active: boolean,
+  matchCount: number,
+  totalCount: number,
+  window: TrendingListWindow,
+  mode: TrendingListMode,
+) {
+  return {
+    surface: TRENDING_PAGE_SURFACE,
+    categoryFilter,
+    active,
+    matchCount,
+    totalCount,
+    window,
+    mode,
+  };
+}
+
+export function trendingFilterResetAnalyticsEvent(): string {
+  return "trending_filter_reset_click";
+}
+
+export function trendingFilterResetAnalyticsData(
+  previousCategoryFilter: string,
+  previousWindow: TrendingListWindow,
+  mode: TrendingListMode,
+) {
+  return {
+    surface: TRENDING_PAGE_SURFACE,
+    previousCategoryFilter,
+    previousWindow,
+    mode,
+  };
+}
+
+export function trendingChromeAnalyticsEvent(): string {
+  return "trending_chrome_click";
+}
+
+export function trendingChromeAnalyticsData(
+  destination: TrendingChromeDestination,
+  placement: TrendingChromePlacement,
+  window: TrendingListWindow,
+  categoryFilter: string,
+  mode: TrendingListMode,
+) {
+  return {
+    surface: TRENDING_PAGE_SURFACE,
+    destination,
+    placement,
     window,
     categoryFilter,
     mode,

--- a/apps/web/src/lib/trending-entry-cta-events.ts
+++ b/apps/web/src/lib/trending-entry-cta-events.ts
@@ -1,11 +1,20 @@
 /**
- * Trending page entry egress CTA event surface.
+ * Trending page navigation CTA event surface.
  */
 export {
   TRENDING_LIST_SURFACE,
+  TRENDING_PAGE_SURFACE,
+  trendingCategoryFilterAnalyticsData,
+  trendingCategoryFilterAnalyticsEvent,
+  trendingChromeAnalyticsData,
+  trendingChromeAnalyticsEvent,
+  trendingFilterResetAnalyticsData,
+  trendingFilterResetAnalyticsEvent,
   trendingListEntryAnalyticsData,
   trendingListEntryAnalyticsEvent,
   trendingListEntryKey,
+  type TrendingChromeDestination,
+  type TrendingChromePlacement,
   type TrendingListMode,
   type TrendingListWindow,
 } from "@/lib/trending-entry-cta-events-lib";

--- a/apps/web/src/lib/validators-expertise-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-expertise-cta-events-lib.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure validators expertise filter analytics helpers.
+ *
+ * Maps coverage-area filter chip clicks to privacy-light event names without
+ * embedding coverage copy or entry titles.
+ */
+
+export const VALIDATORS_EXPERTISE_SURFACE = "validators-expertise";
+
+export function validatorsExpertiseFilterAnalyticsEvent(): string {
+  return "validators_expertise_filter_click";
+}
+
+export function validatorsExpertiseFilterAnalyticsData(
+  expertiseId: string,
+  matchCount: number,
+  expertiseCount: number,
+) {
+  return {
+    surface: VALIDATORS_EXPERTISE_SURFACE,
+    expertiseId,
+    matchCount,
+    expertiseCount,
+  };
+}

--- a/apps/web/src/lib/validators-expertise-cta-events.ts
+++ b/apps/web/src/lib/validators-expertise-cta-events.ts
@@ -1,0 +1,8 @@
+/**
+ * Validators expertise filter CTA event surface.
+ */
+export {
+  VALIDATORS_EXPERTISE_SURFACE,
+  validatorsExpertiseFilterAnalyticsData,
+  validatorsExpertiseFilterAnalyticsEvent,
+} from "@/lib/validators-expertise-cta-events-lib";

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -18,6 +18,12 @@ import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { trackEvent } from "@/lib/analytics";
 import {
+  trendingCategoryFilterAnalyticsData,
+  trendingCategoryFilterAnalyticsEvent,
+  trendingChromeAnalyticsData,
+  trendingChromeAnalyticsEvent,
+  trendingFilterResetAnalyticsData,
+  trendingFilterResetAnalyticsEvent,
   trendingListEntryAnalyticsData,
   trendingListEntryAnalyticsEvent,
 } from "@/lib/trending-entry-cta-events";
@@ -232,6 +238,37 @@ function TrendingPage() {
 
   const shareUrl = `/trending${sp.category ? `?category=${sp.category}` : ""}`;
 
+  const trackCategoryFilter = (categoryFilter: string, active: boolean, matchCount: number) => {
+    trackEvent(
+      trendingCategoryFilterAnalyticsEvent(),
+      trendingCategoryFilterAnalyticsData(
+        categoryFilter,
+        active,
+        matchCount,
+        allRows.length,
+        sp.window,
+        mode,
+      ),
+    );
+  };
+
+  const trackFilterReset = () => {
+    trackEvent(
+      trendingFilterResetAnalyticsEvent(),
+      trendingFilterResetAnalyticsData(sp.category, sp.window, mode),
+    );
+  };
+
+  const trackChrome = (
+    destination: "rss" | "brief" | "browse",
+    placement: "header" | "footer" | "empty",
+  ) => {
+    trackEvent(
+      trendingChromeAnalyticsEvent(),
+      trendingChromeAnalyticsData(destination, placement, sp.window, sp.category, mode),
+    );
+  };
+
   return (
     <PageContainer className="py-12">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -255,6 +292,7 @@ function TrendingPage() {
           {latestBrief && (
             <Link
               to="/brief"
+              onClick={() => trackChrome("brief", "header")}
               className="mt-3 inline-flex items-center gap-2 text-sm text-ink-muted hover:text-ink"
             >
               Featured in Brief #{latestBrief.number} · {latestBrief.title} →
@@ -269,6 +307,7 @@ function TrendingPage() {
           />
           <a
             href="/feeds/trending.xml"
+            onClick={() => trackChrome("rss", "header")}
             className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-ink-muted hover:bg-surface-2 hover:text-ink"
           >
             <Rss className="h-3.5 w-3.5" /> RSS
@@ -296,7 +335,10 @@ function TrendingPage() {
           <div className="flex gap-1.5 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
             <button
               type="button"
-              onClick={() => set({ category: "" })}
+              onClick={() => {
+                trackCategoryFilter("", true, allRows.length);
+                set({ category: "" });
+              }}
               aria-pressed={!sp.category}
               className={cn(
                 "shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-200 ease-out motion-safe:active:scale-[0.97]",
@@ -315,7 +357,10 @@ function TrendingPage() {
                   key={category.id}
                   type="button"
                   disabled={count === 0 && !active}
-                  onClick={() => set({ category: active ? "" : category.id })}
+                  onClick={() => {
+                    trackCategoryFilter(category.id, !active, count);
+                    set({ category: active ? "" : category.id });
+                  }}
                   aria-pressed={active}
                   className={cn(
                     "shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-200 ease-out motion-safe:active:scale-[0.97]",
@@ -346,7 +391,10 @@ function TrendingPage() {
           </p>
           <button
             type="button"
-            onClick={() => set({ window: "7d", category: "" })}
+            onClick={() => {
+              trackFilterReset();
+              set({ window: "7d", category: "" });
+            }}
             className="mt-2 inline-flex h-8 items-center gap-1.5 rounded-md bg-ink px-3 text-xs font-medium text-background transition-transform hover:bg-ink/90 active:translate-y-px"
           >
             Reset filters
@@ -401,18 +449,21 @@ function TrendingPage() {
         <div className="flex flex-wrap gap-2">
           <a
             href="/feeds/trending.xml"
+            onClick={() => trackChrome("rss", "footer")}
             className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-ink transition-transform hover:bg-surface-2 active:translate-y-px"
           >
             <Rss className="h-3.5 w-3.5" /> RSS
           </a>
           <Link
             to="/brief"
+            onClick={() => trackChrome("brief", "footer")}
             className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-ink transition-transform hover:bg-surface-2 active:translate-y-px"
           >
             Weekly Brief →
           </Link>
           <Link
             to="/browse"
+            onClick={() => trackChrome("browse", "footer")}
             className="inline-flex h-8 items-center gap-1.5 rounded-md bg-ink px-3 text-xs font-medium text-background transition-transform hover:opacity-90 active:translate-y-px"
           >
             Browse all <ArrowRight className="h-3.5 w-3.5" />

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -22,6 +22,10 @@ import {
   validatorsRecentReviewedEntryAnalyticsData,
   validatorsRecentReviewedEntryAnalyticsEvent,
 } from "@/lib/insights-page-entry-cta-events";
+import {
+  validatorsExpertiseFilterAnalyticsData,
+  validatorsExpertiseFilterAnalyticsEvent,
+} from "@/lib/validators-expertise-cta-events";
 import atlasRegistry from "@/generated/atlas-registry.json";
 
 export const Route = createFileRoute("/validators")({
@@ -84,6 +88,17 @@ function ValidatorsPage() {
   const [active, setActive] = React.useState<Expertise | "all">("all");
   const list = REVIEW_COVERAGE.filter((coverage) => active === "all" || coverage.id === active);
 
+  const onExpertiseFilter = React.useCallback(
+    (expertiseId: Expertise | "all", matchCount: number) => {
+      trackEvent(
+        validatorsExpertiseFilterAnalyticsEvent(),
+        validatorsExpertiseFilterAnalyticsData(expertiseId, matchCount, EXPERTISE_OPTIONS.length),
+      );
+      setActive(expertiseId);
+    },
+    [],
+  );
+
   return (
     <PageContainer className="py-12">
       <PageHeader
@@ -113,7 +128,7 @@ function ValidatorsPage() {
             role="radio"
             size="md"
             active={active === "all"}
-            onClick={() => setActive("all")}
+            onClick={() => onExpertiseFilter("all", REVIEW_COVERAGE.length)}
           >
             All
           </FilterChip>
@@ -123,7 +138,12 @@ function ValidatorsPage() {
               role="radio"
               size="md"
               active={active === option}
-              onClick={() => setActive(option)}
+              onClick={() =>
+                onExpertiseFilter(
+                  option,
+                  REVIEW_COVERAGE.filter((coverage) => coverage.id === option).length,
+                )
+              }
             >
               {option}
             </FilterChip>

--- a/tests/citation-facts-cta-events-lib.test.ts
+++ b/tests/citation-facts-cta-events-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  CITATION_FACTS_SURFACE,
+  citationFactLabelKey,
+  citationFactsEgressAnalyticsData,
+  citationFactsEgressAnalyticsEvent,
+} from "@/lib/citation-facts-cta-events-lib";
+
+describe("citation facts cta events lib", () => {
+  it("builds privacy-light citation fact egress analytics", () => {
+    expect(citationFactLabelKey(" Package URL ")).toBe("package-url");
+    expect(citationFactsEgressAnalyticsEvent()).toBe(
+      "citation_facts_egress_click",
+    );
+    expect(
+      citationFactsEgressAnalyticsData(
+        "mcp",
+        "browser",
+        "Package URL",
+        "npmjs.com",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: CITATION_FACTS_SURFACE,
+      factLabel: "package-url",
+      host: "npmjs.com",
+    });
+  });
+});

--- a/tests/trending-entry-cta-events-lib.test.ts
+++ b/tests/trending-entry-cta-events-lib.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   TRENDING_LIST_SURFACE,
+  TRENDING_PAGE_SURFACE,
+  trendingCategoryFilterAnalyticsData,
+  trendingCategoryFilterAnalyticsEvent,
+  trendingChromeAnalyticsData,
+  trendingChromeAnalyticsEvent,
+  trendingFilterResetAnalyticsData,
+  trendingFilterResetAnalyticsEvent,
   trendingListEntryAnalyticsData,
   trendingListEntryAnalyticsEvent,
 } from "@/lib/trending-entry-cta-events-lib";
@@ -45,6 +52,61 @@ describe("trending entry cta events lib", () => {
       window: "all",
       categoryFilter: "",
       mode: "fallback",
+    });
+  });
+
+  it("builds privacy-light trending chrome and filter analytics", () => {
+    expect(trendingCategoryFilterAnalyticsEvent()).toBe(
+      "trending_category_filter_click",
+    );
+    expect(
+      trendingCategoryFilterAnalyticsData("mcp", true, 4, 20, "7d", "live"),
+    ).toEqual({
+      surface: TRENDING_PAGE_SURFACE,
+      categoryFilter: "mcp",
+      active: true,
+      matchCount: 4,
+      totalCount: 20,
+      window: "7d",
+      mode: "live",
+    });
+    expect(trendingFilterResetAnalyticsEvent()).toBe(
+      "trending_filter_reset_click",
+    );
+    expect(
+      trendingFilterResetAnalyticsData("agents", "30d", "fallback"),
+    ).toEqual({
+      surface: TRENDING_PAGE_SURFACE,
+      previousCategoryFilter: "agents",
+      previousWindow: "30d",
+      mode: "fallback",
+    });
+    expect(trendingChromeAnalyticsEvent()).toBe("trending_chrome_click");
+    expect(
+      trendingChromeAnalyticsData("rss", "header", "7d", "", "live"),
+    ).toEqual({
+      surface: TRENDING_PAGE_SURFACE,
+      destination: "rss",
+      placement: "header",
+      window: "7d",
+      categoryFilter: "",
+      mode: "live",
+    });
+    expect(
+      trendingChromeAnalyticsData(
+        "brief",
+        "footer",
+        "all",
+        "mcp",
+        "unavailable",
+      ),
+    ).toEqual({
+      surface: TRENDING_PAGE_SURFACE,
+      destination: "brief",
+      placement: "footer",
+      window: "all",
+      categoryFilter: "mcp",
+      mode: "unavailable",
     });
   });
 });

--- a/tests/validators-expertise-cta-events-lib.test.ts
+++ b/tests/validators-expertise-cta-events-lib.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  VALIDATORS_EXPERTISE_SURFACE,
+  validatorsExpertiseFilterAnalyticsData,
+  validatorsExpertiseFilterAnalyticsEvent,
+} from "@/lib/validators-expertise-cta-events-lib";
+
+describe("validators expertise cta events lib", () => {
+  it("builds privacy-light validators expertise filter analytics", () => {
+    expect(validatorsExpertiseFilterAnalyticsEvent()).toBe(
+      "validators_expertise_filter_click",
+    );
+    expect(validatorsExpertiseFilterAnalyticsData("all", 12, 8)).toEqual({
+      surface: VALIDATORS_EXPERTISE_SURFACE,
+      expertiseId: "all",
+      matchCount: 12,
+      expertiseCount: 8,
+    });
+    expect(validatorsExpertiseFilterAnalyticsData("MCP", 3, 8)).toEqual({
+      surface: VALIDATORS_EXPERTISE_SURFACE,
+      expertiseId: "MCP",
+      matchCount: 3,
+      expertiseCount: 8,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extend trending CTA helpers for category filters, reset, RSS, brief, and browse chrome
- Add citation-facts URL egress analytics (host + fact label only)
- Add validators expertise filter chip analytics
- Privacy-light payloads only (no titles, URLs, or coverage copy)

Refs #550

### Why no new issue
Continues Growth Sprint 1 (#550) decision-layer analytics: pure `*-cta-events-lib` helpers + thin wrappers + `trackEvent` wiring, matching #5064/#5066/#5068/#5069.

## Test plan
- [x] prettier + vitest on three libs
- [x] verified no file overlap with currently open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, codecov/project, required-pr-gate)


Made with [Cursor](https://cursor.com)