### PR TITLE
feat(web): add entry detail dossier LLMs link analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -15,6 +15,7 @@ export const ENTRY_DETAIL_RAIL_SURFACE = "detail-rail";
 export const ENTRY_DETAIL_COMPARE_SURFACE = "detail-compare";
 export const ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE = "detail-decision-playbook";
 export const ENTRY_DETAIL_MOBILE_SURFACE = "detail-mobile";
+export const ENTRY_DETAIL_CITATION_FACTS_SURFACE = "detail-citation-facts";
 export const BROWSE_COMPARE_SURFACE = "browse-compare";
 export const COMPARE_TRAY_SURFACE = "compare-tray";
 
@@ -418,6 +419,22 @@ export function entryDetailMobileLlmsAnalyticsData(category: string, slug: strin
     entry: entryDetailEntryKey(category, slug),
     link: "llms",
     surface: ENTRY_DETAIL_MOBILE_SURFACE,
+  };
+}
+
+export function entryDetailLlmsOpenAnalyticsEvent(): string {
+  return "detail_llms_open";
+}
+
+export function entryDetailLlmsOpenAnalyticsData(
+  category: string,
+  slug: string,
+  surface: string = ENTRY_DETAIL_CITATION_FACTS_SURFACE,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    link: "llms",
+    surface,
   };
 }
 

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -4,6 +4,7 @@
 export {
   BROWSE_COMPARE_SURFACE,
   COMPARE_TRAY_SURFACE,
+  ENTRY_DETAIL_CITATION_FACTS_SURFACE,
   ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
   ENTRY_DETAIL_COMPARE_SURFACE,
   ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
@@ -67,6 +68,8 @@ export {
   entryDetailMobileCopyIntentType,
   entryDetailMobileLinkIntentType,
   entryDetailMobileLlmsAnalyticsData,
+  entryDetailLlmsOpenAnalyticsData,
+  entryDetailLlmsOpenAnalyticsEvent,
   entryDetailPlaybookActionAnalyticsData,
   entryDetailPlaybookActionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -99,6 +99,8 @@ import {
   entryDetailCompareToastOpenAnalyticsEvent,
   entryDetailCopyTabSelectAnalyticsData,
   entryDetailCopyTabSelectAnalyticsEvent,
+  entryDetailLlmsOpenAnalyticsData,
+  entryDetailLlmsOpenAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
   entryDetailMobileCompareToastOpenAnalyticsData,
@@ -744,6 +746,12 @@ function Dossier() {
               also available as{" "}
               <a
                 href={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
+                onClick={() =>
+                  trackEvent(
+                    entryDetailLlmsOpenAnalyticsEvent(),
+                    entryDetailLlmsOpenAnalyticsData(entry.category, entry.slug),
+                  )
+                }
                 className="text-ink underline-offset-2 hover:underline"
               >
                 plain text

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -56,6 +56,9 @@ import {
   entryDetailMobileCopyIntentType,
   entryDetailMobileLinkIntentType,
   entryDetailMobileLlmsAnalyticsData,
+  entryDetailLlmsOpenAnalyticsData,
+  entryDetailLlmsOpenAnalyticsEvent,
+  ENTRY_DETAIL_CITATION_FACTS_SURFACE,
   entryDetailPlaybookActionAnalyticsData,
   entryDetailPlaybookActionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events-lib";
@@ -395,6 +398,20 @@ describe("entry detail cta events lib", () => {
       entry: "skills/demo",
       link: "llms",
       surface: "detail-mobile",
+    });
+    expect(entryDetailLlmsOpenAnalyticsEvent()).toBe("detail_llms_open");
+    expect(ENTRY_DETAIL_CITATION_FACTS_SURFACE).toBe("detail-citation-facts");
+    expect(entryDetailLlmsOpenAnalyticsData("mcp", "browser")).toEqual({
+      entry: "mcp/browser",
+      link: "llms",
+      surface: "detail-citation-facts",
+    });
+    expect(
+      entryDetailLlmsOpenAnalyticsData("mcp", "browser", "detail-custom"),
+    ).toEqual({
+      entry: "mcp/browser",
+      link: "llms",
+      surface: "detail-custom",
     });
   });
 


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `detail_llms_open` analytics on the entry detail citation-facts "plain text" LLMs link
- Payload: `{ entry, link: "llms", surface: "detail-citation-facts" }` (no URLs/titles)

## Test plan
- [ ] Vitest covers `entryDetailLlmsOpenAnalyticsEvent/Data`
- [ ] Click plain-text LLMs link on an entry detail page fires `detail_llms_open`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
