### PR TITLE
feat(web): add category hub not-found egress analytics

### DIFF
--- a/apps/web/src/lib/directory-hub-cta-events-lib.ts
+++ b/apps/web/src/lib/directory-hub-cta-events-lib.ts
@@ -6,6 +6,7 @@
  */
 
 export const CATEGORY_HUB_SURFACE = "category-hub";
+export const CATEGORY_HUB_NOTFOUND_SURFACE = "category-hub-notfound";
 export const BEST_INDEX_SURFACE = "best-index";
 export const PLATFORM_INDEX_SURFACE = "platform-index";
 export const PLATFORM_HUB_SURFACE = "platform-hub";
@@ -32,6 +33,16 @@ export function categoryHubSeeAllAnalyticsData(category: string, entryCount: num
     surface: CATEGORY_HUB_SURFACE,
     category,
     entryCount,
+  };
+}
+
+export function categoryHubNotFoundEgressAnalyticsEvent(): string {
+  return "category_hub_notfound_egress_click";
+}
+
+export function categoryHubNotFoundEgressAnalyticsData() {
+  return {
+    surface: CATEGORY_HUB_NOTFOUND_SURFACE,
   };
 }
 

--- a/apps/web/src/lib/directory-hub-cta-events.ts
+++ b/apps/web/src/lib/directory-hub-cta-events.ts
@@ -3,6 +3,7 @@
  */
 export {
   BEST_INDEX_SURFACE,
+  CATEGORY_HUB_NOTFOUND_SURFACE,
   CATEGORY_HUB_SURFACE,
   PLATFORM_CATEGORY_SURFACE,
   PLATFORM_HUB_SURFACE,
@@ -11,6 +12,8 @@ export {
   bestIndexListAnalyticsEvent,
   categoryHubBrowseAnalyticsData,
   categoryHubBrowseAnalyticsEvent,
+  categoryHubNotFoundEgressAnalyticsData,
+  categoryHubNotFoundEgressAnalyticsEvent,
   categoryHubSeeAllAnalyticsData,
   categoryHubSeeAllAnalyticsEvent,
   platformCategoryCategoryAnalyticsData,

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -21,6 +21,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   categoryHubBrowseAnalyticsData,
   categoryHubBrowseAnalyticsEvent,
+  categoryHubNotFoundEgressAnalyticsData,
+  categoryHubNotFoundEgressAnalyticsEvent,
   categoryHubSeeAllAnalyticsData,
   categoryHubSeeAllAnalyticsEvent,
 } from "@/lib/directory-hub-cta-events";
@@ -101,6 +103,12 @@ export const Route = createFileRoute("/$category")({
       <Link
         to="/browse"
         className="mt-6 inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-4 font-medium text-background hover:opacity-90"
+        onClick={() =>
+          trackEvent(
+            categoryHubNotFoundEgressAnalyticsEvent(),
+            categoryHubNotFoundEgressAnalyticsData(),
+          )
+        }
       >
         Browse all <ArrowRight className="h-4 w-4" />
       </Link>

--- a/tests/directory-hub-cta-events-lib.test.ts
+++ b/tests/directory-hub-cta-events-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BEST_INDEX_SURFACE,
+  CATEGORY_HUB_NOTFOUND_SURFACE,
   CATEGORY_HUB_SURFACE,
   PLATFORM_CATEGORY_SURFACE,
   PLATFORM_HUB_SURFACE,
@@ -9,6 +10,8 @@ import {
   bestIndexListAnalyticsEvent,
   categoryHubBrowseAnalyticsData,
   categoryHubBrowseAnalyticsEvent,
+  categoryHubNotFoundEgressAnalyticsData,
+  categoryHubNotFoundEgressAnalyticsEvent,
   categoryHubSeeAllAnalyticsData,
   categoryHubSeeAllAnalyticsEvent,
   platformCategoryCategoryAnalyticsData,
@@ -38,6 +41,12 @@ describe("directory hub cta events lib", () => {
       surface: CATEGORY_HUB_SURFACE,
       category: "skills",
       entryCount: 18,
+    });
+    expect(categoryHubNotFoundEgressAnalyticsEvent()).toBe(
+      "category_hub_notfound_egress_click",
+    );
+    expect(categoryHubNotFoundEgressAnalyticsData()).toEqual({
+      surface: CATEGORY_HUB_NOTFOUND_SURFACE,
     });
   });
 


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `category_hub_notfound_egress_click` on the category hub not-found "Browse all" egress
- Payload: `{ surface: "category-hub-notfound" }` (no category slug or titles)

## Test plan
- [ ] Vitest covers not-found egress helpers
- [ ] Visit an unknown `/$category` and click Browse all
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
