### PR TITLE
test(web): cover absent-field branches in entry-facets-lib

### DIFF
--- a/tests/entry-facets-lib.test.ts
+++ b/tests/entry-facets-lib.test.ts
@@ -23,7 +23,7 @@ describe("facetsFor", () => {
     expect(facetsFor(entry({ category: "hooks" }))).toEqual([]);
   });
 
-  it("maps command syntax to a monospace Invocation facet", () => {
+  it("maps command syntax to a monospace Invocation facet, or [] when absent", () => {
     const [facet] = facetsFor(
       entry({ category: "commands", commandSyntax: "/review" }),
     );
@@ -32,14 +32,16 @@ describe("facetsFor", () => {
       value: "/review",
       mono: true,
     });
+    expect(facetsFor(entry({ category: "commands" }))).toEqual([]);
   });
 
-  it("maps a statusline script language to a Language facet", () => {
+  it("maps a statusline script language to a Language facet, or [] when absent", () => {
     const [facet] = facetsFor(
       entry({ category: "statuslines", scriptLanguage: "bash" }),
     );
     expect(facet.label).toBe("Language");
     expect(facet.value).toBe("bash");
+    expect(facetsFor(entry({ category: "statuslines" }))).toEqual([]);
   });
 
   it("collects the present skill fields, skipping absent ones", () => {
@@ -47,10 +49,11 @@ describe("facetsFor", () => {
       entry({
         category: "skills",
         skillLevel: "advanced",
+        skillType: "general",
         verificationStatus: "production",
       }),
     );
-    expect(facets.map((f) => f.label)).toEqual(["Level", "Verified"]);
+    expect(facets.map((f) => f.label)).toEqual(["Level", "Type", "Verified"]);
     expect(facetsFor(entry({ category: "skills" }))).toEqual([]);
   });
 


### PR DESCRIPTION
## What

Brings `apps/web/src/lib/entry-facets-lib.ts` to **100% branch coverage** (was 88.46%, 23/26) by covering its three previously-untested branches, all "field absent" fallbacks in `facetsFor`:

- `commands` with no `commandSyntax` — falls through to `[]` (only the truthy Invocation-facet path was tested).
- `statuslines` with no `scriptLanguage` — falls through to `[]` (only the truthy Language-facet path was tested).
- `skills` with `skillType` present — pushes the "Type" facet (the existing test only exercised `skillLevel`/`verificationStatus`, never `skillType`).

## Notes

- **Test-only change** — no source behaviour is modified.
- Verified locally: `vitest run tests/entry-facets-lib.test.ts --coverage` → 6 tests pass, 100% statements/branches/functions/lines on the source; `prettier --check` and `pnpm --filter web type-check` clean.