### PR TITLE
feat(web): add tools submit form submit analytics

### DIFF
--- a/apps/web/src/lib/tools-submit-page-cta-events-lib.ts
+++ b/apps/web/src/lib/tools-submit-page-cta-events-lib.ts
@@ -1,8 +1,9 @@
 /**
  * Pure tools submit page navigation analytics helpers.
  *
- * Maps breadcrumb, community submit, and commercial path egress to privacy-light
- * event names without embedding form content, URLs, or contact details.
+ * Maps breadcrumb, community submit, commercial path egress, and lead-form
+ * submit clicks to privacy-light event names without embedding form content,
+ * URLs, or contact details.
  */
 
 export const TOOLS_SUBMIT_PAGE_SURFACE = "tools-submit-page";
@@ -50,5 +51,31 @@ export function toolsSubmitClaimAnalyticsData(source: ToolsSubmitCommercialSourc
   return {
     surface: TOOLS_SUBMIT_PAGE_SURFACE,
     source,
+  };
+}
+
+export type ToolsSubmitListingTier = "featured" | "sponsored";
+
+export function toolsSubmitListingSubmitAnalyticsEvent(): string {
+  return "tools_submit_listing_submit_click";
+}
+
+export function toolsSubmitListingSubmitAnalyticsData(tierInterest: ToolsSubmitListingTier) {
+  return {
+    surface: TOOLS_SUBMIT_PAGE_SURFACE,
+    form: "listing" as const,
+    tierInterest,
+  };
+}
+
+export function toolsSubmitReviewSubmitAnalyticsEvent(): string {
+  return "tools_submit_review_submit_click";
+}
+
+export function toolsSubmitReviewSubmitAnalyticsData(hasEntryRef: boolean) {
+  return {
+    surface: TOOLS_SUBMIT_PAGE_SURFACE,
+    form: "paid-review" as const,
+    hasEntryRef,
   };
 }

--- a/apps/web/src/lib/tools-submit-page-cta-events.ts
+++ b/apps/web/src/lib/tools-submit-page-cta-events.ts
@@ -9,8 +9,13 @@ export {
   toolsSubmitClaimAnalyticsEvent,
   toolsSubmitCommunityAnalyticsData,
   toolsSubmitCommunityAnalyticsEvent,
+  toolsSubmitListingSubmitAnalyticsData,
+  toolsSubmitListingSubmitAnalyticsEvent,
+  toolsSubmitReviewSubmitAnalyticsData,
+  toolsSubmitReviewSubmitAnalyticsEvent,
   toolsSubmitToolsAnalyticsData,
   toolsSubmitToolsAnalyticsEvent,
   type ToolsSubmitCommercialSource,
+  type ToolsSubmitListingTier,
   type ToolsSubmitToolsSource,
 } from "@/lib/tools-submit-page-cta-events-lib";

--- a/apps/web/src/routes/tools.submit.tsx
+++ b/apps/web/src/routes/tools.submit.tsx
@@ -14,6 +14,10 @@ import {
   toolsSubmitClaimAnalyticsEvent,
   toolsSubmitCommunityAnalyticsData,
   toolsSubmitCommunityAnalyticsEvent,
+  toolsSubmitListingSubmitAnalyticsData,
+  toolsSubmitListingSubmitAnalyticsEvent,
+  toolsSubmitReviewSubmitAnalyticsData,
+  toolsSubmitReviewSubmitAnalyticsEvent,
   toolsSubmitToolsAnalyticsData,
   toolsSubmitToolsAnalyticsEvent,
 } from "@/lib/tools-submit-page-cta-events";
@@ -120,13 +124,18 @@ function CommercialToolListingForm() {
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (submitting) return;
+    const form = new FormData(e.currentTarget);
+    const tierInterest = toolListingTierInterest(form.get("tierInterest"));
+    trackEvent(
+      toolsSubmitListingSubmitAnalyticsEvent(),
+      toolsSubmitListingSubmitAnalyticsData(tierInterest),
+    );
     setSubmitting(true);
     setError("");
-    const form = new FormData(e.currentTarget);
     try {
       await submitListingLead({
         kind: "tool",
-        tierInterest: toolListingTierInterest(form.get("tierInterest")),
+        tierInterest,
         contactName: String(form.get("contactName") ?? "").trim(),
         contactEmail: String(form.get("email") ?? "").trim(),
         companyName: String(form.get("company") ?? "").trim(),
@@ -209,10 +218,14 @@ function PaidReviewInterestForm() {
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (submitting) return;
-    setSubmitting(true);
-    setError("");
     const form = new FormData(e.currentTarget);
     const entryRef = String(form.get("entryRef") ?? "").trim();
+    trackEvent(
+      toolsSubmitReviewSubmitAnalyticsEvent(),
+      toolsSubmitReviewSubmitAnalyticsData(Boolean(entryRef)),
+    );
+    setSubmitting(true);
+    setError("");
     const notes = String(form.get("notes") ?? "").trim();
     try {
       await submitListingLead({

--- a/tests/tools-submit-page-cta-events-lib.test.ts
+++ b/tests/tools-submit-page-cta-events-lib.test.ts
@@ -7,6 +7,10 @@ import {
   toolsSubmitClaimAnalyticsEvent,
   toolsSubmitCommunityAnalyticsData,
   toolsSubmitCommunityAnalyticsEvent,
+  toolsSubmitListingSubmitAnalyticsData,
+  toolsSubmitListingSubmitAnalyticsEvent,
+  toolsSubmitReviewSubmitAnalyticsData,
+  toolsSubmitReviewSubmitAnalyticsEvent,
   toolsSubmitToolsAnalyticsData,
   toolsSubmitToolsAnalyticsEvent,
 } from "@/lib/tools-submit-page-cta-events-lib";
@@ -35,6 +39,35 @@ describe("tools submit page cta events lib", () => {
     expect(toolsSubmitClaimAnalyticsData("commercial-paths")).toEqual({
       surface: TOOLS_SUBMIT_PAGE_SURFACE,
       source: "commercial-paths",
+    });
+  });
+
+  it("builds tools submit form submit analytics", () => {
+    expect(toolsSubmitListingSubmitAnalyticsEvent()).toBe(
+      "tools_submit_listing_submit_click",
+    );
+    expect(toolsSubmitListingSubmitAnalyticsData("featured")).toEqual({
+      surface: TOOLS_SUBMIT_PAGE_SURFACE,
+      form: "listing",
+      tierInterest: "featured",
+    });
+    expect(toolsSubmitListingSubmitAnalyticsData("sponsored")).toEqual({
+      surface: TOOLS_SUBMIT_PAGE_SURFACE,
+      form: "listing",
+      tierInterest: "sponsored",
+    });
+    expect(toolsSubmitReviewSubmitAnalyticsEvent()).toBe(
+      "tools_submit_review_submit_click",
+    );
+    expect(toolsSubmitReviewSubmitAnalyticsData(true)).toEqual({
+      surface: TOOLS_SUBMIT_PAGE_SURFACE,
+      form: "paid-review",
+      hasEntryRef: true,
+    });
+    expect(toolsSubmitReviewSubmitAnalyticsData(false)).toEqual({
+      surface: TOOLS_SUBMIT_PAGE_SURFACE,
+      form: "paid-review",
+      hasEntryRef: false,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend tools-submit CTA lib with listing and paid-review form submit helpers
- Wire Featured listing and Trust/source review form submits on /tools/submit
- Events: tools_submit_listing_submit_click, tools_submit_review_submit_click

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)

Made with [Cursor](https://cursor.com)