### PR TITLE
feat(web): add browse empty-state egress analytics

### DIFF
--- a/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
@@ -76,6 +76,25 @@ export function browseEmptySuggestionApplyAnalyticsData(matchCount: number) {
   };
 }
 
+export type BrowseEmptyEgressDestination = "github-search" | "submit";
+
+export function browseEmptyEgressAnalyticsEvent(): string {
+  return "browse_empty_egress_click";
+}
+
+export function browseEmptyEgressAnalyticsData(
+  destination: BrowseEmptyEgressDestination,
+  hasQuery: boolean,
+  activeFilterCount: number,
+) {
+  return {
+    surface: BROWSE_RESULTS_SURFACE,
+    destination,
+    hasQuery,
+    activeFilterCount,
+  };
+}
+
 export function browseSavedSearchLinkClickAnalyticsEvent(): string {
   return "browse_saved_search_link_click";
 }

--- a/apps/web/src/lib/browse-saved-search-cta-events.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events.ts
@@ -6,6 +6,8 @@ export {
   BROWSE_RESULTS_SURFACE,
   BROWSE_SAVED_SEARCH_MANAGER_SURFACE,
   BROWSE_SAVED_SEARCH_SURFACE,
+  browseEmptyEgressAnalyticsData,
+  browseEmptyEgressAnalyticsEvent,
   browseEmptySuggestionApplyAnalyticsData,
   browseEmptySuggestionApplyAnalyticsEvent,
   browseLoadMoreAnalyticsData,
@@ -43,6 +45,7 @@ export {
   browseSavedSearchSaveAnalyticsData,
   browseSavedSearchSaveAnalyticsEvent,
   savedSearchFilterCount,
+  type BrowseEmptyEgressDestination,
   type BrowseSavedSearchAlertCadence,
   type BrowseSavedSearchAlertChannel,
 } from "@/lib/browse-saved-search-cta-events-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -85,6 +85,8 @@ import {
   type BrowseFilterAxis,
 } from "@/lib/browse-filter-cta-events";
 import {
+  browseEmptyEgressAnalyticsData,
+  browseEmptyEgressAnalyticsEvent,
   browseEmptySuggestionApplyAnalyticsData,
   browseEmptySuggestionApplyAnalyticsEvent,
   browseLoadMoreAnalyticsData,
@@ -1289,6 +1291,12 @@ function Browse() {
                       href={`https://github.com/search?q=${encodeURIComponent(sp.q)}&type=repositories`}
                       target="_blank"
                       rel="noreferrer"
+                      onClick={() =>
+                        trackEvent(
+                          browseEmptyEgressAnalyticsEvent(),
+                          browseEmptyEgressAnalyticsData("github-search", true, activeCount),
+                        )
+                      }
                       className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 font-medium text-ink hover:bg-surface-2"
                     >
                       Search GitHub for "{sp.q}" <ExternalLink className="h-3 w-3" />
@@ -1296,6 +1304,12 @@ function Browse() {
                   )}
                   <a
                     href={sp.q ? `/submit?title=${encodeURIComponent(sp.q)}` : "/submit"}
+                    onClick={() =>
+                      trackEvent(
+                        browseEmptyEgressAnalyticsEvent(),
+                        browseEmptyEgressAnalyticsData("submit", Boolean(sp.q), activeCount),
+                      )
+                    }
                     className="inline-flex h-8 items-center gap-1.5 rounded-md bg-ink px-3 font-medium text-background hover:bg-ink/90"
                   >
                     Submit this resource

--- a/tests/browse-saved-search-cta-events-lib.test.ts
+++ b/tests/browse-saved-search-cta-events-lib.test.ts
@@ -4,6 +4,8 @@ import {
   BROWSE_RESULTS_SURFACE,
   BROWSE_SAVED_SEARCH_MANAGER_SURFACE,
   BROWSE_SAVED_SEARCH_SURFACE,
+  browseEmptyEgressAnalyticsData,
+  browseEmptyEgressAnalyticsEvent,
   browseEmptySuggestionApplyAnalyticsData,
   browseEmptySuggestionApplyAnalyticsEvent,
   browseLoadMoreAnalyticsData,
@@ -133,6 +135,19 @@ describe("browse saved search cta events lib", () => {
     expect(browseEmptySuggestionApplyAnalyticsData(8)).toEqual({
       surface: BROWSE_RESULTS_SURFACE,
       matchCount: 8,
+    });
+    expect(browseEmptyEgressAnalyticsEvent()).toBe("browse_empty_egress_click");
+    expect(browseEmptyEgressAnalyticsData("github-search", true, 2)).toEqual({
+      surface: BROWSE_RESULTS_SURFACE,
+      destination: "github-search",
+      hasQuery: true,
+      activeFilterCount: 2,
+    });
+    expect(browseEmptyEgressAnalyticsData("submit", false, 0)).toEqual({
+      surface: BROWSE_RESULTS_SURFACE,
+      destination: "submit",
+      hasQuery: false,
+      activeFilterCount: 0,
     });
     expect(
       browseSavedSearchLinkClickAnalyticsData({


### PR DESCRIPTION
## Summary
- Extend browse-saved-search CTA lib with empty-state egress helpers
- Wire Search GitHub and Submit this resource when browse has no suggestion chips
- Event: browse_empty_egress_click (destination: github-search | submit)

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build locally
- [ ] CI green (validate-web, coverage, codecov/patch, required-pr-gate)

Made with [Cursor](https://cursor.com)