### PR TITLE
feat(web): add contributor GitHub/trace, OpenAPI client, and changelog poll analytics

### DIFF
--- a/apps/web/src/components/openapi.tsx
+++ b/apps/web/src/components/openapi.tsx
@@ -271,8 +271,21 @@ export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
             <div className="space-y-2 rounded-md border border-border bg-background p-3">
               {endpoint.clientExamples.map((example) => (
                 <div key={example.label}>
-                  <div className="mb-1 text-[10px] uppercase tracking-wider text-ink-subtle">
-                    {example.label}
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <div className="text-[10px] uppercase tracking-wider text-ink-subtle">
+                      {example.label}
+                    </div>
+                    <CopyButton
+                      value={example.code}
+                      label="Copy"
+                      size="sm"
+                      event={openApiCopyAnalyticsEvent()}
+                      eventData={openApiCopyAnalyticsData(
+                        endpoint.id,
+                        endpoint.method,
+                        "client-example",
+                      )}
+                    />
                   </div>
                   <pre className="overflow-auto font-mono text-[11px] text-ink">
                     <code>{example.code}</code>

--- a/apps/web/src/lib/changelog-page-cta-events-lib.ts
+++ b/apps/web/src/lib/changelog-page-cta-events-lib.ts
@@ -87,3 +87,15 @@ export function changelogDiffEgressAnalyticsData(
     matchCount,
   };
 }
+
+export function changelogPollCopyAnalyticsEvent(): string {
+  return "changelog_poll_copy_click";
+}
+
+export function changelogPollCopyAnalyticsData(matchCount: number) {
+  return {
+    surface: CHANGELOG_PAGE_SURFACE,
+    command: "diff-since",
+    matchCount,
+  };
+}

--- a/apps/web/src/lib/changelog-page-cta-events.ts
+++ b/apps/web/src/lib/changelog-page-cta-events.ts
@@ -7,6 +7,8 @@ export {
   changelogDiffEgressAnalyticsEvent,
   changelogFeedEgressAnalyticsData,
   changelogFeedEgressAnalyticsEvent,
+  changelogPollCopyAnalyticsData,
+  changelogPollCopyAnalyticsEvent,
   changelogQualityEgressAnalyticsData,
   changelogQualityEgressAnalyticsEvent,
   changelogReadMoreAnalyticsData,

--- a/apps/web/src/lib/contributor-profile-cta-events-lib.ts
+++ b/apps/web/src/lib/contributor-profile-cta-events-lib.ts
@@ -93,3 +93,45 @@ export function contributorProfileSubmitterAnalyticsData(
     rowCount,
   };
 }
+
+export function contributorProfileGithubAnalyticsEvent(): string {
+  return "contributor_profile_github_click";
+}
+
+export function contributorProfileGithubAnalyticsData(
+  contributorSlug: string,
+  acceptedCount: number,
+) {
+  return {
+    surface: CONTRIBUTOR_PROFILE_SURFACE,
+    contributorSlug,
+    acceptedCount,
+  };
+}
+
+export type ContributorProfileTraceDestination =
+  | "original-submission"
+  | "import-pr"
+  | "source"
+  | "external-submitter";
+
+export function contributorProfileTraceEgressAnalyticsEvent(): string {
+  return "contributor_profile_trace_egress_click";
+}
+
+export function contributorProfileTraceEgressAnalyticsData(
+  contributorSlug: string,
+  destination: ContributorProfileTraceDestination,
+  role: string,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    surface: CONTRIBUTOR_PROFILE_SURFACE,
+    contributorSlug,
+    destination,
+    role,
+    rowIndex,
+    rowCount,
+  };
+}

--- a/apps/web/src/lib/contributor-profile-cta-events.ts
+++ b/apps/web/src/lib/contributor-profile-cta-events.ts
@@ -5,6 +5,8 @@ export {
   CONTRIBUTOR_PROFILE_SURFACE,
   contributorProfileCategoryAnalyticsData,
   contributorProfileCategoryAnalyticsEvent,
+  contributorProfileGithubAnalyticsData,
+  contributorProfileGithubAnalyticsEvent,
   contributorProfileIndexAnalyticsData,
   contributorProfileIndexAnalyticsEvent,
   contributorProfilePeerAnalyticsData,
@@ -13,4 +15,7 @@ export {
   contributorProfileSubmitAnalyticsEvent,
   contributorProfileSubmitterAnalyticsData,
   contributorProfileSubmitterAnalyticsEvent,
+  contributorProfileTraceEgressAnalyticsData,
+  contributorProfileTraceEgressAnalyticsEvent,
+  type ContributorProfileTraceDestination,
 } from "@/lib/contributor-profile-cta-events-lib";

--- a/apps/web/src/lib/contributors-index-cta-events-lib.ts
+++ b/apps/web/src/lib/contributors-index-cta-events-lib.ts
@@ -40,3 +40,26 @@ export function contributorsIndexSubmitAnalyticsData(
     totalAccepted,
   };
 }
+
+export type ContributorsIndexGithubVariant = "featured" | "card";
+
+export function contributorsIndexGithubAnalyticsEvent(): string {
+  return "contributors_index_github_click";
+}
+
+export function contributorsIndexGithubAnalyticsData(
+  contributorSlug: string,
+  acceptedCount: number,
+  variant: ContributorsIndexGithubVariant,
+  rowIndex: number | null,
+  contributorCount: number,
+) {
+  return {
+    surface: CONTRIBUTORS_INDEX_SURFACE,
+    contributorSlug,
+    acceptedCount,
+    variant,
+    rowIndex,
+    contributorCount,
+  };
+}

--- a/apps/web/src/lib/contributors-index-cta-events.ts
+++ b/apps/web/src/lib/contributors-index-cta-events.ts
@@ -3,8 +3,11 @@
  */
 export {
   CONTRIBUTORS_INDEX_SURFACE,
+  contributorsIndexGithubAnalyticsData,
+  contributorsIndexGithubAnalyticsEvent,
   contributorsIndexProfileAnalyticsData,
   contributorsIndexProfileAnalyticsEvent,
   contributorsIndexSubmitAnalyticsData,
   contributorsIndexSubmitAnalyticsEvent,
+  type ContributorsIndexGithubVariant,
 } from "@/lib/contributors-index-cta-events-lib";

--- a/apps/web/src/lib/openapi-cta-events-lib.ts
+++ b/apps/web/src/lib/openapi-cta-events-lib.ts
@@ -7,7 +7,7 @@
 
 export const OPENAPI_SURFACE = "openapi";
 
-export type OpenApiCopyKind = "curl" | "response";
+export type OpenApiCopyKind = "curl" | "response" | "client-example";
 
 export function openApiCopyAnalyticsEvent(): string {
   return "openapi_copy_click";

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -15,6 +15,8 @@ import {
   changelogDiffEgressAnalyticsEvent,
   changelogFeedEgressAnalyticsData,
   changelogFeedEgressAnalyticsEvent,
+  changelogPollCopyAnalyticsData,
+  changelogPollCopyAnalyticsEvent,
   changelogQualityEgressAnalyticsData,
   changelogQualityEgressAnalyticsEvent,
   changelogReadMoreAnalyticsData,
@@ -23,6 +25,7 @@ import {
   changelogStreamFilterAnalyticsEvent,
   type ChangelogStreamFilter,
 } from "@/lib/changelog-page-cta-events";
+import { CopyButton } from "@/components/copy-button";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { changelogItemListJsonLd } from "@/lib/changelog-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
@@ -324,6 +327,15 @@ function ChangelogPage() {
               SHA-256.
             </p>
             <pre className="mt-3 overflow-x-auto rounded-md bg-background p-3 font-mono text-[11px] text-ink">
+              <div className="mb-2 flex justify-end">
+                <CopyButton
+                  value="curl https://heyclau.de/api/registry/diff?since=2026-05-19"
+                  label="Copy"
+                  size="sm"
+                  event={changelogPollCopyAnalyticsEvent()}
+                  eventData={changelogPollCopyAnalyticsData(items.length)}
+                />
+              </div>
               {`curl https://heyclau.de/api/registry/diff?since=2026-05-19`}
             </pre>
           </div>

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -326,8 +326,8 @@ function ChangelogPage() {
               Poll the diff endpoint or subscribe via your feed reader. Every payload carries a
               SHA-256.
             </p>
-            <pre className="mt-3 overflow-x-auto rounded-md bg-background p-3 font-mono text-[11px] text-ink">
-              <div className="mb-2 flex justify-end">
+            <div className="mt-3 overflow-hidden rounded-md bg-background">
+              <div className="flex justify-end border-b border-border px-3 py-1.5">
                 <CopyButton
                   value="curl https://heyclau.de/api/registry/diff?since=2026-05-19"
                   label="Copy"
@@ -336,8 +336,10 @@ function ChangelogPage() {
                   eventData={changelogPollCopyAnalyticsData(items.length)}
                 />
               </div>
-              {`curl https://heyclau.de/api/registry/diff?since=2026-05-19`}
-            </pre>
+              <pre className="overflow-x-auto p-3 font-mono text-[11px] text-ink">
+                {`curl https://heyclau.de/api/registry/diff?since=2026-05-19`}
+              </pre>
+            </div>
           </div>
 
           <div className="rounded-xl border border-border bg-surface p-5">

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -31,6 +31,8 @@ import {
 import {
   contributorProfileCategoryAnalyticsData,
   contributorProfileCategoryAnalyticsEvent,
+  contributorProfileGithubAnalyticsData,
+  contributorProfileGithubAnalyticsEvent,
   contributorProfileIndexAnalyticsData,
   contributorProfileIndexAnalyticsEvent,
   contributorProfilePeerAnalyticsData,
@@ -39,6 +41,9 @@ import {
   contributorProfileSubmitAnalyticsEvent,
   contributorProfileSubmitterAnalyticsData,
   contributorProfileSubmitterAnalyticsEvent,
+  contributorProfileTraceEgressAnalyticsData,
+  contributorProfileTraceEgressAnalyticsEvent,
+  type ContributorProfileTraceDestination,
 } from "@/lib/contributor-profile-cta-events";
 import { contributorPersonJsonLd } from "@/lib/contributor-person-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
@@ -140,6 +145,12 @@ function ContributorPage() {
                 href={contributor.github}
                 target="_blank"
                 rel="noreferrer"
+                onClick={() =>
+                  trackEvent(
+                    contributorProfileGithubAnalyticsEvent(),
+                    contributorProfileGithubAnalyticsData(contributor.slug, acceptedEntries.length),
+                  )
+                }
                 className="inline-flex items-center gap-1 rounded-md border border-border bg-surface px-2 py-0.5 text-ink-muted hover:text-ink"
               >
                 <Github className="h-3 w-3" /> GitHub <ArrowUpRight className="h-3 w-3" />
@@ -407,6 +418,18 @@ function ContributionRow({
                 href={submitter.href}
                 target="_blank"
                 rel="noreferrer"
+                onClick={() =>
+                  trackEvent(
+                    contributorProfileTraceEgressAnalyticsEvent(),
+                    contributorProfileTraceEgressAnalyticsData(
+                      contributor.slug,
+                      "external-submitter",
+                      role,
+                      rowIndex,
+                      rowCount,
+                    ),
+                  )
+                }
                 className="text-ink-muted hover:text-ink"
               >
                 {submitter.label}
@@ -440,13 +463,39 @@ function ContributionRow({
       {(entry.sourceSubmissionUrl || entry.importPrUrl || entry.sourceUrl) && (
         <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
           {entry.sourceSubmissionUrl && (
-            <ExternalTraceLink href={entry.sourceSubmissionUrl} label="Original submission" />
+            <ExternalTraceLink
+              href={entry.sourceSubmissionUrl}
+              label="Original submission"
+              destination="original-submission"
+              contributorSlug={contributor.slug}
+              role={role}
+              rowIndex={rowIndex}
+              rowCount={rowCount}
+            />
           )}
           {entry.importPrUrl && (
-            <ExternalTraceLink href={entry.importPrUrl} label="Import PR" icon={GitPullRequest} />
+            <ExternalTraceLink
+              href={entry.importPrUrl}
+              label="Import PR"
+              icon={GitPullRequest}
+              destination="import-pr"
+              contributorSlug={contributor.slug}
+              role={role}
+              rowIndex={rowIndex}
+              rowCount={rowCount}
+            />
           )}
           {entry.sourceUrl && (
-            <ExternalTraceLink href={entry.sourceUrl} label="Source" icon={ArrowUpRight} />
+            <ExternalTraceLink
+              href={entry.sourceUrl}
+              label="Source"
+              icon={ArrowUpRight}
+              destination="source"
+              contributorSlug={contributor.slug}
+              role={role}
+              rowIndex={rowIndex}
+              rowCount={rowCount}
+            />
           )}
         </div>
       )}
@@ -458,16 +507,38 @@ function ExternalTraceLink({
   href,
   label,
   icon: Icon = ArrowUpRight,
+  destination,
+  contributorSlug,
+  role,
+  rowIndex,
+  rowCount,
 }: {
   href: string;
   label: string;
   icon?: ElementType;
+  destination: ContributorProfileTraceDestination;
+  contributorSlug: string;
+  role: string;
+  rowIndex: number;
+  rowCount: number;
 }) {
   return (
     <a
       href={href}
       target="_blank"
       rel="noreferrer"
+      onClick={() =>
+        trackEvent(
+          contributorProfileTraceEgressAnalyticsEvent(),
+          contributorProfileTraceEgressAnalyticsData(
+            contributorSlug,
+            destination,
+            role,
+            rowIndex,
+            rowCount,
+          ),
+        )
+      }
       className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2 text-ink-muted hover:border-border-strong hover:text-ink"
     >
       {label}

--- a/apps/web/src/routes/contributors.index.tsx
+++ b/apps/web/src/routes/contributors.index.tsx
@@ -3,6 +3,8 @@ import { Github } from "lucide-react";
 import { CONTRIBUTORS } from "@/data/contributors";
 import { trackEvent } from "@/lib/analytics";
 import {
+  contributorsIndexGithubAnalyticsData,
+  contributorsIndexGithubAnalyticsEvent,
   contributorsIndexProfileAnalyticsData,
   contributorsIndexProfileAnalyticsEvent,
   contributorsIndexSubmitAnalyticsData,
@@ -95,6 +97,18 @@ function ContributorsPage() {
                 href={top.github}
                 target="_blank"
                 rel="noreferrer"
+                onClick={() =>
+                  trackEvent(
+                    contributorsIndexGithubAnalyticsEvent(),
+                    contributorsIndexGithubAnalyticsData(
+                      top.slug,
+                      top.acceptedCount,
+                      "featured",
+                      null,
+                      sorted.length,
+                    ),
+                  )
+                }
                 className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-background px-3 text-sm text-ink hover:bg-surface-2"
               >
                 <Github className="h-3.5 w-3.5" /> GitHub
@@ -137,7 +151,19 @@ function ContributorsPage() {
                 href={c.github}
                 target="_blank"
                 rel="noreferrer"
-                onClick={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  trackEvent(
+                    contributorsIndexGithubAnalyticsEvent(),
+                    contributorsIndexGithubAnalyticsData(
+                      c.slug,
+                      c.acceptedCount,
+                      "card",
+                      rowIndex,
+                      sorted.length,
+                    ),
+                  );
+                }}
                 className="text-ink-subtle hover:text-ink"
                 aria-label={`${c.handle} on GitHub`}
               >

--- a/tests/changelog-page-cta-events-lib.test.ts
+++ b/tests/changelog-page-cta-events-lib.test.ts
@@ -5,6 +5,8 @@ import {
   changelogDiffEgressAnalyticsEvent,
   changelogFeedEgressAnalyticsData,
   changelogFeedEgressAnalyticsEvent,
+  changelogPollCopyAnalyticsData,
+  changelogPollCopyAnalyticsEvent,
   changelogQualityEgressAnalyticsData,
   changelogQualityEgressAnalyticsEvent,
   changelogReadMoreAnalyticsData,
@@ -63,6 +65,12 @@ describe("changelog page cta events lib", () => {
       surface: CHANGELOG_PAGE_SURFACE,
       releaseStream: "release",
       rowIndex: 1,
+      matchCount: 12,
+    });
+    expect(changelogPollCopyAnalyticsEvent()).toBe("changelog_poll_copy_click");
+    expect(changelogPollCopyAnalyticsData(12)).toEqual({
+      surface: CHANGELOG_PAGE_SURFACE,
+      command: "diff-since",
       matchCount: 12,
     });
   });

--- a/tests/contributor-profile-cta-events-lib.test.ts
+++ b/tests/contributor-profile-cta-events-lib.test.ts
@@ -3,6 +3,8 @@ import {
   CONTRIBUTOR_PROFILE_SURFACE,
   contributorProfileCategoryAnalyticsData,
   contributorProfileCategoryAnalyticsEvent,
+  contributorProfileGithubAnalyticsData,
+  contributorProfileGithubAnalyticsEvent,
   contributorProfileIndexAnalyticsData,
   contributorProfileIndexAnalyticsEvent,
   contributorProfilePeerAnalyticsData,
@@ -11,6 +13,8 @@ import {
   contributorProfileSubmitAnalyticsEvent,
   contributorProfileSubmitterAnalyticsData,
   contributorProfileSubmitterAnalyticsEvent,
+  contributorProfileTraceEgressAnalyticsData,
+  contributorProfileTraceEgressAnalyticsEvent,
 } from "@/lib/contributor-profile-cta-events-lib";
 
 describe("contributor profile cta events lib", () => {
@@ -74,6 +78,33 @@ describe("contributor profile cta events lib", () => {
       role: "submitted",
       rowIndex: 2,
       rowCount: 6,
+    });
+    expect(contributorProfileGithubAnalyticsEvent()).toBe(
+      "contributor_profile_github_click",
+    );
+    expect(contributorProfileGithubAnalyticsData("alice", 12)).toEqual({
+      surface: CONTRIBUTOR_PROFILE_SURFACE,
+      contributorSlug: "alice",
+      acceptedCount: 12,
+    });
+    expect(contributorProfileTraceEgressAnalyticsEvent()).toBe(
+      "contributor_profile_trace_egress_click",
+    );
+    expect(
+      contributorProfileTraceEgressAnalyticsData(
+        "alice",
+        "import-pr",
+        "authored",
+        1,
+        4,
+      ),
+    ).toEqual({
+      surface: CONTRIBUTOR_PROFILE_SURFACE,
+      contributorSlug: "alice",
+      destination: "import-pr",
+      role: "authored",
+      rowIndex: 1,
+      rowCount: 4,
     });
   });
 });

--- a/tests/contributors-index-cta-events-lib.test.ts
+++ b/tests/contributors-index-cta-events-lib.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   CONTRIBUTORS_INDEX_SURFACE,
+  contributorsIndexGithubAnalyticsData,
+  contributorsIndexGithubAnalyticsEvent,
   contributorsIndexProfileAnalyticsData,
   contributorsIndexProfileAnalyticsEvent,
   contributorsIndexSubmitAnalyticsData,
@@ -29,6 +31,32 @@ describe("contributors index cta events lib", () => {
       surface: CONTRIBUTORS_INDEX_SURFACE,
       contributorCount: 24,
       totalAccepted: 310,
+    });
+  });
+
+  it("builds contributors index GitHub egress analytics", () => {
+    expect(contributorsIndexGithubAnalyticsEvent()).toBe(
+      "contributors_index_github_click",
+    );
+    expect(
+      contributorsIndexGithubAnalyticsData("alice", 12, "featured", null, 24),
+    ).toEqual({
+      surface: CONTRIBUTORS_INDEX_SURFACE,
+      contributorSlug: "alice",
+      acceptedCount: 12,
+      variant: "featured",
+      rowIndex: null,
+      contributorCount: 24,
+    });
+    expect(
+      contributorsIndexGithubAnalyticsData("bob", 4, "card", 2, 24),
+    ).toEqual({
+      surface: CONTRIBUTORS_INDEX_SURFACE,
+      contributorSlug: "bob",
+      acceptedCount: 4,
+      variant: "card",
+      rowIndex: 2,
+      contributorCount: 24,
     });
   });
 });

--- a/tests/openapi-cta-events-lib.test.ts
+++ b/tests/openapi-cta-events-lib.test.ts
@@ -26,6 +26,14 @@ describe("openapi cta events lib", () => {
         copyKind: "response",
       },
     );
+    expect(
+      openApiCopyAnalyticsData("list-entries", "GET", "client-example"),
+    ).toEqual({
+      surface: OPENAPI_SURFACE,
+      endpointId: "list-entries",
+      method: "GET",
+      copyKind: "client-example",
+    });
     expect(openApiSendAnalyticsEvent()).toBe("openapi_send_click");
     expect(openApiSendAnalyticsData("search", "GET", true)).toEqual({
       surface: OPENAPI_SURFACE,


### PR DESCRIPTION
## Summary
- Extend contributors index/profile analytics for GitHub egress and provenance trace links (original submission, import PR, source, external submitter)
- Extend OpenAPI playground analytics for tested client-example copy
- Extend changelog analytics for sidebar diff-poll command copy
- Privacy-light payloads only (no URLs, names, command bodies, or code snippets)

Refs #550

### Why no new issue
Continues Growth Sprint 1 (#550) decision-layer analytics: pure `*-cta-events-lib` helpers + thin wrappers + `trackEvent` wiring, matching #5069/#5081/#5087/#5091/#5094/#5095/#5096/#5097. No separate issue is needed because this is incremental analytics coverage on the already-scoped growth sprint.

### Conflict avoidance
Does not touch open PR paths: browse saved-search / `browse.tsx` (#5098), tools-submit CTA files (#5092), or `README.md` (#5033).

## Test plan
- [x] prettier + vitest on four libs
- [x] verified no file overlap with currently open PRs
- [x] CI green (validate-web, coverage, required-pr-gate)

Made with [Cursor](https://cursor.com)