### PR TITLE
feat(web): add compare curated not-found egress analytics

### DIFF
--- a/apps/web/src/lib/compare-curated-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-curated-egress-cta-events-lib.ts
@@ -6,6 +6,7 @@
  */
 
 export const COMPARE_CURATED_PAGE_SURFACE = "compare-curated-page";
+export const COMPARE_CURATED_NOTFOUND_SURFACE = "compare-curated-notfound";
 
 export type CompareCuratedEgressLinkKind = "interactive";
 
@@ -23,5 +24,15 @@ export function compareCuratedEgressAnalyticsData(
     linkKind,
     refCount,
     hasInteractive,
+  };
+}
+
+export function compareCuratedNotFoundEgressAnalyticsEvent(): string {
+  return "compare_curated_notfound_egress_click";
+}
+
+export function compareCuratedNotFoundEgressAnalyticsData() {
+  return {
+    surface: COMPARE_CURATED_NOTFOUND_SURFACE,
   };
 }

--- a/apps/web/src/lib/compare-curated-egress-cta-events.ts
+++ b/apps/web/src/lib/compare-curated-egress-cta-events.ts
@@ -3,7 +3,10 @@
  */
 export {
   COMPARE_CURATED_PAGE_SURFACE,
+  COMPARE_CURATED_NOTFOUND_SURFACE,
   compareCuratedEgressAnalyticsData,
   compareCuratedEgressAnalyticsEvent,
+  compareCuratedNotFoundEgressAnalyticsData,
+  compareCuratedNotFoundEgressAnalyticsEvent,
   type CompareCuratedEgressLinkKind,
 } from "@/lib/compare-curated-egress-cta-events-lib";

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -20,6 +20,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   compareCuratedEgressAnalyticsData,
   compareCuratedEgressAnalyticsEvent,
+  compareCuratedNotFoundEgressAnalyticsData,
+  compareCuratedNotFoundEgressAnalyticsEvent,
 } from "@/lib/compare-curated-egress-cta-events";
 
 export const Route = createFileRoute("/compare/$slug")({
@@ -66,7 +68,16 @@ export const Route = createFileRoute("/compare/$slug")({
   notFoundComponent: () => (
     <div className="mx-auto max-w-2xl px-6 py-24 text-center">
       <h1 className="h-display-2 text-ink">Comparison not found</h1>
-      <Link to="/compare" className="mt-4 inline-block text-ink-muted hover:text-ink">
+      <Link
+        to="/compare"
+        className="mt-4 inline-block text-ink-muted hover:text-ink"
+        onClick={() =>
+          trackEvent(
+            compareCuratedNotFoundEgressAnalyticsEvent(),
+            compareCuratedNotFoundEgressAnalyticsData(),
+          )
+        }
+      >
         ← Build your own comparison
       </Link>
     </div>

--- a/tests/compare-curated-egress-cta-events-lib.test.ts
+++ b/tests/compare-curated-egress-cta-events-lib.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  COMPARE_CURATED_NOTFOUND_SURFACE,
   COMPARE_CURATED_PAGE_SURFACE,
   compareCuratedEgressAnalyticsData,
   compareCuratedEgressAnalyticsEvent,
+  compareCuratedNotFoundEgressAnalyticsData,
+  compareCuratedNotFoundEgressAnalyticsEvent,
 } from "@/lib/compare-curated-egress-cta-events-lib";
 
 describe("compare curated egress cta events lib", () => {
@@ -15,6 +18,12 @@ describe("compare curated egress cta events lib", () => {
       linkKind: "interactive",
       refCount: 4,
       hasInteractive: true,
+    });
+    expect(compareCuratedNotFoundEgressAnalyticsEvent()).toBe(
+      "compare_curated_notfound_egress_click",
+    );
+    expect(compareCuratedNotFoundEgressAnalyticsData()).toEqual({
+      surface: COMPARE_CURATED_NOTFOUND_SURFACE,
     });
   });
 });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `compare_curated_notfound_egress_click` on the curated comparison not-found egress link
- Payload: `{ surface: "compare-curated-notfound" }` (no comparison slug or titles)

## Test plan
- [ ] Vitest covers not-found egress helpers
- [ ] Visit an unknown `/compare/$slug` and click "Build your own comparison"
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
