### PR TITLE
fix(web): wire browse mobile category filter analytics

### DIFF
--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -1107,16 +1107,15 @@ function Browse() {
                 { id: "", label: "All" },
                 ...CATEGORIES.map((c) => ({ id: c.id, label: c.label })),
               ].map((c) => (
-                <Link
-                  key={c.id || "all"}
-                  to="/browse"
-                  search={{ ...sp, category: c.id }}
-                  className="shrink-0"
-                >
-                  <FilterChip role="radio" active={(sp.category || "") === c.id} onClick={() => {}}>
+                <span key={c.id || "all"} className="shrink-0">
+                  <FilterChip
+                    role="radio"
+                    active={(sp.category || "") === c.id}
+                    onClick={() => onCategoryFilter(c.id)}
+                  >
                     {c.label}
                   </FilterChip>
-                </Link>
+                </span>
               ))}
             </div>
             <span


### PR DESCRIPTION
## Summary
- Route mobile category chips through onCategoryFilter (same as desktop)
- Fires existing browse_filter_select instead of silent Link navigation

Refs #550

## Test plan
- [x] prettier, type-check, build locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)

Made with [Cursor](https://cursor.com)