### PR TITLE
test(web): cover date-fallback branches in growth-surface-rules-lib

### DIFF
--- a/tests/growth-surface-rules-lib.test.ts
+++ b/tests/growth-surface-rules-lib.test.ts
@@ -260,6 +260,25 @@ describe("buildDiscoverySurfaceLists recentlyVerified", () => {
       "older-review",
     ]);
   });
+
+  it("falls back to an empty verification date when no verification signal is present", () => {
+    const surfaces = buildDiscoverySurfaceLists([
+      entry("undated-package", {
+        packageVerified: true,
+        dateAdded: undefined,
+        trustSignals: null,
+      }),
+      entry("dated-package", {
+        packageVerified: true,
+        verifiedAt: "2026-05-15",
+      }),
+    ]);
+
+    expect(slugs(surfaces.recentlyVerified)).toEqual([
+      "dated-package",
+      "undated-package",
+    ]);
+  });
 });
 
 describe("buildDiscoverySurfaceLists sourceBacked", () => {
@@ -299,6 +318,26 @@ describe("buildDiscoverySurfaceLists sourceBacked", () => {
     ]);
 
     expect(slugs(surfaces.sourceBacked)).toEqual(["newer", "older"]);
+  });
+
+  it("breaks star ties without throwing when dateAdded is missing on both sides", () => {
+    const surfaces = buildDiscoverySurfaceLists([
+      entry("undated-a", {
+        githubStars: 40,
+        dateAdded: undefined,
+        trustSignals: { sourceStatus: "available" },
+      }),
+      entry("undated-b", {
+        githubStars: 40,
+        dateAdded: undefined,
+        trustSignals: { sourceStatus: "available" },
+      }),
+    ]);
+
+    expect(slugs(surfaces.sourceBacked).sort()).toEqual([
+      "undated-a",
+      "undated-b",
+    ]);
   });
 });
 
@@ -367,6 +406,26 @@ describe("buildDiscoverySurfaceLists safeInstall", () => {
     ]);
 
     expect(slugs(surfaces.safeInstall)).toEqual(["newer", "older"]);
+  });
+
+  it("breaks safe-install score ties without throwing when dateAdded is missing", () => {
+    const surfaces = buildDiscoverySurfaceLists([
+      entry("undated-a", {
+        installCommand: "npx a",
+        downloadTrust: "first-party",
+        dateAdded: undefined,
+      }),
+      entry("undated-b", {
+        installCommand: "npx b",
+        downloadTrust: "first-party",
+        dateAdded: undefined,
+      }),
+    ]);
+
+    expect(slugs(surfaces.safeInstall).sort()).toEqual([
+      "undated-a",
+      "undated-b",
+    ]);
   });
 });
 


### PR DESCRIPTION
## What

Raises `apps/web/src/lib/growth-surface-rules-lib.ts` branch coverage from **94.8% to 97.4% (75/77)** (statements/functions/lines already 100%, unchanged) by covering three previously-untested tie-break/fallback branches in `buildDiscoverySurfaceLists`:

- `recentVerificationDate`'s final `""` fallback in the `recentlyVerified` sort, when an entry qualifies via `packageVerified` but has none of `trustSignals.lastVerifiedAt`/`verifiedAt`/`reviewedAt`/`repoUpdatedAt`/`dateAdded` set.
- The `sourceBacked` star-tie sort comparator's `?? ""` fallback on both sides when `dateAdded` is `undefined` (existing tie-break test only used entries with a real `dateAdded`).
- The `safeInstall` score-tie sort comparator's equivalent `?? ""` fallback.

## Notes

- **Test-only change** — no source behaviour is modified.
- The one remaining uncovered branch (source line 132, `popularBySourceSignals`'s `(right.githubStars ?? 0)`) is unreachable through the public API: that list's `.filter()` already requires `typeof entry.githubStars === "number" && entry.githubStars > 0` before any entry reaches the sort comparator, so the `?? 0` fallback can never actually trigger. Flagging in case a maintainer wants to simplify it.
- Verified locally: `vitest run tests/growth-surface-rules-lib.test.ts --coverage` → 33 tests pass; `prettier --check` and `pnpm --filter web type-check` clean.