### PR TITLE
feat(web): add entry detail tag and category hub analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-tag-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-tag-cta-events-lib.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure entry detail tag and category-hub egress analytics helpers.
+ *
+ * Maps overview tag chips and "More in {category}" navigation to privacy-light
+ * event names without embedding tag labels or entry titles.
+ */
+
+export const ENTRY_DETAIL_TAGS_SURFACE = "detail-tags";
+export const ENTRY_DETAIL_RELATED_SURFACE = "detail-related";
+
+export function entryDetailTagEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryDetailTagAnalyticsEvent(): string {
+  return "detail_tag_click";
+}
+
+export function entryDetailTagAnalyticsData(
+  category: string,
+  slug: string,
+  tagSlug: string,
+  rowIndex: number,
+  tagCount: number,
+) {
+  return {
+    entry: entryDetailTagEntryKey(category, slug),
+    surface: ENTRY_DETAIL_TAGS_SURFACE,
+    tagSlug,
+    rowIndex,
+    tagCount,
+  };
+}
+
+export function entryDetailCategoryHubAnalyticsEvent(): string {
+  return "detail_category_hub_click";
+}
+
+export function entryDetailCategoryHubAnalyticsData(category: string, slug: string) {
+  return {
+    entry: entryDetailTagEntryKey(category, slug),
+    surface: ENTRY_DETAIL_RELATED_SURFACE,
+    category,
+  };
+}

--- a/apps/web/src/lib/entry-detail-tag-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-tag-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Entry detail tag and category-hub CTA event surface.
+ */
+export {
+  ENTRY_DETAIL_RELATED_SURFACE,
+  ENTRY_DETAIL_TAGS_SURFACE,
+  entryDetailCategoryHubAnalyticsData,
+  entryDetailCategoryHubAnalyticsEvent,
+  entryDetailTagAnalyticsData,
+  entryDetailTagAnalyticsEvent,
+  entryDetailTagEntryKey,
+} from "@/lib/entry-detail-tag-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -82,6 +82,12 @@ import { useCompare, useIsCompared } from "@/lib/compare";
 import { serializeCompareItems } from "@/lib/compare-selection";
 import { trackEvent } from "@/lib/analytics";
 import {
+  entryDetailCategoryHubAnalyticsData,
+  entryDetailCategoryHubAnalyticsEvent,
+  entryDetailTagAnalyticsData,
+  entryDetailTagAnalyticsEvent,
+} from "@/lib/entry-detail-tag-cta-events";
+import {
   ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
@@ -861,7 +867,7 @@ function Dossier() {
               </div>
             )}
             <div className="mt-4 flex flex-wrap gap-1.5">
-              {entry.tags.map((t) => {
+              {entry.tags.map((t, rowIndex) => {
                 const slug = tagSlug(t);
                 const base =
                   "inline-flex rounded-md border border-border bg-surface px-2 py-0.5 text-xs text-ink-muted";
@@ -878,6 +884,18 @@ function Dossier() {
                     key={t}
                     to="/tags/$tag"
                     params={{ tag: slug }}
+                    onClick={() =>
+                      trackEvent(
+                        entryDetailTagAnalyticsEvent(),
+                        entryDetailTagAnalyticsData(
+                          entry.category,
+                          entry.slug,
+                          slug,
+                          rowIndex,
+                          entry.tags.length,
+                        ),
+                      )
+                    }
                     className={`${base} hover:border-border-strong hover:text-ink`}
                   >
                     #{t}
@@ -975,6 +993,12 @@ function Dossier() {
                 <Link
                   to="/$category"
                   params={{ category: entry.category }}
+                  onClick={() =>
+                    trackEvent(
+                      entryDetailCategoryHubAnalyticsEvent(),
+                      entryDetailCategoryHubAnalyticsData(entry.category, entry.slug),
+                    )
+                  }
                   className="story-link text-xs font-medium text-ink"
                 >
                   More in {categoryLabels[entry.category] ?? entry.category} →

--- a/tests/entry-detail-tag-cta-events-lib.test.ts
+++ b/tests/entry-detail-tag-cta-events-lib.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_DETAIL_RELATED_SURFACE,
+  ENTRY_DETAIL_TAGS_SURFACE,
+  entryDetailCategoryHubAnalyticsData,
+  entryDetailCategoryHubAnalyticsEvent,
+  entryDetailTagAnalyticsData,
+  entryDetailTagAnalyticsEvent,
+} from "@/lib/entry-detail-tag-cta-events-lib";
+
+describe("entry detail tag cta events lib", () => {
+  it("builds privacy-light tag and category hub egress analytics", () => {
+    expect(entryDetailTagAnalyticsEvent()).toBe("detail_tag_click");
+    expect(
+      entryDetailTagAnalyticsData("mcp", "browser", "browser", 0, 5),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_DETAIL_TAGS_SURFACE,
+      tagSlug: "browser",
+      rowIndex: 0,
+      tagCount: 5,
+    });
+    expect(entryDetailCategoryHubAnalyticsEvent()).toBe(
+      "detail_category_hub_click",
+    );
+    expect(entryDetailCategoryHubAnalyticsData("skills", "demo")).toEqual({
+      entry: "skills/demo",
+      surface: ENTRY_DETAIL_RELATED_SURFACE,
+      category: "skills",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add entry-detail tag CTA lib + wrapper for tag chips and category hub egress
- Wire overview tag links and More in category on entry detail
- Events: detail_tag_click, detail_category_hub_click

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)

Made with [Cursor](https://cursor.com)