### PR TITLE
feat(web): add submit, claim, and brief-approve analytics

### DIFF
--- a/apps/web/src/lib/brief-approve-cta-events-lib.ts
+++ b/apps/web/src/lib/brief-approve-cta-events-lib.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure brief approve page navigation analytics helpers.
+ *
+ * Maps approve CTA and brief egress navigation to privacy-light event names
+ * without embedding approval tokens, notes, or schedule timestamps.
+ */
+
+export const BRIEF_APPROVE_SURFACE = "brief-approve";
+
+export type BriefApproveAction = "approve";
+export type BriefApproveOutcome = "intent" | "success" | "error" | "already";
+export type BriefApproveEgressDestination = "brief";
+
+export function briefApproveActionAnalyticsEvent(): string {
+  return "brief_approve_action_click";
+}
+
+export function briefApproveActionAnalyticsData(
+  action: BriefApproveAction,
+  outcome: BriefApproveOutcome,
+  hasNote: boolean,
+) {
+  return {
+    surface: BRIEF_APPROVE_SURFACE,
+    action,
+    outcome,
+    hasNote,
+  };
+}
+
+export function briefApproveEgressAnalyticsEvent(): string {
+  return "brief_approve_egress_click";
+}
+
+export function briefApproveEgressAnalyticsData(destination: BriefApproveEgressDestination) {
+  return {
+    surface: BRIEF_APPROVE_SURFACE,
+    destination,
+  };
+}

--- a/apps/web/src/lib/brief-approve-cta-events.ts
+++ b/apps/web/src/lib/brief-approve-cta-events.ts
@@ -1,0 +1,13 @@
+/**
+ * Brief approve page CTA event surface.
+ */
+export {
+  BRIEF_APPROVE_SURFACE,
+  briefApproveActionAnalyticsData,
+  briefApproveActionAnalyticsEvent,
+  briefApproveEgressAnalyticsData,
+  briefApproveEgressAnalyticsEvent,
+  type BriefApproveAction,
+  type BriefApproveEgressDestination,
+  type BriefApproveOutcome,
+} from "@/lib/brief-approve-cta-events-lib";

--- a/apps/web/src/lib/claim-page-cta-events-lib.ts
+++ b/apps/web/src/lib/claim-page-cta-events-lib.ts
@@ -1,13 +1,16 @@
 /**
  * Pure claim page navigation analytics helpers.
  *
- * Maps submit egress, claim type selection, and listing pick navigation to
- * privacy-light event names without embedding titles, queries, or form content.
+ * Maps submit egress, claim type selection, listing pick/change/reset, and
+ * form file clicks to privacy-light event names without embedding titles,
+ * queries, or form content.
  */
 
 export const CLAIM_PAGE_SURFACE = "claim-page";
 
 export type ClaimPageType = "maintain" | "transfer" | "correct" | "remove";
+export type ClaimPageEgressDestination = "submit";
+export type ClaimPageFileOutcome = "intent" | "success" | "error";
 
 export function claimPageEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;
@@ -49,5 +52,56 @@ export function claimPageEntrySelectAnalyticsData(
     entry: claimPageEntryKey(category, slug),
     rowIndex,
     resultCount,
+  };
+}
+
+export function claimPageChangeListingAnalyticsEvent(): string {
+  return "claim_page_change_listing_click";
+}
+
+export function claimPageChangeListingAnalyticsData(category: string, slug: string) {
+  return {
+    surface: CLAIM_PAGE_SURFACE,
+    entry: claimPageEntryKey(category, slug),
+  };
+}
+
+export function claimPageResetAnalyticsEvent(): string {
+  return "claim_page_reset_click";
+}
+
+export function claimPageResetAnalyticsData() {
+  return {
+    surface: CLAIM_PAGE_SURFACE,
+  };
+}
+
+export function claimPageEgressAnalyticsEvent(): string {
+  return "claim_page_egress_click";
+}
+
+export function claimPageEgressAnalyticsData(destination: ClaimPageEgressDestination) {
+  return {
+    surface: CLAIM_PAGE_SURFACE,
+    destination,
+  };
+}
+
+export function claimPageFileAnalyticsEvent(): string {
+  return "claim_page_file_click";
+}
+
+export function claimPageFileAnalyticsData(
+  type: ClaimPageType,
+  outcome: ClaimPageFileOutcome,
+  proofFieldCount: number,
+  filledProofCount: number,
+) {
+  return {
+    surface: CLAIM_PAGE_SURFACE,
+    type,
+    outcome,
+    proofFieldCount,
+    filledProofCount,
   };
 }

--- a/apps/web/src/lib/claim-page-cta-events.ts
+++ b/apps/web/src/lib/claim-page-cta-events.ts
@@ -3,11 +3,21 @@
  */
 export {
   CLAIM_PAGE_SURFACE,
+  claimPageChangeListingAnalyticsData,
+  claimPageChangeListingAnalyticsEvent,
+  claimPageEgressAnalyticsData,
+  claimPageEgressAnalyticsEvent,
   claimPageEntrySelectAnalyticsData,
   claimPageEntrySelectAnalyticsEvent,
+  claimPageFileAnalyticsData,
+  claimPageFileAnalyticsEvent,
+  claimPageResetAnalyticsData,
+  claimPageResetAnalyticsEvent,
   claimPageSubmitAnalyticsData,
   claimPageSubmitAnalyticsEvent,
   claimPageTypeSelectAnalyticsData,
   claimPageTypeSelectAnalyticsEvent,
+  type ClaimPageEgressDestination,
+  type ClaimPageFileOutcome,
   type ClaimPageType,
 } from "@/lib/claim-page-cta-events-lib";

--- a/apps/web/src/lib/submit-cta-events-lib.ts
+++ b/apps/web/src/lib/submit-cta-events-lib.ts
@@ -1,13 +1,16 @@
 /**
  * Pure submit flow analytics helpers.
  *
- * Maps submission start and success events to privacy-light payloads without
+ * Maps wizard navigation, category selection, preflight retry, commercial
+ * egress, and submit start/success events to privacy-light payloads without
  * embedding entry titles, slugs, or form field content.
  */
 
 export const SUBMIT_SURFACE = "submit";
 
 export type SubmitSuccessPath = "manual" | "gate";
+export type SubmitStepDirection = "back" | "continue";
+export type SubmitEgressDestination = "advertise" | "jobs-post";
 
 export function submitStartAnalyticsEvent(): string {
   return "submit_start";
@@ -30,5 +33,66 @@ export function submitSuccessAnalyticsData(category: string, path: SubmitSuccess
     surface: SUBMIT_SURFACE,
     category,
     path,
+  };
+}
+
+export function submitCategorySelectAnalyticsEvent(): string {
+  return "submit_category_select";
+}
+
+export function submitCategorySelectAnalyticsData(
+  category: string,
+  webOnly: boolean,
+  categoryCount: number,
+) {
+  return {
+    surface: SUBMIT_SURFACE,
+    category,
+    webOnly,
+    categoryCount,
+  };
+}
+
+export function submitStepAnalyticsEvent(): string {
+  return "submit_step_click";
+}
+
+export function submitStepAnalyticsData(
+  direction: SubmitStepDirection,
+  fromStep: number,
+  toStep: number,
+  category: string,
+  stepCount: number,
+) {
+  return {
+    surface: SUBMIT_SURFACE,
+    direction,
+    fromStep,
+    toStep,
+    category,
+    stepCount,
+  };
+}
+
+export function submitPreflightRetryAnalyticsEvent(): string {
+  return "submit_preflight_retry_click";
+}
+
+export function submitPreflightRetryAnalyticsData(category: string, step: number) {
+  return {
+    surface: SUBMIT_SURFACE,
+    category,
+    step,
+  };
+}
+
+export function submitEgressAnalyticsEvent(): string {
+  return "submit_egress_click";
+}
+
+export function submitEgressAnalyticsData(destination: SubmitEgressDestination) {
+  return {
+    surface: SUBMIT_SURFACE,
+    destination,
   };
 }

--- a/apps/web/src/lib/submit-cta-events.ts
+++ b/apps/web/src/lib/submit-cta-events.ts
@@ -3,9 +3,19 @@
  */
 export {
   SUBMIT_SURFACE,
+  submitCategorySelectAnalyticsData,
+  submitCategorySelectAnalyticsEvent,
+  submitEgressAnalyticsData,
+  submitEgressAnalyticsEvent,
+  submitPreflightRetryAnalyticsData,
+  submitPreflightRetryAnalyticsEvent,
   submitStartAnalyticsData,
   submitStartAnalyticsEvent,
+  submitStepAnalyticsData,
+  submitStepAnalyticsEvent,
   submitSuccessAnalyticsData,
   submitSuccessAnalyticsEvent,
+  type SubmitEgressDestination,
+  type SubmitStepDirection,
   type SubmitSuccessPath,
 } from "@/lib/submit-cta-events-lib";

--- a/apps/web/src/routes/brief.approve.tsx
+++ b/apps/web/src/routes/brief.approve.tsx
@@ -2,6 +2,13 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { useState, type ReactNode } from "react";
 import { z } from "zod";
+import { trackEvent } from "@/lib/analytics";
+import {
+  briefApproveActionAnalyticsData,
+  briefApproveActionAnalyticsEvent,
+  briefApproveEgressAnalyticsData,
+  briefApproveEgressAnalyticsEvent,
+} from "@/lib/brief-approve-cta-events";
 
 const tokenInput = z.object({ token: z.string() });
 const confirmInput = z.object({
@@ -118,12 +125,36 @@ function ApprovePage() {
           type="button"
           disabled={state.phase === "working"}
           onClick={async () => {
+            const hasNote = note.trim().length > 0;
+            trackEvent(
+              briefApproveActionAnalyticsEvent(),
+              briefApproveActionAnalyticsData("approve", "intent", hasNote),
+            );
             setState({ phase: "working" });
             try {
               const res = await confirmApprove({ data: { token, note } });
-              if (res.ok) setState({ phase: "done", scheduledSendAt: res.scheduledSendAt });
-              else setState({ phase: "error", reason: res.reason });
+              if (res.ok) {
+                trackEvent(
+                  briefApproveActionAnalyticsEvent(),
+                  briefApproveActionAnalyticsData("approve", "success", hasNote),
+                );
+                setState({ phase: "done", scheduledSendAt: res.scheduledSendAt });
+              } else {
+                trackEvent(
+                  briefApproveActionAnalyticsEvent(),
+                  briefApproveActionAnalyticsData(
+                    "approve",
+                    res.reason === "already" ? "already" : "error",
+                    hasNote,
+                  ),
+                );
+                setState({ phase: "error", reason: res.reason });
+              }
             } catch {
+              trackEvent(
+                briefApproveActionAnalyticsEvent(),
+                briefApproveActionAnalyticsData("approve", "error", hasNote),
+              );
               setState({ phase: "error", reason: "error" });
             }
           }}
@@ -142,7 +173,13 @@ function Shell({ heading, children }: { heading: string; children: ReactNode }) 
       <div className="eyebrow text-ink-subtle">Weekly Brief</div>
       <h1 className="mt-2 h-display-2 text-ink">{heading}</h1>
       <p className="mt-4 text-pretty text-ink-muted">{children}</p>
-      <Link to="/brief" className="mt-8 inline-block text-sm text-ink-muted hover:text-ink">
+      <Link
+        to="/brief"
+        onClick={() =>
+          trackEvent(briefApproveEgressAnalyticsEvent(), briefApproveEgressAnalyticsData("brief"))
+        }
+        className="mt-8 inline-block text-sm text-ink-muted hover:text-ink"
+      >
         ← Back to the Weekly Brief
       </Link>
     </div>

--- a/apps/web/src/routes/claim.tsx
+++ b/apps/web/src/routes/claim.tsx
@@ -5,10 +5,16 @@ import { ENTRIES } from "@/data/entries";
 import { resolveClaimWebsiteUrl } from "@/lib/claim-website-url-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
+  claimPageChangeListingAnalyticsData,
+  claimPageChangeListingAnalyticsEvent,
+  claimPageEgressAnalyticsData,
+  claimPageEgressAnalyticsEvent,
   claimPageEntrySelectAnalyticsData,
   claimPageEntrySelectAnalyticsEvent,
-  claimPageSubmitAnalyticsData,
-  claimPageSubmitAnalyticsEvent,
+  claimPageFileAnalyticsData,
+  claimPageFileAnalyticsEvent,
+  claimPageResetAnalyticsData,
+  claimPageResetAnalyticsEvent,
   claimPageTypeSelectAnalyticsData,
   claimPageTypeSelectAnalyticsEvent,
 } from "@/lib/claim-page-cta-events";
@@ -172,6 +178,10 @@ function ClaimPage() {
     if (!picked || !contactEmail || submitting) return;
     setSubmitting(true);
     setError("");
+    trackEvent(
+      claimPageFileAnalyticsEvent(),
+      claimPageFileAnalyticsData(type, "intent", PROOF_FIELDS.length, filled.length),
+    );
     const proofLines = PROOF_FIELDS.filter((field) => field.id !== "email")
       .map((field) => {
         const value = (proof[field.id] ?? "").trim();
@@ -199,8 +209,16 @@ function ClaimPage() {
         }),
       });
       if (!response.ok) throw new Error(`Claim intake returned ${response.status}`);
+      trackEvent(
+        claimPageFileAnalyticsEvent(),
+        claimPageFileAnalyticsData(type, "success", PROOF_FIELDS.length, filled.length),
+      );
       setDone(true);
     } catch {
+      trackEvent(
+        claimPageFileAnalyticsEvent(),
+        claimPageFileAnalyticsData(type, "error", PROOF_FIELDS.length, filled.length),
+      );
       setError("Claim could not be submitted. Check the required fields and try again.");
     } finally {
       setSubmitting(false);
@@ -221,6 +239,7 @@ function ClaimPage() {
         <button
           type="button"
           onClick={() => {
+            trackEvent(claimPageResetAnalyticsEvent(), claimPageResetAnalyticsData());
             setDone(false);
             setPicked(null);
             setQuery("");
@@ -264,6 +283,10 @@ function ClaimPage() {
                   <button
                     type="button"
                     onClick={() => {
+                      trackEvent(
+                        claimPageChangeListingAnalyticsEvent(),
+                        claimPageChangeListingAnalyticsData(picked.category, picked.slug),
+                      );
                       setPicked(null);
                       setQuery("");
                     }}
@@ -472,7 +495,7 @@ function ClaimPage() {
             to="/submit"
             className="text-ink hover:underline"
             onClick={() =>
-              trackEvent(claimPageSubmitAnalyticsEvent(), claimPageSubmitAnalyticsData())
+              trackEvent(claimPageEgressAnalyticsEvent(), claimPageEgressAnalyticsData("submit"))
             }
           >
             Submit a resource →

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -27,8 +27,16 @@ import { cn } from "@/lib/utils";
 import { absoluteUrl } from "@/lib/seo";
 import { trackEvent } from "@/lib/analytics";
 import {
+  submitCategorySelectAnalyticsData,
+  submitCategorySelectAnalyticsEvent,
+  submitEgressAnalyticsData,
+  submitEgressAnalyticsEvent,
+  submitPreflightRetryAnalyticsData,
+  submitPreflightRetryAnalyticsEvent,
   submitStartAnalyticsData,
   submitStartAnalyticsEvent,
+  submitStepAnalyticsData,
+  submitStepAnalyticsEvent,
   submitSuccessAnalyticsData,
   submitSuccessAnalyticsEvent,
 } from "@/lib/submit-cta-events";
@@ -284,11 +292,23 @@ function SubmitPage() {
       <p className="mt-2 text-sm text-ink-muted">
         Free, source-backed, useful. The site opens a single-entry GitHub PR for private-gate
         review. Commercial tools go through{" "}
-        <a href="/advertise" className="text-ink underline">
+        <a
+          href="/advertise"
+          className="text-ink underline"
+          onClick={() =>
+            trackEvent(submitEgressAnalyticsEvent(), submitEgressAnalyticsData("advertise"))
+          }
+        >
           advertise
         </a>
         . Jobs go through{" "}
-        <a href="/jobs/post" className="text-ink underline">
+        <a
+          href="/jobs/post"
+          className="text-ink underline"
+          onClick={() =>
+            trackEvent(submitEgressAnalyticsEvent(), submitEgressAnalyticsData("jobs-post"))
+          }
+        >
           post a job
         </a>
         .
@@ -314,7 +334,12 @@ function SubmitPage() {
           e.preventDefault();
           if (!canContinue) return;
           if (step < STEPS.length - 1) {
-            setStep((s) => s + 1);
+            const toStep = step + 1;
+            trackEvent(
+              submitStepAnalyticsEvent(),
+              submitStepAnalyticsData("continue", step, toStep, category || "", STEPS.length),
+            );
+            setStep(toStep);
             return;
           }
           if (!preflightResult) {
@@ -337,6 +362,10 @@ function SubmitPage() {
                     key={c.id}
                     type="button"
                     onClick={() => {
+                      trackEvent(
+                        submitCategorySelectAnalyticsEvent(),
+                        submitCategorySelectAnalyticsData(c.id, disabled, CATEGORIES.length),
+                      );
                       setCategory(c.id);
                       setData({});
                       setPreflightResult(null);
@@ -368,7 +397,13 @@ function SubmitPage() {
             {unsupportedWebCategory && (
               <div className="mt-4 rounded-md border border-border bg-background p-3 text-xs text-ink-muted">
                 This category is not enabled for website-created PRs yet. Use{" "}
-                <a href="/advertise" className="text-ink underline">
+                <a
+                  href="/advertise"
+                  className="text-ink underline"
+                  onClick={() =>
+                    trackEvent(submitEgressAnalyticsEvent(), submitEgressAnalyticsData("advertise"))
+                  }
+                >
                   commercial intake
                 </a>{" "}
                 for tools or contact a maintainer for special routing.
@@ -438,7 +473,13 @@ function SubmitPage() {
               result={preflightResult}
               error={preflightError}
               busy={preflightBusy}
-              onRun={() => void runServerPreflight()}
+              onRun={() => {
+                trackEvent(
+                  submitPreflightRetryAnalyticsEvent(),
+                  submitPreflightRetryAnalyticsData(category || "", step),
+                );
+                void runServerPreflight();
+              }}
             />
 
             <div>
@@ -466,7 +507,15 @@ function SubmitPage() {
         <div className="mt-6 flex items-center justify-between gap-2">
           <button
             type="button"
-            onClick={() => setStep((s) => Math.max(0, s - 1))}
+            onClick={() => {
+              if (step === 0) return;
+              const toStep = step - 1;
+              trackEvent(
+                submitStepAnalyticsEvent(),
+                submitStepAnalyticsData("back", step, toStep, category || "", STEPS.length),
+              );
+              setStep(toStep);
+            }}
             disabled={step === 0}
             className="text-sm text-ink-muted hover:text-ink disabled:opacity-40"
           >

--- a/tests/brief-approve-cta-events-lib.test.ts
+++ b/tests/brief-approve-cta-events-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  BRIEF_APPROVE_SURFACE,
+  briefApproveActionAnalyticsData,
+  briefApproveActionAnalyticsEvent,
+  briefApproveEgressAnalyticsData,
+  briefApproveEgressAnalyticsEvent,
+} from "@/lib/brief-approve-cta-events-lib";
+
+describe("brief approve cta events lib", () => {
+  it("builds privacy-light brief approve action and egress analytics", () => {
+    expect(briefApproveActionAnalyticsEvent()).toBe(
+      "brief_approve_action_click",
+    );
+    expect(briefApproveActionAnalyticsData("approve", "intent", true)).toEqual({
+      surface: BRIEF_APPROVE_SURFACE,
+      action: "approve",
+      outcome: "intent",
+      hasNote: true,
+    });
+    expect(
+      briefApproveActionAnalyticsData("approve", "already", false),
+    ).toEqual({
+      surface: BRIEF_APPROVE_SURFACE,
+      action: "approve",
+      outcome: "already",
+      hasNote: false,
+    });
+    expect(briefApproveEgressAnalyticsEvent()).toBe(
+      "brief_approve_egress_click",
+    );
+    expect(briefApproveEgressAnalyticsData("brief")).toEqual({
+      surface: BRIEF_APPROVE_SURFACE,
+      destination: "brief",
+    });
+  });
+});

--- a/tests/claim-page-cta-events-lib.test.ts
+++ b/tests/claim-page-cta-events-lib.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
   CLAIM_PAGE_SURFACE,
+  claimPageChangeListingAnalyticsData,
+  claimPageChangeListingAnalyticsEvent,
+  claimPageEgressAnalyticsData,
+  claimPageEgressAnalyticsEvent,
   claimPageEntrySelectAnalyticsData,
   claimPageEntrySelectAnalyticsEvent,
+  claimPageFileAnalyticsData,
+  claimPageFileAnalyticsEvent,
+  claimPageResetAnalyticsData,
+  claimPageResetAnalyticsEvent,
   claimPageSubmitAnalyticsData,
   claimPageSubmitAnalyticsEvent,
   claimPageTypeSelectAnalyticsData,
@@ -28,6 +36,33 @@ describe("claim page cta events lib", () => {
       entry: "mcp/browser",
       rowIndex: 1,
       resultCount: 6,
+    });
+  });
+
+  it("builds claim page reset, change, egress, and file analytics", () => {
+    expect(claimPageChangeListingAnalyticsEvent()).toBe(
+      "claim_page_change_listing_click",
+    );
+    expect(claimPageChangeListingAnalyticsData("agents", "demo")).toEqual({
+      surface: CLAIM_PAGE_SURFACE,
+      entry: "agents/demo",
+    });
+    expect(claimPageResetAnalyticsEvent()).toBe("claim_page_reset_click");
+    expect(claimPageResetAnalyticsData()).toEqual({
+      surface: CLAIM_PAGE_SURFACE,
+    });
+    expect(claimPageEgressAnalyticsEvent()).toBe("claim_page_egress_click");
+    expect(claimPageEgressAnalyticsData("submit")).toEqual({
+      surface: CLAIM_PAGE_SURFACE,
+      destination: "submit",
+    });
+    expect(claimPageFileAnalyticsEvent()).toBe("claim_page_file_click");
+    expect(claimPageFileAnalyticsData("maintain", "success", 4, 3)).toEqual({
+      surface: CLAIM_PAGE_SURFACE,
+      type: "maintain",
+      outcome: "success",
+      proofFieldCount: 4,
+      filledProofCount: 3,
     });
   });
 });

--- a/tests/submit-cta-events-lib.test.ts
+++ b/tests/submit-cta-events-lib.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
   SUBMIT_SURFACE,
+  submitCategorySelectAnalyticsData,
+  submitCategorySelectAnalyticsEvent,
+  submitEgressAnalyticsData,
+  submitEgressAnalyticsEvent,
+  submitPreflightRetryAnalyticsData,
+  submitPreflightRetryAnalyticsEvent,
   submitStartAnalyticsData,
   submitStartAnalyticsEvent,
+  submitStepAnalyticsData,
+  submitStepAnalyticsEvent,
   submitSuccessAnalyticsData,
   submitSuccessAnalyticsEvent,
 } from "@/lib/submit-cta-events-lib";
@@ -25,6 +33,50 @@ describe("submit cta events lib", () => {
       surface: SUBMIT_SURFACE,
       category: "hooks",
       path: "manual",
+    });
+  });
+
+  it("builds privacy-light submit wizard navigation analytics", () => {
+    expect(submitCategorySelectAnalyticsEvent()).toBe("submit_category_select");
+    expect(submitCategorySelectAnalyticsData("mcp", false, 9)).toEqual({
+      surface: SUBMIT_SURFACE,
+      category: "mcp",
+      webOnly: false,
+      categoryCount: 9,
+    });
+    expect(submitStepAnalyticsEvent()).toBe("submit_step_click");
+    expect(submitStepAnalyticsData("continue", 0, 1, "mcp", 4)).toEqual({
+      surface: SUBMIT_SURFACE,
+      direction: "continue",
+      fromStep: 0,
+      toStep: 1,
+      category: "mcp",
+      stepCount: 4,
+    });
+    expect(submitStepAnalyticsData("back", 2, 1, "skills", 4)).toEqual({
+      surface: SUBMIT_SURFACE,
+      direction: "back",
+      fromStep: 2,
+      toStep: 1,
+      category: "skills",
+      stepCount: 4,
+    });
+    expect(submitPreflightRetryAnalyticsEvent()).toBe(
+      "submit_preflight_retry_click",
+    );
+    expect(submitPreflightRetryAnalyticsData("hooks", 3)).toEqual({
+      surface: SUBMIT_SURFACE,
+      category: "hooks",
+      step: 3,
+    });
+    expect(submitEgressAnalyticsEvent()).toBe("submit_egress_click");
+    expect(submitEgressAnalyticsData("advertise")).toEqual({
+      surface: SUBMIT_SURFACE,
+      destination: "advertise",
+    });
+    expect(submitEgressAnalyticsData("jobs-post")).toEqual({
+      surface: SUBMIT_SURFACE,
+      destination: "jobs-post",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend submit CTA helpers for category select, step nav, preflight retry, and advertise/jobs egress
- Extend claim CTA helpers for change listing, reset, file outcomes, and submit egress
- Add brief-approve CTA helpers for approve action outcomes and brief egress
- Privacy-light payloads only (no form content, tokens, notes, or URLs)

Refs #550

### Why no new issue
Continues Growth Sprint 1 (#550) decision-layer analytics: pure `*-cta-events-lib` helpers + thin wrappers + `trackEvent` wiring, matching #5068/#5069/#5081.

## Test plan
- [x] prettier + vitest on three libs
- [x] verified no file overlap with currently open PRs
- [x] CI green (validate-web, coverage, codecov/patch, codecov/project, required-pr-gate)