### PR TITLE
feat(web): add integrations detail action egress analytics

### DIFF
--- a/apps/web/src/lib/integrations-hub-cta-events-lib.ts
+++ b/apps/web/src/lib/integrations-hub-cta-events-lib.ts
@@ -84,3 +84,24 @@ export function integrationsDetailRelatedAnalyticsData(
     relatedCount,
   };
 }
+
+export type IntegrationsDetailActionRole = "primary" | "secondary";
+
+export function integrationsDetailActionAnalyticsEvent(): string {
+  return "integrations_detail_action_click";
+}
+
+export function integrationsDetailActionAnalyticsData(
+  integrationSlug: string,
+  action: IntegrationsDetailActionRole,
+  status: string,
+  kind: string,
+) {
+  return {
+    surface: INTEGRATIONS_DETAIL_SURFACE,
+    integrationSlug,
+    action,
+    status,
+    kind,
+  };
+}

--- a/apps/web/src/lib/integrations-hub-cta-events.ts
+++ b/apps/web/src/lib/integrations-hub-cta-events.ts
@@ -4,6 +4,8 @@
 export {
   INTEGRATIONS_DETAIL_SURFACE,
   INTEGRATIONS_INDEX_SURFACE,
+  integrationsDetailActionAnalyticsData,
+  integrationsDetailActionAnalyticsEvent,
   integrationsDetailIndexAnalyticsData,
   integrationsDetailIndexAnalyticsEvent,
   integrationsDetailRelatedAnalyticsData,
@@ -14,4 +16,5 @@ export {
   integrationsIndexCardAnalyticsEvent,
   integrationsIndexEcosystemAnalyticsData,
   integrationsIndexEcosystemAnalyticsEvent,
+  type IntegrationsDetailActionRole,
 } from "@/lib/integrations-hub-cta-events-lib";

--- a/apps/web/src/routes/integrations.$slug.tsx
+++ b/apps/web/src/routes/integrations.$slug.tsx
@@ -13,6 +13,8 @@ import { ogImageUrl } from "@/lib/og-image";
 import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
+  integrationsDetailActionAnalyticsData,
+  integrationsDetailActionAnalyticsEvent,
   integrationsDetailIndexAnalyticsData,
   integrationsDetailIndexAnalyticsEvent,
   integrationsDetailRelatedAnalyticsData,
@@ -95,6 +97,17 @@ function IntegrationDetail() {
               href={integration.primaryAction.href}
               target="_blank"
               rel="noreferrer"
+              onClick={() =>
+                trackEvent(
+                  integrationsDetailActionAnalyticsEvent(),
+                  integrationsDetailActionAnalyticsData(
+                    integration.slug,
+                    "primary",
+                    integration.status,
+                    integration.kind,
+                  ),
+                )
+              }
               className="inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-3 text-sm font-medium text-background hover:bg-ink/90"
             >
               {integration.primaryAction.label} <ArrowUpRight className="h-3.5 w-3.5" />
@@ -104,6 +117,17 @@ function IntegrationDetail() {
                 href={integration.secondaryAction.href}
                 target="_blank"
                 rel="noreferrer"
+                onClick={() =>
+                  trackEvent(
+                    integrationsDetailActionAnalyticsEvent(),
+                    integrationsDetailActionAnalyticsData(
+                      integration.slug,
+                      "secondary",
+                      integration.status,
+                      integration.kind,
+                    ),
+                  )
+                }
                 className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-sm text-ink hover:bg-surface-2"
               >
                 {integration.secondaryAction.label}

--- a/tests/integrations-hub-cta-events-lib.test.ts
+++ b/tests/integrations-hub-cta-events-lib.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   INTEGRATIONS_DETAIL_SURFACE,
   INTEGRATIONS_INDEX_SURFACE,
+  integrationsDetailActionAnalyticsData,
+  integrationsDetailActionAnalyticsEvent,
   integrationsDetailIndexAnalyticsData,
   integrationsDetailIndexAnalyticsEvent,
   integrationsDetailRelatedAnalyticsData,
@@ -71,6 +73,37 @@ describe("integrations hub cta events lib", () => {
       relatedSlug: "mcp-server",
       rowIndex: 0,
       relatedCount: 3,
+    });
+    expect(integrationsDetailActionAnalyticsEvent()).toBe(
+      "integrations_detail_action_click",
+    );
+    expect(
+      integrationsDetailActionAnalyticsData(
+        "raycast",
+        "primary",
+        "live",
+        "extension",
+      ),
+    ).toEqual({
+      surface: INTEGRATIONS_DETAIL_SURFACE,
+      integrationSlug: "raycast",
+      action: "primary",
+      status: "live",
+      kind: "extension",
+    });
+    expect(
+      integrationsDetailActionAnalyticsData(
+        "mcp-server",
+        "secondary",
+        "beta",
+        "mcp-server",
+      ),
+    ).toEqual({
+      surface: INTEGRATIONS_DETAIL_SURFACE,
+      integrationSlug: "mcp-server",
+      action: "secondary",
+      status: "beta",
+      kind: "mcp-server",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend integrations-hub CTA lib with primary/secondary action egress helpers
- Wire external action links on /integrations/$slug
- Event: integrations_detail_action_click (action: primary | secondary)

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)

Made with [Cursor](https://cursor.com)