### PR TITLE
feat(web): add feeds follow, browse recents panel, and entry disclosure analytics

### DIFF
--- a/apps/web/src/components/subscribe-form.tsx
+++ b/apps/web/src/components/subscribe-form.tsx
@@ -3,6 +3,11 @@ import { Check, Loader2, Mail } from "lucide-react";
 import { toast } from "sonner";
 import { subscribeToNewsletter } from "@/lib/api/newsletter";
 import { useRecents } from "@/lib/recents";
+import { trackEvent } from "@/lib/analytics";
+import {
+  newsletterSubscribeAnalyticsData,
+  newsletterSubscribeAnalyticsEvent,
+} from "@/lib/conversion-cta-events";
 import { cn } from "@/lib/utils";
 
 interface SubscribeFormProps {
@@ -14,6 +19,8 @@ interface SubscribeFormProps {
   className?: string;
   /** Human-readable label for the local follow record. */
   followLabel?: string;
+  /** Optional hook after a successful subscribe (never receives email). */
+  onSubscribed?: (pending: boolean) => void;
 }
 
 export function SubscribeForm({
@@ -23,6 +30,7 @@ export function SubscribeForm({
   placeholder = "you@domain.com",
   className,
   followLabel,
+  onSubscribed,
 }: SubscribeFormProps) {
   const [email, setEmail] = React.useState("");
   const [state, setState] = React.useState<"idle" | "loading" | "ok" | "error">("idle");
@@ -39,6 +47,11 @@ export function SubscribeForm({
       setState("ok");
       setMessage("You're on the list. Check your inbox.");
       toast.success("Subscribed", { description: "Check your inbox to confirm." });
+      trackEvent(
+        newsletterSubscribeAnalyticsEvent(),
+        newsletterSubscribeAnalyticsData(source ?? "inline", res.pending),
+      );
+      onSubscribed?.(res.pending);
       // Record locally so /subscriptions can list it.
       const list = segments && segments.length > 0 ? segments : ["all"];
       for (const seg of list) {

--- a/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
@@ -286,3 +286,20 @@ export function browseSavedSearchManagerAlertsEditorAnalyticsData(
     filterCount,
   };
 }
+
+export function browseRecentsPanelToggleAnalyticsEvent(): string {
+  return "browse_recents_panel_toggle_click";
+}
+
+export function browseRecentsPanelToggleAnalyticsData(
+  open: boolean,
+  savedCount: number,
+  recentCount: number,
+) {
+  return {
+    surface: BROWSE_RECENTS_PANEL_SURFACE,
+    open,
+    savedCount,
+    recentCount,
+  };
+}

--- a/apps/web/src/lib/browse-saved-search-cta-events.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events.ts
@@ -14,6 +14,8 @@ export {
   browseLoadMoreAnalyticsEvent,
   browseRecentEntryClickAnalyticsData,
   browseRecentEntryClickAnalyticsEvent,
+  browseRecentsPanelToggleAnalyticsData,
+  browseRecentsPanelToggleAnalyticsEvent,
   browseSavedSearchApplyAnalyticsData,
   browseSavedSearchApplyAnalyticsEvent,
   browseSavedSearchLinkClickAnalyticsData,

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -452,3 +452,23 @@ export function entryDetailCitationPlainTextAnalyticsData(category: string, slug
     destination: "plain-text",
   };
 }
+
+export type EntryDetailCodeDisclosureKind = "script-body" | "full-copy";
+
+export function entryDetailCodeDisclosureAnalyticsEvent(): string {
+  return "entry_detail_code_disclosure_click";
+}
+
+export function entryDetailCodeDisclosureAnalyticsData(
+  category: string,
+  slug: string,
+  kind: EntryDetailCodeDisclosureKind,
+  open: boolean,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+    kind,
+    open,
+  };
+}

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -71,4 +71,7 @@ export {
   entryDetailPlaybookActionAnalyticsEvent,
   entryDetailCitationPlainTextAnalyticsData,
   entryDetailCitationPlainTextAnalyticsEvent,
+  entryDetailCodeDisclosureAnalyticsData,
+  entryDetailCodeDisclosureAnalyticsEvent,
+  type EntryDetailCodeDisclosureKind,
 } from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/lib/feeds-page-cta-events-lib.ts
+++ b/apps/web/src/lib/feeds-page-cta-events-lib.ts
@@ -56,3 +56,20 @@ export function feedsPageFeedCopyAnalyticsData(
     sectionCount,
   };
 }
+
+export function feedsPageEmailFollowAnalyticsEvent(): string {
+  return "feeds_page_email_follow_click";
+}
+
+export function feedsPageEmailFollowAnalyticsData(
+  feedKey: string,
+  feedKind: FeedsPageFeedKind,
+  pending: boolean,
+) {
+  return {
+    surface: FEEDS_PAGE_SURFACE,
+    feedKey,
+    feedKind,
+    pending,
+  };
+}

--- a/apps/web/src/lib/feeds-page-cta-events.ts
+++ b/apps/web/src/lib/feeds-page-cta-events.ts
@@ -5,6 +5,8 @@ export {
   FEEDS_PAGE_SURFACE,
   feedsPageApiDocsAnalyticsData,
   feedsPageApiDocsAnalyticsEvent,
+  feedsPageEmailFollowAnalyticsData,
+  feedsPageEmailFollowAnalyticsEvent,
   feedsPageFeedCopyAnalyticsData,
   feedsPageFeedCopyAnalyticsEvent,
   feedsPageFeedOpenAnalyticsData,

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -93,6 +93,8 @@ import {
   browseLoadMoreAnalyticsEvent,
   browseRecentEntryClickAnalyticsData,
   browseRecentEntryClickAnalyticsEvent,
+  browseRecentsPanelToggleAnalyticsData,
+  browseRecentsPanelToggleAnalyticsEvent,
   browseSavedSearchApplyAnalyticsData,
   browseSavedSearchApplyAnalyticsEvent,
   browseSavedSearchLinkClickAnalyticsData,
@@ -1156,6 +1158,17 @@ function Browse() {
             <details
               className="mt-4 rounded-lg border border-border bg-surface px-3 py-2 [&[open]>summary>svg]:rotate-90"
               open={recents.saved.some((s) => s.alerts?.enabled)}
+              onToggle={(e) => {
+                const open = (e.currentTarget as HTMLDetailsElement).open;
+                trackEvent(
+                  browseRecentsPanelToggleAnalyticsEvent(),
+                  browseRecentsPanelToggleAnalyticsData(
+                    open,
+                    recents.saved.length,
+                    recentEntries.length,
+                  ),
+                );
+              }}
             >
               <summary className="flex cursor-pointer list-none items-center gap-2 text-xs text-ink-muted hover:text-ink">
                 <Clock className="h-3.5 w-3.5" />

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -107,6 +107,9 @@ import {
   entryDetailPlaybookActionAnalyticsEvent,
   entryDetailCitationPlainTextAnalyticsData,
   entryDetailCitationPlainTextAnalyticsEvent,
+  entryDetailCodeDisclosureAnalyticsData,
+  entryDetailCodeDisclosureAnalyticsEvent,
+  type EntryDetailCodeDisclosureKind,
 } from "@/lib/entry-detail-cta-events";
 import {
   detailDecisionPresetAnalyticsData,
@@ -1311,7 +1314,13 @@ function SchemaDetails({ entry }: { entry: Entry }) {
               <FieldRow label="Script language" value={entry.scriptLanguage} />
             </FieldGrid>
             <PillList label="Allowed tools" values={entry.allowedTools} />
-            <CodeDisclosure label="Script body" value={entry.scriptBody} />
+            <CodeDisclosure
+              label="Script body"
+              value={entry.scriptBody}
+              category={entry.category}
+              slug={entry.slug}
+              kind="script-body"
+            />
           </MetadataGroup>
         )}
 
@@ -1353,7 +1362,13 @@ function SchemaDetails({ entry }: { entry: Entry }) {
           </MetadataGroup>
         )}
 
-        <CodeDisclosure label="Full copyable content" value={entry.fullCopy ?? entry.copySnippet} />
+        <CodeDisclosure
+          label="Full copyable content"
+          value={entry.fullCopy ?? entry.copySnippet}
+          category={entry.category}
+          slug={entry.slug}
+          kind="full-copy"
+        />
       </div>
     </DossierSection>
   );
@@ -1486,10 +1501,31 @@ function CollectionItemList({
   );
 }
 
-function CodeDisclosure({ label, value }: { label: string; value?: string }) {
+function CodeDisclosure({
+  label,
+  value,
+  category,
+  slug,
+  kind,
+}: {
+  label: string;
+  value?: string;
+  category: string;
+  slug: string;
+  kind: EntryDetailCodeDisclosureKind;
+}) {
   if (!value) return null;
   return (
-    <details className="mt-3 rounded-lg border border-border bg-background">
+    <details
+      className="mt-3 rounded-lg border border-border bg-background"
+      onToggle={(e) => {
+        const open = (e.currentTarget as HTMLDetailsElement).open;
+        trackEvent(
+          entryDetailCodeDisclosureAnalyticsEvent(),
+          entryDetailCodeDisclosureAnalyticsData(category, slug, kind, open),
+        );
+      }}
+    >
       <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-ink">{label}</summary>
       <pre className="max-h-96 overflow-auto border-t border-border p-3 font-mono text-[12px] leading-relaxed text-ink">
         <code>{value}</code>

--- a/apps/web/src/routes/feeds.tsx
+++ b/apps/web/src/routes/feeds.tsx
@@ -9,6 +9,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   feedsPageApiDocsAnalyticsData,
   feedsPageApiDocsAnalyticsEvent,
+  feedsPageEmailFollowAnalyticsData,
+  feedsPageEmailFollowAnalyticsEvent,
   feedsPageFeedCopyAnalyticsData,
   feedsPageFeedCopyAnalyticsEvent,
   feedsPageFeedOpenAnalyticsData,
@@ -99,7 +101,17 @@ function FeedRow({
             Email
           </summary>
           <div className="mt-2 w-72">
-            <SubscribeForm segments={[segment]} source={`feeds:${segment}`} label="Follow" />
+            <SubscribeForm
+              segments={[segment]}
+              source={`feeds:${segment}`}
+              label="Follow"
+              onSubscribed={(pending) =>
+                trackEvent(
+                  feedsPageEmailFollowAnalyticsEvent(),
+                  feedsPageEmailFollowAnalyticsData(feedKey, feedKind, pending),
+                )
+              }
+            />
           </div>
         </details>
       </div>

--- a/tests/browse-saved-search-cta-events-lib.test.ts
+++ b/tests/browse-saved-search-cta-events-lib.test.ts
@@ -12,6 +12,8 @@ import {
   browseLoadMoreAnalyticsEvent,
   browseRecentEntryClickAnalyticsData,
   browseRecentEntryClickAnalyticsEvent,
+  browseRecentsPanelToggleAnalyticsData,
+  browseRecentsPanelToggleAnalyticsEvent,
   browseSavedSearchApplyAnalyticsData,
   browseSavedSearchApplyAnalyticsEvent,
   browseSavedSearchLinkClickAnalyticsData,
@@ -251,6 +253,15 @@ describe("browse saved search cta events lib", () => {
       surface: BROWSE_SAVED_SEARCH_MANAGER_SURFACE,
       open: true,
       filterCount: 3,
+    });
+    expect(browseRecentsPanelToggleAnalyticsEvent()).toBe(
+      "browse_recents_panel_toggle_click",
+    );
+    expect(browseRecentsPanelToggleAnalyticsData(true, 4, 6)).toEqual({
+      surface: BROWSE_RECENTS_PANEL_SURFACE,
+      open: true,
+      savedCount: 4,
+      recentCount: 6,
     });
   });
 });

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -60,6 +60,9 @@ import {
   entryDetailPlaybookActionAnalyticsEvent,
   entryDetailCitationPlainTextAnalyticsData,
   entryDetailCitationPlainTextAnalyticsEvent,
+  entryDetailCodeDisclosureAnalyticsData,
+  entryDetailCodeDisclosureAnalyticsEvent,
+  ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
 } from "@/lib/entry-detail-cta-events-lib";
 
 describe("entry detail cta events lib", () => {
@@ -441,6 +444,35 @@ describe("entry detail cta events lib", () => {
       entry: "mcp/filesystem",
       surface: "detail-command-center",
       destination: "plain-text",
+    });
+    expect(entryDetailCodeDisclosureAnalyticsEvent()).toBe(
+      "entry_detail_code_disclosure_click",
+    );
+    expect(
+      entryDetailCodeDisclosureAnalyticsData(
+        "skills",
+        "demo",
+        "script-body",
+        false,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+      kind: "script-body",
+      open: false,
+    });
+    expect(
+      entryDetailCodeDisclosureAnalyticsData(
+        "mcp",
+        "browser",
+        "full-copy",
+        true,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+      kind: "full-copy",
+      open: true,
     });
   });
 });

--- a/tests/feeds-page-cta-events-lib.test.ts
+++ b/tests/feeds-page-cta-events-lib.test.ts
@@ -5,6 +5,8 @@ import {
   feedsPageApiDocsAnalyticsEvent,
   feedsPageFeedCopyAnalyticsData,
   feedsPageFeedCopyAnalyticsEvent,
+  feedsPageEmailFollowAnalyticsData,
+  feedsPageEmailFollowAnalyticsEvent,
   feedsPageFeedOpenAnalyticsData,
   feedsPageFeedOpenAnalyticsEvent,
 } from "@/lib/feeds-page-cta-events-lib";
@@ -34,6 +36,17 @@ describe("feeds page cta events lib", () => {
       feedKind: "category",
       rowIndex: 2,
       sectionCount: 12,
+    });
+    expect(feedsPageEmailFollowAnalyticsEvent()).toBe(
+      "feeds_page_email_follow_click",
+    );
+    expect(
+      feedsPageEmailFollowAnalyticsData("changelog", "changelog", true),
+    ).toEqual({
+      surface: FEEDS_PAGE_SURFACE,
+      feedKey: "changelog",
+      feedKind: "changelog",
+      pending: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Wire privacy-light `feeds_page_email_follow_click` when a feeds row email subscribe succeeds (feed key/kind + pending flag only)
- Wire `browse_recents_panel_toggle_click` when the browse "Recents & saved searches" panel expands or collapses (open state + counts)
- Wire `entry_detail_code_disclosure_click` when entry detail script-body or full-copy `<details>` toggles (kind + open state)
- Add pure `*-cta-events-lib` helpers, thin re-exports, route wiring, and Vitest coverage for all three surfaces
- Paths avoid open PRs (#5092 tools-submit, #5033 README) and #5099 contributor/openapi/changelog analytics

## Test plan
- [x] `npm test -- tests/feeds-page-cta-events-lib.test.ts tests/browse-saved-search-cta-events-lib.test.ts tests/entry-detail-cta-events-lib.test.ts`
- [ ] CI validate-web, coverage, codecov/patch, codecov/project, required-pr-gate

Refs #550

Made with [Cursor](https://cursor.com)