### PR TITLE
feat(web): add integrations install, jobs share, and changelog feed analytics

### DIFF
--- a/apps/web/src/lib/changelog-page-cta-events-lib.ts
+++ b/apps/web/src/lib/changelog-page-cta-events-lib.ts
@@ -53,3 +53,37 @@ export function changelogQualityEgressAnalyticsData(issueCount: number) {
     issueCount,
   };
 }
+
+export type ChangelogFeedDestination = "rss" | "atom";
+
+export function changelogFeedEgressAnalyticsEvent(): string {
+  return "changelog_feed_egress_click";
+}
+
+export function changelogFeedEgressAnalyticsData(
+  destination: ChangelogFeedDestination,
+  matchCount: number,
+) {
+  return {
+    surface: CHANGELOG_PAGE_SURFACE,
+    destination,
+    matchCount,
+  };
+}
+
+export function changelogDiffEgressAnalyticsEvent(): string {
+  return "changelog_diff_egress_click";
+}
+
+export function changelogDiffEgressAnalyticsData(
+  releaseStream: ReleaseStream,
+  rowIndex: number,
+  matchCount: number,
+) {
+  return {
+    surface: CHANGELOG_PAGE_SURFACE,
+    releaseStream,
+    rowIndex,
+    matchCount,
+  };
+}

--- a/apps/web/src/lib/changelog-page-cta-events.ts
+++ b/apps/web/src/lib/changelog-page-cta-events.ts
@@ -3,11 +3,16 @@
  */
 export {
   CHANGELOG_PAGE_SURFACE,
+  changelogDiffEgressAnalyticsData,
+  changelogDiffEgressAnalyticsEvent,
+  changelogFeedEgressAnalyticsData,
+  changelogFeedEgressAnalyticsEvent,
   changelogQualityEgressAnalyticsData,
   changelogQualityEgressAnalyticsEvent,
   changelogReadMoreAnalyticsData,
   changelogReadMoreAnalyticsEvent,
   changelogStreamFilterAnalyticsData,
   changelogStreamFilterAnalyticsEvent,
+  type ChangelogFeedDestination,
   type ChangelogStreamFilter,
 } from "@/lib/changelog-page-cta-events-lib";

--- a/apps/web/src/lib/integrations-hub-cta-events-lib.ts
+++ b/apps/web/src/lib/integrations-hub-cta-events-lib.ts
@@ -105,3 +105,24 @@ export function integrationsDetailActionAnalyticsData(
     kind,
   };
 }
+
+export function integrationsDetailInstallCopyAnalyticsEvent(): string {
+  return "integrations_detail_install_copy_click";
+}
+
+export function integrationsDetailInstallCopyAnalyticsData(
+  integrationSlug: string,
+  installIndex: number,
+  installCount: number,
+  status: string,
+  kind: string,
+) {
+  return {
+    surface: INTEGRATIONS_DETAIL_SURFACE,
+    integrationSlug,
+    installIndex,
+    installCount,
+    status,
+    kind,
+  };
+}

--- a/apps/web/src/lib/integrations-hub-cta-events.ts
+++ b/apps/web/src/lib/integrations-hub-cta-events.ts
@@ -8,6 +8,8 @@ export {
   integrationsDetailActionAnalyticsEvent,
   integrationsDetailIndexAnalyticsData,
   integrationsDetailIndexAnalyticsEvent,
+  integrationsDetailInstallCopyAnalyticsData,
+  integrationsDetailInstallCopyAnalyticsEvent,
   integrationsDetailRelatedAnalyticsData,
   integrationsDetailRelatedAnalyticsEvent,
   integrationsIndexApiDocsAnalyticsData,

--- a/apps/web/src/lib/jobs-hub-cta-events-lib.ts
+++ b/apps/web/src/lib/jobs-hub-cta-events-lib.ts
@@ -168,3 +168,15 @@ export function jobsErrorRetryAnalyticsData(surface: JobsErrorSurface) {
     surface,
   };
 }
+
+export function jobsDetailShareCopyAnalyticsEvent(): string {
+  return "jobs_detail_share_copy_click";
+}
+
+export function jobsDetailShareCopyAnalyticsData(jobSlug: string, tier: string) {
+  return {
+    surface: JOBS_DETAIL_SURFACE,
+    jobSlug,
+    tier,
+  };
+}

--- a/apps/web/src/lib/jobs-hub-cta-events.ts
+++ b/apps/web/src/lib/jobs-hub-cta-events.ts
@@ -10,6 +10,8 @@ export {
   jobsDetailIndexAnalyticsEvent,
   jobsDetailRelatedAnalyticsData,
   jobsDetailRelatedAnalyticsEvent,
+  jobsDetailShareCopyAnalyticsData,
+  jobsDetailShareCopyAnalyticsEvent,
   jobsErrorRetryAnalyticsData,
   jobsErrorRetryAnalyticsEvent,
   jobsIndexFilterClearAnalyticsData,

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -11,6 +11,10 @@ import {
   changelogDiffEntryAnalyticsEvent,
 } from "@/lib/directory-page-entry-cta-events";
 import {
+  changelogDiffEgressAnalyticsData,
+  changelogDiffEgressAnalyticsEvent,
+  changelogFeedEgressAnalyticsData,
+  changelogFeedEgressAnalyticsEvent,
   changelogQualityEgressAnalyticsData,
   changelogQualityEgressAnalyticsEvent,
   changelogReadMoreAnalyticsData,
@@ -125,12 +129,24 @@ function ChangelogPage() {
         <div className="flex flex-wrap items-center gap-2">
           <a
             href="/feed.xml"
+            onClick={() =>
+              trackEvent(
+                changelogFeedEgressAnalyticsEvent(),
+                changelogFeedEgressAnalyticsData("rss", items.length),
+              )
+            }
             className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-sm font-medium text-ink hover:bg-surface-2"
           >
             <Rss className="h-3.5 w-3.5" /> RSS
           </a>
           <a
             href="/atom.xml"
+            onClick={() =>
+              trackEvent(
+                changelogFeedEgressAnalyticsEvent(),
+                changelogFeedEgressAnalyticsData("atom", items.length),
+              )
+            }
             className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-sm font-medium text-ink hover:bg-surface-2"
           >
             Atom
@@ -267,6 +283,12 @@ function ChangelogPage() {
                       {note.prevHash && (
                         <a
                           href={`/api/registry/diff?from=${encodeURIComponent(note.prevHash)}&to=${encodeURIComponent(note.hash ?? "")}`}
+                          onClick={() =>
+                            trackEvent(
+                              changelogDiffEgressAnalyticsEvent(),
+                              changelogDiffEgressAnalyticsData(note.stream, i, items.length),
+                            )
+                          }
                           className="mt-3 inline-block text-[11px] font-mono text-ink-muted hover:text-ink"
                         >
                           Compare to {note.prevHash} →

--- a/apps/web/src/routes/integrations.$slug.tsx
+++ b/apps/web/src/routes/integrations.$slug.tsx
@@ -17,6 +17,8 @@ import {
   integrationsDetailActionAnalyticsEvent,
   integrationsDetailIndexAnalyticsData,
   integrationsDetailIndexAnalyticsEvent,
+  integrationsDetailInstallCopyAnalyticsData,
+  integrationsDetailInstallCopyAnalyticsEvent,
   integrationsDetailRelatedAnalyticsData,
   integrationsDetailRelatedAnalyticsEvent,
 } from "@/lib/integrations-hub-cta-events";
@@ -168,17 +170,30 @@ function IntegrationDetail() {
           {integration.install && integration.install.length > 0 && (
             <Block title="Install">
               <div className="space-y-3">
-                {integration.install.map((i: { client: string; snippet: string }) => (
-                  <div key={i.client} className="rounded-md border border-border bg-surface">
-                    <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
-                      <span className="text-xs font-medium text-ink">{i.client}</span>
-                      <CopyButton value={i.snippet} label="Copy" />
+                {integration.install.map(
+                  (i: { client: string; snippet: string }, installIndex: number) => (
+                    <div key={i.client} className="rounded-md border border-border bg-surface">
+                      <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+                        <span className="text-xs font-medium text-ink">{i.client}</span>
+                        <CopyButton
+                          value={i.snippet}
+                          label="Copy"
+                          event={integrationsDetailInstallCopyAnalyticsEvent()}
+                          eventData={integrationsDetailInstallCopyAnalyticsData(
+                            integration.slug,
+                            installIndex,
+                            integration.install!.length,
+                            integration.status,
+                            integration.kind,
+                          )}
+                        />
+                      </div>
+                      <pre className="overflow-auto p-3 font-mono text-[11px] text-ink">
+                        <code>{i.snippet}</code>
+                      </pre>
                     </div>
-                    <pre className="overflow-auto p-3 font-mono text-[11px] text-ink">
-                      <code>{i.snippet}</code>
-                    </pre>
-                  </div>
-                ))}
+                  ),
+                )}
               </div>
             </Block>
           )}

--- a/apps/web/src/routes/jobs.$slug.tsx
+++ b/apps/web/src/routes/jobs.$slug.tsx
@@ -16,6 +16,8 @@ import {
   jobsDetailIndexAnalyticsEvent,
   jobsDetailRelatedAnalyticsData,
   jobsDetailRelatedAnalyticsEvent,
+  jobsDetailShareCopyAnalyticsData,
+  jobsDetailShareCopyAnalyticsEvent,
   jobsErrorRetryAnalyticsData,
   jobsErrorRetryAnalyticsEvent,
 } from "@/lib/jobs-hub-cta-events";
@@ -292,6 +294,8 @@ function JobDetail() {
                 label="Copy link"
                 size="sm"
                 className="inline-flex h-9 flex-1 items-center justify-center gap-1.5 rounded-md border border-border bg-background px-3 text-xs text-ink-muted hover:text-ink"
+                event={jobsDetailShareCopyAnalyticsEvent()}
+                eventData={jobsDetailShareCopyAnalyticsData(job.slug, job.tier)}
               />
             </div>
             <p className="mt-3 text-[11px] leading-relaxed text-ink-subtle">

--- a/tests/changelog-page-cta-events-lib.test.ts
+++ b/tests/changelog-page-cta-events-lib.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   CHANGELOG_PAGE_SURFACE,
+  changelogDiffEgressAnalyticsData,
+  changelogDiffEgressAnalyticsEvent,
+  changelogFeedEgressAnalyticsData,
+  changelogFeedEgressAnalyticsEvent,
   changelogQualityEgressAnalyticsData,
   changelogQualityEgressAnalyticsEvent,
   changelogReadMoreAnalyticsData,
@@ -35,6 +39,31 @@ describe("changelog page cta events lib", () => {
     expect(changelogQualityEgressAnalyticsData(12)).toEqual({
       surface: CHANGELOG_PAGE_SURFACE,
       issueCount: 12,
+    });
+  });
+
+  it("builds changelog feed and diff egress analytics", () => {
+    expect(changelogFeedEgressAnalyticsEvent()).toBe(
+      "changelog_feed_egress_click",
+    );
+    expect(changelogFeedEgressAnalyticsData("rss", 12)).toEqual({
+      surface: CHANGELOG_PAGE_SURFACE,
+      destination: "rss",
+      matchCount: 12,
+    });
+    expect(changelogFeedEgressAnalyticsData("atom", 12)).toEqual({
+      surface: CHANGELOG_PAGE_SURFACE,
+      destination: "atom",
+      matchCount: 12,
+    });
+    expect(changelogDiffEgressAnalyticsEvent()).toBe(
+      "changelog_diff_egress_click",
+    );
+    expect(changelogDiffEgressAnalyticsData("release", 1, 12)).toEqual({
+      surface: CHANGELOG_PAGE_SURFACE,
+      releaseStream: "release",
+      rowIndex: 1,
+      matchCount: 12,
     });
   });
 });

--- a/tests/integrations-hub-cta-events-lib.test.ts
+++ b/tests/integrations-hub-cta-events-lib.test.ts
@@ -6,6 +6,8 @@ import {
   integrationsDetailActionAnalyticsEvent,
   integrationsDetailIndexAnalyticsData,
   integrationsDetailIndexAnalyticsEvent,
+  integrationsDetailInstallCopyAnalyticsData,
+  integrationsDetailInstallCopyAnalyticsEvent,
   integrationsDetailRelatedAnalyticsData,
   integrationsDetailRelatedAnalyticsEvent,
   integrationsIndexApiDocsAnalyticsData,
@@ -104,6 +106,25 @@ describe("integrations hub cta events lib", () => {
       action: "secondary",
       status: "beta",
       kind: "mcp-server",
+    });
+    expect(integrationsDetailInstallCopyAnalyticsEvent()).toBe(
+      "integrations_detail_install_copy_click",
+    );
+    expect(
+      integrationsDetailInstallCopyAnalyticsData(
+        "raycast",
+        0,
+        2,
+        "live",
+        "extension",
+      ),
+    ).toEqual({
+      surface: INTEGRATIONS_DETAIL_SURFACE,
+      integrationSlug: "raycast",
+      installIndex: 0,
+      installCount: 2,
+      status: "live",
+      kind: "extension",
     });
   });
 });

--- a/tests/jobs-hub-cta-events-lib.test.ts
+++ b/tests/jobs-hub-cta-events-lib.test.ts
@@ -8,6 +8,8 @@ import {
   jobsDetailIndexAnalyticsEvent,
   jobsDetailRelatedAnalyticsData,
   jobsDetailRelatedAnalyticsEvent,
+  jobsDetailShareCopyAnalyticsData,
+  jobsDetailShareCopyAnalyticsEvent,
   jobsErrorRetryAnalyticsData,
   jobsErrorRetryAnalyticsEvent,
   jobsIndexFilterClearAnalyticsData,
@@ -132,6 +134,14 @@ describe("jobs hub cta events lib", () => {
     });
     expect(jobsErrorRetryAnalyticsData("jobs-detail")).toEqual({
       surface: "jobs-detail",
+    });
+    expect(jobsDetailShareCopyAnalyticsEvent()).toBe(
+      "jobs_detail_share_copy_click",
+    );
+    expect(jobsDetailShareCopyAnalyticsData("senior-mcp", "featured")).toEqual({
+      surface: JOBS_DETAIL_SURFACE,
+      jobSlug: "senior-mcp",
+      tier: "featured",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Extend integrations hub analytics for detail install-snippet copy
- Extend jobs hub analytics for detail share-link copy
- Extend changelog analytics for RSS/Atom feed egress and registry diff compare
- Privacy-light payloads only (no snippets, URLs, hashes, or free-text labels)

Refs #550

### Why no new issue
Continues Growth Sprint 1 (#550) decision-layer analytics: pure `*-cta-events-lib` helpers + thin wrappers + `trackEvent` wiring, matching #5069/#5081/#5087/#5091/#5094.

### Conflict avoidance
Does not touch open PR paths: tools-submit CTA files (#5092) or `README.md` (#5033).

## Test plan
- [x] prettier + vitest on three libs
- [x] verified no file overlap with currently open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, codecov/project, required-pr-gate)

Made with [Cursor](https://cursor.com)