### PR TITLE
feat(web): add entry plain-text and report cite CTA analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -440,3 +440,15 @@ export function entryDetailPlaybookActionAnalyticsData(
     ...(typeof adding === "boolean" ? { adding } : {}),
   };
 }
+
+export function entryDetailCitationPlainTextAnalyticsEvent(): string {
+  return "entry_detail_citation_plain_text_click";
+}
+
+export function entryDetailCitationPlainTextAnalyticsData(category: string, slug: string) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+    destination: "plain-text",
+  };
+}

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -69,4 +69,6 @@ export {
   entryDetailMobileLlmsAnalyticsData,
   entryDetailPlaybookActionAnalyticsData,
   entryDetailPlaybookActionAnalyticsEvent,
+  entryDetailCitationPlainTextAnalyticsData,
+  entryDetailCitationPlainTextAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
@@ -33,3 +33,14 @@ export function mcpSecurityReportCategoryBrowseAnalyticsData(entryCount: number)
     entryCount,
   };
 }
+
+export function mcpSecurityReportCiteAnalyticsEvent(): string {
+  return "mcp_security_report_cite_click";
+}
+
+export function mcpSecurityReportCiteAnalyticsData() {
+  return {
+    surface: MCP_SECURITY_REPORT_SURFACE,
+    destination: "canonical",
+  };
+}

--- a/apps/web/src/lib/mcp-security-report-page-cta-events.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events.ts
@@ -5,6 +5,8 @@ export {
   MCP_SECURITY_REPORT_SURFACE,
   mcpSecurityReportCategoryBrowseAnalyticsData,
   mcpSecurityReportCategoryBrowseAnalyticsEvent,
+  mcpSecurityReportCiteAnalyticsData,
+  mcpSecurityReportCiteAnalyticsEvent,
   mcpSecurityReportEgressAnalyticsData,
   mcpSecurityReportEgressAnalyticsEvent,
   type McpSecurityReportEgressDestination,

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -55,3 +55,14 @@ export function stateReportEgressAnalyticsData(
     destination,
   };
 }
+
+export function stateReportCiteAnalyticsEvent(): string {
+  return "state_report_cite_click";
+}
+
+export function stateReportCiteAnalyticsData(reportId: StateReportId) {
+  return {
+    reportId,
+    destination: "canonical",
+  };
+}

--- a/apps/web/src/lib/state-report-page-cta-events.ts
+++ b/apps/web/src/lib/state-report-page-cta-events.ts
@@ -4,6 +4,8 @@
 export {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
+  stateReportCiteAnalyticsData,
+  stateReportCiteAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
   type StateReportEgressDestination,

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -105,6 +105,8 @@ import {
   entryDetailMobileCompareToastOpenAnalyticsEvent,
   entryDetailPlaybookActionAnalyticsData,
   entryDetailPlaybookActionAnalyticsEvent,
+  entryDetailCitationPlainTextAnalyticsData,
+  entryDetailCitationPlainTextAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
 import {
   detailDecisionPresetAnalyticsData,
@@ -744,6 +746,12 @@ function Dossier() {
               also available as{" "}
               <a
                 href={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
+                onClick={() =>
+                  trackEvent(
+                    entryDetailCitationPlainTextAnalyticsEvent(),
+                    entryDetailCitationPlainTextAnalyticsData(entry.category, entry.slug),
+                  )
+                }
                 className="text-ink underline-offset-2 hover:underline"
               >
                 plain text

--- a/apps/web/src/routes/mcp-security-report.tsx
+++ b/apps/web/src/routes/mcp-security-report.tsx
@@ -15,6 +15,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   mcpSecurityReportCategoryBrowseAnalyticsData,
   mcpSecurityReportCategoryBrowseAnalyticsEvent,
+  mcpSecurityReportCiteAnalyticsData,
+  mcpSecurityReportCiteAnalyticsEvent,
   mcpSecurityReportEgressAnalyticsData,
   mcpSecurityReportEgressAnalyticsEvent,
   type McpSecurityReportEgressDestination,
@@ -274,7 +276,16 @@ function McpSecurityReportPage() {
         </p>
         <p className="mt-3 max-w-2xl text-sm text-ink-muted">
           Citing this report? Link to{" "}
-          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+          <a
+            href={absoluteUrl(PATH)}
+            onClick={() =>
+              trackEvent(
+                mcpSecurityReportCiteAnalyticsEvent(),
+                mcpSecurityReportCiteAnalyticsData(),
+              )
+            }
+            className="text-ink underline-offset-2 hover:underline"
+          >
             heyclau.de/mcp-security-report
           </a>{" "}
           with the data-as-of date. See also the{" "}

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -18,6 +18,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
+  stateReportCiteAnalyticsData,
+  stateReportCiteAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
   type StateReportEgressDestination,
@@ -30,6 +32,10 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
     stateReportEgressAnalyticsEvent(),
     stateReportEgressAnalyticsData(REPORT_ID, destination),
   );
+}
+
+function trackStateReportCite() {
+  trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
 }
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -142,7 +148,11 @@ function StateOfAgentSkillsPage() {
         </p>
         <p className="mt-3 max-w-2xl text-sm text-ink-muted">
           Citing this report? Link to{" "}
-          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+          <a
+            href={absoluteUrl(PATH)}
+            onClick={() => trackStateReportCite()}
+            className="text-ink underline-offset-2 hover:underline"
+          >
             heyclau.de/state-of-agent-skills
           </a>{" "}
           with the data-as-of date. See also the{" "}

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -18,6 +18,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
+  stateReportCiteAnalyticsData,
+  stateReportCiteAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
   type StateReportEgressDestination,
@@ -30,6 +32,10 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
     stateReportEgressAnalyticsEvent(),
     stateReportEgressAnalyticsData(REPORT_ID, destination),
   );
+}
+
+function trackStateReportCite() {
+  trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
 }
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -142,7 +148,11 @@ function StateOfAiAgentsPage() {
         </p>
         <p className="mt-3 max-w-2xl text-sm text-ink-muted">
           Citing this report? Link to{" "}
-          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+          <a
+            href={absoluteUrl(PATH)}
+            onClick={() => trackStateReportCite()}
+            className="text-ink underline-offset-2 hover:underline"
+          >
             heyclau.de/state-of-ai-agents
           </a>{" "}
           with the data-as-of date. See also the{" "}

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -18,6 +18,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
+  stateReportCiteAnalyticsData,
+  stateReportCiteAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
   type StateReportEgressDestination,
@@ -30,6 +32,10 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
     stateReportEgressAnalyticsEvent(),
     stateReportEgressAnalyticsData(REPORT_ID, destination),
   );
+}
+
+function trackStateReportCite() {
+  trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
 }
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -143,7 +149,11 @@ function StateOfClaudeCodeHooksPage() {
         </p>
         <p className="mt-3 max-w-2xl text-sm text-ink-muted">
           Citing this report? Link to{" "}
-          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+          <a
+            href={absoluteUrl(PATH)}
+            onClick={() => trackStateReportCite()}
+            className="text-ink underline-offset-2 hover:underline"
+          >
             heyclau.de/state-of-claude-code-hooks
           </a>{" "}
           with the data-as-of date. See also the broader{" "}

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -29,6 +29,8 @@ import {
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
+  stateReportCiteAnalyticsData,
+  stateReportCiteAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
   type StateReportEgressDestination,
@@ -41,6 +43,10 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
     stateReportEgressAnalyticsEvent(),
     stateReportEgressAnalyticsData(REPORT_ID, destination),
   );
+}
+
+function trackStateReportCite() {
+  trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
 }
 
 const PATH = "/state-of-claude-tooling";
@@ -331,7 +337,11 @@ function StateOfClaudeToolingPage() {
         </p>
         <p className="mt-3 max-w-2xl text-sm text-ink-muted">
           Citing this report? Link to{" "}
-          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+          <a
+            href={absoluteUrl(PATH)}
+            onClick={() => trackStateReportCite()}
+            className="text-ink underline-offset-2 hover:underline"
+          >
             heyclau.de/state-of-claude-tooling
           </a>{" "}
           and reference the data-as-of date. Browse the underlying catalog on the{" "}

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -25,6 +25,8 @@ import {
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
+  stateReportCiteAnalyticsData,
+  stateReportCiteAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
   type StateReportEgressDestination,
@@ -37,6 +39,10 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
     stateReportEgressAnalyticsEvent(),
     stateReportEgressAnalyticsData(REPORT_ID, destination),
   );
+}
+
+function trackStateReportCite() {
+  trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
 }
 
 const PATH = "/state-of-mcp-servers";
@@ -324,7 +330,11 @@ function StateOfMcpServersPage() {
         </p>
         <p className="mt-3 max-w-2xl text-sm text-ink-muted">
           Citing this report? Link to{" "}
-          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+          <a
+            href={absoluteUrl(PATH)}
+            onClick={() => trackStateReportCite()}
+            className="text-ink underline-offset-2 hover:underline"
+          >
             heyclau.de/state-of-mcp-servers
           </a>{" "}
           with the data-as-of date. See also the{" "}

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -58,6 +58,8 @@ import {
   entryDetailMobileLlmsAnalyticsData,
   entryDetailPlaybookActionAnalyticsData,
   entryDetailPlaybookActionAnalyticsEvent,
+  entryDetailCitationPlainTextAnalyticsData,
+  entryDetailCitationPlainTextAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events-lib";
 
 describe("entry detail cta events lib", () => {
@@ -429,6 +431,16 @@ describe("entry detail cta events lib", () => {
       surface: "detail-decision-playbook",
       compareCount: 3,
       adding: true,
+    });
+    expect(entryDetailCitationPlainTextAnalyticsEvent()).toBe(
+      "entry_detail_citation_plain_text_click",
+    );
+    expect(
+      entryDetailCitationPlainTextAnalyticsData("mcp", "filesystem"),
+    ).toEqual({
+      entry: "mcp/filesystem",
+      surface: "detail-command-center",
+      destination: "plain-text",
     });
   });
 });

--- a/tests/mcp-security-report-page-cta-events-lib.test.ts
+++ b/tests/mcp-security-report-page-cta-events-lib.test.ts
@@ -3,6 +3,8 @@ import {
   MCP_SECURITY_REPORT_SURFACE,
   mcpSecurityReportCategoryBrowseAnalyticsData,
   mcpSecurityReportCategoryBrowseAnalyticsEvent,
+  mcpSecurityReportCiteAnalyticsData,
+  mcpSecurityReportCiteAnalyticsEvent,
   mcpSecurityReportEgressAnalyticsData,
   mcpSecurityReportEgressAnalyticsEvent,
 } from "@/lib/mcp-security-report-page-cta-events-lib";
@@ -23,6 +25,13 @@ describe("mcp security report page cta events lib", () => {
       surface: MCP_SECURITY_REPORT_SURFACE,
       category: "mcp",
       entryCount: 128,
+    });
+    expect(mcpSecurityReportCiteAnalyticsEvent()).toBe(
+      "mcp_security_report_cite_click",
+    );
+    expect(mcpSecurityReportCiteAnalyticsData()).toEqual({
+      surface: MCP_SECURITY_REPORT_SURFACE,
+      destination: "canonical",
     });
   });
 });

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
+  stateReportCiteAnalyticsData,
+  stateReportCiteAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
 } from "@/lib/state-report-page-cta-events-lib";
@@ -39,5 +41,10 @@ describe("state report page cta events lib", () => {
         destination: "quality",
       },
     );
+    expect(stateReportCiteAnalyticsEvent()).toBe("state_report_cite_click");
+    expect(stateReportCiteAnalyticsData("agent-skills")).toEqual({
+      reportId: "agent-skills",
+      destination: "canonical",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Extend entry detail analytics for citation-facts plain-text egress
- Extend MCP security report analytics for canonical cite link clicks
- Extend state report analytics for canonical cite links across all five state-of pages
- Privacy-light payloads only (no URLs, titles, or free-text content)

Refs #550

### Why no new issue
Continues Growth Sprint 1 (#550) decision-layer analytics: pure `*-cta-events-lib` helpers + thin wrappers + `trackEvent` wiring, matching #5069/#5081/#5087/#5091/#5094/#5095/#5096.

### Conflict avoidance
Does not touch open PR paths: tools-submit CTA files (#5092) or `README.md` (#5033).

## Test plan
- [x] prettier + vitest on three libs
- [x] verified no file overlap with currently open PRs
- [ ] CI green (validate-web, coverage, codecov/patch, codecov/project, required-pr-gate)

Made with [Cursor](https://cursor.com)