### PR TITLE
test(web): cover trust/source and count-fallback branches in browse-trust-filters-lib

### DIFF
--- a/tests/browse-trust-filters-lib.test.ts
+++ b/tests/browse-trust-filters-lib.test.ts
@@ -131,6 +131,27 @@ describe("browse trust filters lib", () => {
     );
   });
 
+  it("forwards active trust and source filters when building facet counts", () => {
+    const entries = [
+      entry({
+        slug: "trusted-verified",
+        trust: "trusted",
+        source: "verified",
+        safetyNotes: "Sandboxed",
+      }),
+    ];
+    const counts = buildBrowseTrustSignalCounts(
+      { ...slice, trust: "trusted", source: "verified" },
+      (filters) => {
+        expect(filters.trust).toEqual(["trusted"]);
+        expect(filters.source).toEqual(["verified"]);
+        return countSearchResults(filters, entries);
+      },
+    );
+
+    expect(counts["safety-notes"]).toBe(1);
+  });
+
   it("formats utility dropdown labels with facet counts", () => {
     expect(formatBrowseTrustUtilityOptionLabel("Safety notes", 12)).toBe(
       "Safety notes (12)",
@@ -150,6 +171,19 @@ describe("browse trust filters lib", () => {
     });
     expect(options[1]?.label).toBe("Safety notes (3)");
     expect(options).toHaveLength(BROWSE_TRUST_SIGNAL_OPTIONS.length + 1);
+  });
+
+  it("defaults missing facet counts to zero when building utility options", () => {
+    const options = buildBrowseTrustUtilityOptions(
+      {} as Record<(typeof BROWSE_TRUST_SIGNAL_OPTIONS)[number]["id"], number>,
+    );
+
+    expect(options[1]).toEqual({
+      id: "safety-notes",
+      label: "Safety notes (0)",
+      count: 0,
+    });
+    expect(options.every((option) => option.count === 0)).toBe(true);
   });
 
   it("orders empty-state relaxation trials from least specific filters first", () => {


### PR DESCRIPTION
## What

Raises `apps/web/src/lib/browse-trust-filters-lib.ts` branch coverage from **81.81% (27/33) to 93.93% (31/33)** (all statements/functions/lines already at 100%, unchanged) by covering four previously-untested branches:

- `buildBrowseTrustSignalCounts` forwarding an active `slice.trust`/`slice.source` filter through to the underlying search-filter call (both were only ever exercised with the default empty-string values in existing tests).
- `buildBrowseTrustUtilityOptions` defaulting a missing facet count to `0` (`counts[option.id] ?? 0`, used for both the formatted label and the raw `count` field) when the supplied `counts` map doesn't include every signal id.

## Notes

- **Test-only change** — no source behaviour is modified.
- The remaining 2 uncovered branches (source lines 57 and 63, inside the private, unexported `toSearchFilters` helper) are not reachable through the module's public API: `toSearchFilters` is only ever called once, from `buildBrowseTrustSignalCounts`, always with a defined, valid `signalOverride` (one of the fixed `BROWSE_TRUST_SIGNAL_OPTIONS` ids) — so its `signalOverride ?? slice.signal` fallback and the "invalid signal" branch of `isBrowseTrustSignalFilter(signal) ? signal : ""` can't be hit without either a source change or exporting the private helper purely to test it, both out of scope for a test-only PR. Flagging in case a maintainer wants to simplify/inline that helper instead.
- Verified locally: `vitest run tests/browse-trust-filters-lib.test.ts --coverage` → 11 tests pass; `prettier --check` and `pnpm --filter web type-check` clean.