### PR TITLE
feat(web): add subscriptions, quality, and a11y chrome analytics

### DIFF
--- a/apps/web/src/components/peek-hint.tsx
+++ b/apps/web/src/components/peek-hint.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { X } from "lucide-react";
 import { Kbd } from "@/components/badges";
+import { trackEvent } from "@/lib/analytics";
+import {
+  peekHintDismissAnalyticsData,
+  peekHintDismissAnalyticsEvent,
+} from "@/lib/a11y-chrome-cta-events";
 import { defaultLocalStorage } from "@/lib/dossier-prefs-lib";
 import { dismissPeekHint, peekHintDismissed } from "@/lib/peek-hint-lib";
 import { cn } from "@/lib/utils";
@@ -31,12 +36,14 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
       setVisible(false);
       setEligible(false);
       dismissPeekHint(defaultLocalStorage());
+      trackEvent(peekHintDismissAnalyticsEvent(), peekHintDismissAnalyticsData("timeout"));
     }, 8000);
     const onKey = (e: KeyboardEvent) => {
       if (e.key.toLowerCase() === "p" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         setVisible(false);
         setEligible(false);
         dismissPeekHint(defaultLocalStorage());
+        trackEvent(peekHintDismissAnalyticsEvent(), peekHintDismissAnalyticsData("hotkey"));
       }
     };
     window.addEventListener("keydown", onKey);
@@ -68,6 +75,7 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
           setVisible(false);
           setEligible(false);
           dismissPeekHint(defaultLocalStorage());
+          trackEvent(peekHintDismissAnalyticsEvent(), peekHintDismissAnalyticsData("button"));
         }}
         aria-label="Dismiss peek shortcut hint"
         className="inline-flex h-4 w-4 items-center justify-center rounded text-ink-subtle hover:text-ink"

--- a/apps/web/src/components/skip-link.tsx
+++ b/apps/web/src/components/skip-link.tsx
@@ -1,7 +1,11 @@
+import { trackEvent } from "@/lib/analytics";
+import { skipLinkAnalyticsData, skipLinkAnalyticsEvent } from "@/lib/a11y-chrome-cta-events";
+
 export function SkipLink() {
   return (
     <a
       href="#main"
+      onClick={() => trackEvent(skipLinkAnalyticsEvent(), skipLinkAnalyticsData())}
       className="sr-only fixed left-3 top-3 z-[60] inline-flex h-9 items-center rounded-md bg-ink px-3 text-sm font-medium text-background focus:not-sr-only focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
     >
       Skip to main content

--- a/apps/web/src/lib/a11y-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/a11y-chrome-cta-events-lib.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure a11y chrome navigation analytics helpers.
+ *
+ * Maps skip-link activation and peek-hint dismiss actions to privacy-light
+ * event names without embedding page path or coach-mark copy.
+ */
+
+export const SKIP_LINK_SURFACE = "skip-link";
+export const PEEK_HINT_SURFACE = "peek-hint";
+
+export type PeekHintDismissReason = "button" | "timeout" | "hotkey";
+
+export function skipLinkAnalyticsEvent(): string {
+  return "skip_link_click";
+}
+
+export function skipLinkAnalyticsData() {
+  return {
+    surface: SKIP_LINK_SURFACE,
+  };
+}
+
+export function peekHintDismissAnalyticsEvent(): string {
+  return "peek_hint_dismiss_click";
+}
+
+export function peekHintDismissAnalyticsData(reason: PeekHintDismissReason) {
+  return {
+    surface: PEEK_HINT_SURFACE,
+    reason,
+  };
+}

--- a/apps/web/src/lib/a11y-chrome-cta-events.ts
+++ b/apps/web/src/lib/a11y-chrome-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * A11y chrome CTA event surface (skip-link + peek-hint).
+ */
+export {
+  PEEK_HINT_SURFACE,
+  SKIP_LINK_SURFACE,
+  peekHintDismissAnalyticsData,
+  peekHintDismissAnalyticsEvent,
+  skipLinkAnalyticsData,
+  skipLinkAnalyticsEvent,
+  type PeekHintDismissReason,
+} from "@/lib/a11y-chrome-cta-events-lib";

--- a/apps/web/src/lib/quality-page-cta-events-lib.ts
+++ b/apps/web/src/lib/quality-page-cta-events-lib.ts
@@ -1,11 +1,19 @@
 /**
  * Pure quality page navigation analytics helpers.
  *
- * Maps category browse egress, changelog navigation, and report CTAs to
- * privacy-light event names without embedding titles, URLs, or entry names.
+ * Maps category browse egress, changelog navigation, report CTAs, and
+ * methodology accordion toggles to privacy-light event names without embedding
+ * titles, URLs, or entry names.
  */
 
 export const QUALITY_PAGE_SURFACE = "quality-page";
+
+export type QualityMethodId =
+  | "source-backed"
+  | "safety-notes"
+  | "privacy-notes"
+  | "reviewed"
+  | "install-command";
 
 export function qualityPageCategoryBrowseAnalyticsEvent(): string {
   return "quality_page_category_browse_click";
@@ -54,5 +62,22 @@ export function qualityPageIssueAnalyticsEvent(): string {
 export function qualityPageIssueAnalyticsData() {
   return {
     surface: QUALITY_PAGE_SURFACE,
+  };
+}
+
+export function qualityPageMethodToggleAnalyticsEvent(): string {
+  return "quality_page_method_toggle_click";
+}
+
+export function qualityPageMethodToggleAnalyticsData(
+  methodId: QualityMethodId,
+  open: boolean,
+  methodCount: number,
+) {
+  return {
+    surface: QUALITY_PAGE_SURFACE,
+    methodId,
+    open,
+    methodCount,
   };
 }

--- a/apps/web/src/lib/quality-page-cta-events.ts
+++ b/apps/web/src/lib/quality-page-cta-events.ts
@@ -11,4 +11,7 @@ export {
   qualityPageClaimAnalyticsEvent,
   qualityPageIssueAnalyticsData,
   qualityPageIssueAnalyticsEvent,
+  qualityPageMethodToggleAnalyticsData,
+  qualityPageMethodToggleAnalyticsEvent,
+  type QualityMethodId,
 } from "@/lib/quality-page-cta-events-lib";

--- a/apps/web/src/lib/subscriptions-page-cta-events-lib.ts
+++ b/apps/web/src/lib/subscriptions-page-cta-events-lib.ts
@@ -1,8 +1,9 @@
 /**
  * Pure subscriptions page navigation analytics helpers.
  *
- * Maps directory egress, alert manager open, and unsubscribe confirms to
- * privacy-light event names without embedding emails, labels, or follow IDs.
+ * Maps directory egress, alert manager open, rename actions, remove intents,
+ * and unsubscribe confirms to privacy-light event names without embedding
+ * emails, labels, or follow IDs.
  */
 
 export const SUBSCRIPTIONS_PAGE_SURFACE = "subscriptions-page";
@@ -10,6 +11,8 @@ export const SUBSCRIPTIONS_PAGE_SURFACE = "subscriptions-page";
 export type SubscriptionsPageDestination = "feeds" | "browse";
 
 export type SubscriptionsPageConfirmKind = "follow" | "segment";
+
+export type SubscriptionsPageRenamePhase = "start" | "save";
 
 export function subscriptionsPageEgressAnalyticsEvent(): string {
   return "subscriptions_page_egress_click";
@@ -42,5 +45,35 @@ export function subscriptionsPageConfirmAnalyticsData(kind: SubscriptionsPageCon
   return {
     surface: SUBSCRIPTIONS_PAGE_SURFACE,
     kind,
+  };
+}
+
+export function subscriptionsPageRenameAnalyticsEvent(): string {
+  return "subscriptions_page_rename_click";
+}
+
+export function subscriptionsPageRenameAnalyticsData(
+  phase: SubscriptionsPageRenamePhase,
+  followCount: number,
+) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    phase,
+    followCount,
+  };
+}
+
+export function subscriptionsPageRemoveIntentAnalyticsEvent(): string {
+  return "subscriptions_page_remove_intent_click";
+}
+
+export function subscriptionsPageRemoveIntentAnalyticsData(
+  kind: SubscriptionsPageConfirmKind,
+  itemCount: number,
+) {
+  return {
+    surface: SUBSCRIPTIONS_PAGE_SURFACE,
+    kind,
+    itemCount,
   };
 }

--- a/apps/web/src/lib/subscriptions-page-cta-events.ts
+++ b/apps/web/src/lib/subscriptions-page-cta-events.ts
@@ -9,6 +9,11 @@ export {
   subscriptionsPageEgressAnalyticsEvent,
   subscriptionsPageManageAlertsAnalyticsData,
   subscriptionsPageManageAlertsAnalyticsEvent,
+  subscriptionsPageRemoveIntentAnalyticsData,
+  subscriptionsPageRemoveIntentAnalyticsEvent,
+  subscriptionsPageRenameAnalyticsData,
+  subscriptionsPageRenameAnalyticsEvent,
   type SubscriptionsPageConfirmKind,
   type SubscriptionsPageDestination,
+  type SubscriptionsPageRenamePhase,
 } from "@/lib/subscriptions-page-cta-events-lib";

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -36,8 +36,13 @@ import {
   qualityPageClaimAnalyticsEvent,
   qualityPageIssueAnalyticsData,
   qualityPageIssueAnalyticsEvent,
+  qualityPageMethodToggleAnalyticsData,
+  qualityPageMethodToggleAnalyticsEvent,
+  type QualityMethodId,
 } from "@/lib/quality-page-cta-events";
 import { cn } from "@/lib/utils";
+
+const QUALITY_METHOD_COUNT = 5;
 
 const CHANGELOG_PREVIEW_COUNT = 6;
 
@@ -323,22 +328,27 @@ function QualityPage() {
           </p>
           <div className="mt-4 space-y-2">
             <Method
+              methodId="source-backed"
               label="Source-backed"
               detail="A verifiable source URL (repo, package registry, official docs) that matches the claimed author."
             />
             <Method
+              methodId="safety-notes"
               label="Safety notes"
               detail="Required for MCP, hooks, skills, and commands — anything that runs code, touches files, or holds credentials."
             />
             <Method
+              methodId="privacy-notes"
               label="Privacy notes"
               detail="Required for MCP and skills — covers what data leaves your machine."
             />
             <Method
+              methodId="reviewed"
               label="Reviewed"
               detail="A maintainer has eyeballed the metadata. Not a code audit, not a runtime sandbox."
             />
             <Method
+              methodId="install-command"
               label="Install command"
               detail="An exact, copyable command. We do not run it for you."
             />
@@ -405,12 +415,27 @@ function MethodologyCard({ id, title, body }: { id: string; title: string; body:
   );
 }
 
-function Method({ label, detail }: { label: string; detail: string }) {
+function Method({
+  methodId,
+  label,
+  detail,
+}: {
+  methodId: QualityMethodId;
+  label: string;
+  detail: string;
+}) {
   const [open, setOpen] = useState(false);
   return (
     <button
       type="button"
-      onClick={() => setOpen((v) => !v)}
+      onClick={() => {
+        const next = !open;
+        trackEvent(
+          qualityPageMethodToggleAnalyticsEvent(),
+          qualityPageMethodToggleAnalyticsData(methodId, next, QUALITY_METHOD_COUNT),
+        );
+        setOpen(next);
+      }}
       className="w-full rounded-lg border border-border bg-surface p-3 text-left transition-colors duration-200 ease-out hover:bg-surface-2"
       aria-expanded={open}
     >

--- a/apps/web/src/routes/subscriptions.tsx
+++ b/apps/web/src/routes/subscriptions.tsx
@@ -14,6 +14,10 @@ import {
   subscriptionsPageEgressAnalyticsEvent,
   subscriptionsPageManageAlertsAnalyticsData,
   subscriptionsPageManageAlertsAnalyticsEvent,
+  subscriptionsPageRemoveIntentAnalyticsData,
+  subscriptionsPageRemoveIntentAnalyticsEvent,
+  subscriptionsPageRenameAnalyticsData,
+  subscriptionsPageRenameAnalyticsEvent,
 } from "@/lib/subscriptions-page-cta-events";
 import {
   AlertDialog,
@@ -103,10 +107,18 @@ function SubscriptionsPage() {
 
   const removeFollow = (id: string) => {
     const f = recents.follows.find((x) => x.id === id);
+    trackEvent(
+      subscriptionsPageRemoveIntentAnalyticsEvent(),
+      subscriptionsPageRemoveIntentAnalyticsData("follow", followCount),
+    );
     setConfirm({ kind: "follow", id, label: f?.label ?? "this stream" });
   };
   const removeSegment = (id: string) => {
     const s = recents.segments.find((x) => x.id === id);
+    trackEvent(
+      subscriptionsPageRemoveIntentAnalyticsEvent(),
+      subscriptionsPageRemoveIntentAnalyticsData("segment", segmentCount),
+    );
     setConfirm({ kind: "segment", id, label: s?.label ?? "this segment", email: s?.email });
   };
 
@@ -200,6 +212,10 @@ function SubscriptionsPage() {
                           onChange={(e) => setRenameDraft(e.target.value)}
                           onKeyDown={(e) => {
                             if (e.key === "Enter") {
+                              trackEvent(
+                                subscriptionsPageRenameAnalyticsEvent(),
+                                subscriptionsPageRenameAnalyticsData("save", followCount),
+                              );
                               recents.renameFollow(f.id, renameDraft);
                               setRenameId(null);
                             } else if (e.key === "Escape") setRenameId(null);
@@ -219,6 +235,10 @@ function SubscriptionsPage() {
                         type="button"
                         aria-label="Save"
                         onClick={() => {
+                          trackEvent(
+                            subscriptionsPageRenameAnalyticsEvent(),
+                            subscriptionsPageRenameAnalyticsData("save", followCount),
+                          );
                           recents.renameFollow(f.id, renameDraft);
                           setRenameId(null);
                         }}
@@ -231,6 +251,10 @@ function SubscriptionsPage() {
                         type="button"
                         aria-label="Rename"
                         onClick={() => {
+                          trackEvent(
+                            subscriptionsPageRenameAnalyticsEvent(),
+                            subscriptionsPageRenameAnalyticsData("start", followCount),
+                          );
                           setRenameId(f.id);
                           setRenameDraft(f.label);
                         }}

--- a/tests/a11y-chrome-cta-events-lib.test.ts
+++ b/tests/a11y-chrome-cta-events-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  PEEK_HINT_SURFACE,
+  SKIP_LINK_SURFACE,
+  peekHintDismissAnalyticsData,
+  peekHintDismissAnalyticsEvent,
+  skipLinkAnalyticsData,
+  skipLinkAnalyticsEvent,
+} from "@/lib/a11y-chrome-cta-events-lib";
+
+describe("a11y chrome cta events lib", () => {
+  it("builds privacy-light skip-link and peek-hint analytics", () => {
+    expect(skipLinkAnalyticsEvent()).toBe("skip_link_click");
+    expect(skipLinkAnalyticsData()).toEqual({
+      surface: SKIP_LINK_SURFACE,
+    });
+    expect(peekHintDismissAnalyticsEvent()).toBe("peek_hint_dismiss_click");
+    expect(peekHintDismissAnalyticsData("button")).toEqual({
+      surface: PEEK_HINT_SURFACE,
+      reason: "button",
+    });
+    expect(peekHintDismissAnalyticsData("timeout")).toEqual({
+      surface: PEEK_HINT_SURFACE,
+      reason: "timeout",
+    });
+    expect(peekHintDismissAnalyticsData("hotkey")).toEqual({
+      surface: PEEK_HINT_SURFACE,
+      reason: "hotkey",
+    });
+  });
+});

--- a/tests/quality-page-cta-events-lib.test.ts
+++ b/tests/quality-page-cta-events-lib.test.ts
@@ -9,6 +9,8 @@ import {
   qualityPageClaimAnalyticsEvent,
   qualityPageIssueAnalyticsData,
   qualityPageIssueAnalyticsEvent,
+  qualityPageMethodToggleAnalyticsData,
+  qualityPageMethodToggleAnalyticsEvent,
 } from "@/lib/quality-page-cta-events-lib";
 
 describe("quality page cta events lib", () => {
@@ -37,6 +39,28 @@ describe("quality page cta events lib", () => {
     expect(qualityPageIssueAnalyticsEvent()).toBe("quality_page_issue_click");
     expect(qualityPageIssueAnalyticsData()).toEqual({
       surface: QUALITY_PAGE_SURFACE,
+    });
+  });
+
+  it("builds quality methodology accordion toggle analytics", () => {
+    expect(qualityPageMethodToggleAnalyticsEvent()).toBe(
+      "quality_page_method_toggle_click",
+    );
+    expect(
+      qualityPageMethodToggleAnalyticsData("source-backed", true, 5),
+    ).toEqual({
+      surface: QUALITY_PAGE_SURFACE,
+      methodId: "source-backed",
+      open: true,
+      methodCount: 5,
+    });
+    expect(
+      qualityPageMethodToggleAnalyticsData("install-command", false, 5),
+    ).toEqual({
+      surface: QUALITY_PAGE_SURFACE,
+      methodId: "install-command",
+      open: false,
+      methodCount: 5,
     });
   });
 });

--- a/tests/subscriptions-page-cta-events-lib.test.ts
+++ b/tests/subscriptions-page-cta-events-lib.test.ts
@@ -7,6 +7,10 @@ import {
   subscriptionsPageEgressAnalyticsEvent,
   subscriptionsPageManageAlertsAnalyticsData,
   subscriptionsPageManageAlertsAnalyticsEvent,
+  subscriptionsPageRemoveIntentAnalyticsData,
+  subscriptionsPageRemoveIntentAnalyticsEvent,
+  subscriptionsPageRenameAnalyticsData,
+  subscriptionsPageRenameAnalyticsEvent,
 } from "@/lib/subscriptions-page-cta-events-lib";
 
 describe("subscriptions page cta events lib", () => {
@@ -40,6 +44,35 @@ describe("subscriptions page cta events lib", () => {
     expect(subscriptionsPageConfirmAnalyticsData("segment")).toEqual({
       surface: SUBSCRIPTIONS_PAGE_SURFACE,
       kind: "segment",
+    });
+  });
+
+  it("builds subscriptions rename and remove-intent analytics", () => {
+    expect(subscriptionsPageRenameAnalyticsEvent()).toBe(
+      "subscriptions_page_rename_click",
+    );
+    expect(subscriptionsPageRenameAnalyticsData("start", 3)).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      phase: "start",
+      followCount: 3,
+    });
+    expect(subscriptionsPageRenameAnalyticsData("save", 3)).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      phase: "save",
+      followCount: 3,
+    });
+    expect(subscriptionsPageRemoveIntentAnalyticsEvent()).toBe(
+      "subscriptions_page_remove_intent_click",
+    );
+    expect(subscriptionsPageRemoveIntentAnalyticsData("follow", 4)).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      kind: "follow",
+      itemCount: 4,
+    });
+    expect(subscriptionsPageRemoveIntentAnalyticsData("segment", 2)).toEqual({
+      surface: SUBSCRIPTIONS_PAGE_SURFACE,
+      kind: "segment",
+      itemCount: 2,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend subscriptions CTA helpers for rename start/save and remove-intent
- Extend quality CTA helpers for methodology accordion toggles
- Add a11y chrome CTA helpers for skip-link and peek-hint dismiss
- Privacy-light payloads only (no emails, labels, coach-mark copy, or paths)

Refs #550

### Why no new issue
Continues Growth Sprint 1 (#550) decision-layer analytics: pure `*-cta-events-lib` helpers + thin wrappers + `trackEvent` wiring, matching #5069/#5081/#5087.

## Test plan
- [x] prettier + vitest on three libs
- [x] verified no file overlap with currently open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, codecov/project, required-pr-gate)


Made with [Cursor](https://cursor.com)