### PR TITLE
feat(web): add exports + download cards for tooling and MCP reports

### DIFF
--- a/apps/web/src/lib/claude-tooling-stats-lib.ts
+++ b/apps/web/src/lib/claude-tooling-stats-lib.ts
@@ -1,0 +1,106 @@
+import { pctOf } from "@/lib/pct-of-lib";
+import { installMethodDistribution, notesCoverage } from "@/lib/ecosystem-stats";
+import type { ReportModel } from "@/lib/data-reports";
+import {
+  CATEGORIES,
+  HARNESSES,
+  PLATFORM_LABEL,
+  SOURCE_LABEL,
+  TRUST_LABEL,
+  type Entry,
+  type Platform,
+  type SourceStatus,
+  type TrustLevel,
+} from "@/types/registry";
+
+const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
+
+export function buildClaudeToolingReport(entries: ReadonlyArray<Entry>, asOf: string): ReportModel {
+  const total = entries.length;
+  const install = installMethodDistribution(entries);
+  const notes = notesCoverage(entries);
+
+  const categoryRows = CATEGORIES.map((category) => {
+    const count = entries.filter((entry) => entry.category === category.id).length;
+    return { label: category.label, count, pct: pctOf(count, total) };
+  }).filter((row) => row.count > 0);
+
+  const trustRows = TRUST_ORDER.map((trust) => {
+    const count = entries.filter((entry) => entry.trust === trust).length;
+    return { label: TRUST_LABEL[trust], count, pct: pctOf(count, total) };
+  }).filter((row) => row.count > 0);
+
+  const sourceRows = SOURCE_ORDER.map((source) => {
+    const count = entries.filter((entry) => entry.source === source).length;
+    return { label: SOURCE_LABEL[source], count, pct: pctOf(count, total) };
+  }).filter((row) => row.count > 0);
+
+  const platformRows = HARNESSES.map((harness) => {
+    const count = entries.filter((entry) =>
+      entry.platforms.includes(harness.id as Platform),
+    ).length;
+    return { label: PLATFORM_LABEL[harness.id], count, pct: pctOf(count, total) };
+  }).filter((row) => row.count > 0);
+
+  return {
+    slug: "/state-of-claude-tooling",
+    exportSlug: "claude-tooling",
+    title: "State of Claude Tooling",
+    description:
+      "A data report on the Claude and AI agent tooling ecosystem: category coverage, trust and source provenance, platform compatibility, install methods, and safety/privacy note coverage from the HeyClaude registry.",
+    keywords: ["Claude tooling", "AI agent tooling", "MCP", "registry", "trust signals"],
+    asOf,
+    total,
+    stats: [
+      { key: "total", label: "Total resources", value: total, hint: "registry" },
+      { key: "categories", label: "Categories tracked", value: CATEGORIES.length, hint: "types" },
+    ],
+    dimensions: [
+      {
+        key: "categories",
+        title: "Resources by category",
+        help: "Catalog split by tracked category.",
+        rows: categoryRows,
+      },
+      {
+        key: "trust",
+        title: "Trust-level distribution",
+        help: "Reviewed trust labels across the catalog.",
+        rows: trustRows,
+      },
+      {
+        key: "source",
+        title: "Source provenance distribution",
+        help: "Where listing identity is verified from.",
+        rows: sourceRows,
+      },
+      {
+        key: "platforms",
+        title: "Platform coverage",
+        help: "Declared compatibility across harnesses.",
+        rows: platformRows,
+      },
+      {
+        key: "install-methods",
+        title: "Install methods",
+        help: "Install command distribution for package-installable entries.",
+        rows: install.rows.map((row) => ({
+          label: row.label,
+          count: row.count,
+          pct: pctOf(row.count, install.total),
+        })),
+      },
+      {
+        key: "notes-coverage",
+        title: "Safety & privacy coverage",
+        help: "How many entries include reviewer-checked safety and privacy notes.",
+        rows: [
+          { label: "Safety notes", count: notes.safety, pct: pctOf(notes.safety, total) },
+          { label: "Privacy notes", count: notes.privacy, pct: pctOf(notes.privacy, total) },
+          { label: "Both", count: notes.both, pct: pctOf(notes.both, total) },
+        ].filter((row) => row.count > 0),
+      },
+    ].filter((dimension) => dimension.rows.length > 0),
+  };
+}

--- a/apps/web/src/lib/claude-tooling-stats.ts
+++ b/apps/web/src/lib/claude-tooling-stats.ts
@@ -1,0 +1,4 @@
+/**
+ * State of Claude Tooling report helpers.
+ */
+export { buildClaudeToolingReport } from "@/lib/claude-tooling-stats-lib";

--- a/apps/web/src/lib/mcp-servers-stats-lib.ts
+++ b/apps/web/src/lib/mcp-servers-stats-lib.ts
@@ -1,0 +1,113 @@
+import { pctOf } from "@/lib/pct-of-lib";
+import { installMethodDistribution } from "@/lib/ecosystem-stats";
+import {
+  classifyTransport,
+  hostingDistribution,
+  hostingOf,
+  transportDistribution,
+} from "@/lib/mcp-stats";
+import type { ReportModel } from "@/lib/data-reports";
+import {
+  SOURCE_LABEL,
+  TRUST_LABEL,
+  type Entry,
+  type SourceStatus,
+  type TrustLevel,
+} from "@/types/registry";
+
+const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
+
+export function buildMcpServersReport(entries: ReadonlyArray<Entry>, asOf: string): ReportModel {
+  const mcp = entries.filter((entry) => entry.category === "mcp");
+  const total = mcp.length;
+  const transport = transportDistribution(mcp);
+  const hosting = hostingDistribution(mcp);
+  const install = installMethodDistribution(mcp);
+
+  const remote = mcp.filter(
+    (entry) => hostingOf(classifyTransport(entry)) === "Remote (hosted)",
+  ).length;
+  const local = mcp.filter(
+    (entry) => hostingOf(classifyTransport(entry)) === "Local (stdio)",
+  ).length;
+  const sourceBacked = mcp.filter(
+    (entry) => entry.source === "source-backed" || entry.source === "first-party",
+  ).length;
+
+  const trustRows = TRUST_ORDER.map((trust) => {
+    const count = mcp.filter((entry) => entry.trust === trust).length;
+    return { label: TRUST_LABEL[trust], count, pct: pctOf(count, total) };
+  }).filter((row) => row.count > 0);
+
+  const sourceRows = SOURCE_ORDER.map((source) => {
+    const count = mcp.filter((entry) => entry.source === source).length;
+    return { label: SOURCE_LABEL[source], count, pct: pctOf(count, total) };
+  }).filter((row) => row.count > 0);
+
+  return {
+    slug: "/state-of-mcp-servers",
+    exportSlug: "mcp-servers",
+    title: "State of MCP Servers 2026",
+    description:
+      "A data report on MCP servers for Claude: transport mix, local vs hosted split, trust and source provenance, and install methods from the HeyClaude registry.",
+    keywords: ["MCP servers", "Model Context Protocol", "Claude", "transport", "registry"],
+    asOf,
+    total,
+    stats: [
+      { key: "total", label: "MCP servers", value: total, hint: "registry" },
+      { key: "remote", label: "Hosted (remote)", value: remote, hint: `${pctOf(remote, total)}%` },
+      { key: "local", label: "Local (stdio)", value: local, hint: `${pctOf(local, total)}%` },
+      {
+        key: "source-backed",
+        label: "Source-backed",
+        value: sourceBacked,
+        hint: `${pctOf(sourceBacked, total)}%`,
+      },
+    ],
+    dimensions: [
+      {
+        key: "transport",
+        title: "Transport distribution",
+        help: "How MCP servers connect to Claude.",
+        rows: transport.rows.map((row) => ({
+          label: row.label,
+          count: row.count,
+          pct: pctOf(row.count, transport.total),
+        })),
+      },
+      {
+        key: "hosting",
+        title: "Local vs hosted",
+        help: "Whether a server runs locally (stdio) or remotely (HTTP/SSE).",
+        rows: hosting.rows.map((row) => ({
+          label: row.label,
+          count: row.count,
+          pct: pctOf(row.count, hosting.total),
+        })),
+      },
+      {
+        key: "trust",
+        title: "Trust-level distribution",
+        help: "Registry trust labels for MCP servers.",
+        rows: trustRows,
+      },
+      {
+        key: "source",
+        title: "Source provenance distribution",
+        help: "How listing identity is verified.",
+        rows: sourceRows,
+      },
+      {
+        key: "install-methods",
+        title: "Install methods",
+        help: "Install command distribution for MCP servers with install commands.",
+        rows: install.rows.map((row) => ({
+          label: row.label,
+          count: row.count,
+          pct: pctOf(row.count, install.total),
+        })),
+      },
+    ].filter((dimension) => dimension.rows.length > 0),
+  };
+}

--- a/apps/web/src/lib/mcp-servers-stats.ts
+++ b/apps/web/src/lib/mcp-servers-stats.ts
@@ -1,0 +1,4 @@
+/**
+ * State of MCP servers report helpers.
+ */
+export { buildMcpServersReport } from "@/lib/mcp-servers-stats-lib";

--- a/apps/web/src/routes/api/reports/$report.ts
+++ b/apps/web/src/routes/api/reports/$report.ts
@@ -6,6 +6,8 @@ import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { buildHooksReport } from "@/lib/hooks-stats";
 import { buildSkillsReport } from "@/lib/skills-stats";
 import { buildAgentsReport } from "@/lib/agents-stats";
+import { buildClaudeToolingReport } from "@/lib/claude-tooling-stats";
+import { buildMcpServersReport } from "@/lib/mcp-servers-stats";
 import { reportToCsv, reportToJson, type ReportModel } from "@/lib/data-reports";
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -15,6 +17,8 @@ const REPORT_BUILDERS: Record<string, () => ReportModel> = {
   "claude-code-hooks": () => buildHooksReport(ENTRIES, AS_OF),
   "agent-skills": () => buildSkillsReport(ENTRIES, AS_OF),
   "ai-agents": () => buildAgentsReport(ENTRIES, AS_OF),
+  "claude-tooling": () => buildClaudeToolingReport(ENTRIES, AS_OF),
+  "mcp-servers": () => buildMcpServersReport(ENTRIES, AS_OF),
 };
 
 const CACHE_CONTROL = "public, max-age=3600, s-maxage=86400";

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -21,6 +21,7 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { CountUp } from "@/components/count-up";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { ReportDownloads } from "@/components/report-downloads";
 import { trackEvent } from "@/lib/analytics";
 import {
   stateReportEntryAnalyticsData,
@@ -280,6 +281,8 @@ function StateOfClaudeToolingPage() {
       >
         <DistTable rows={NOTES_DIST} />
       </Section>
+
+      <ReportDownloads exportSlug="claude-tooling" />
 
       <section className="mt-12">
         <div className="flex items-center gap-2">

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -16,6 +16,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -244,7 +245,11 @@ function StateOfMcpServersPage() {
           <h2 className="h-display-2 text-ink text-balance">Trust-level distribution</h2>
           <p className="mt-2 text-sm text-ink-muted">
             Every server carries a trust signal you can verify.{" "}
-            <Link to="/quality" className="text-ink underline-offset-2 hover:underline">
+            <Link
+              to="/quality"
+              onClick={() => trackStateReportEgress("quality")}
+              className="text-ink underline-offset-2 hover:underline"
+            >
               See how we score.
             </Link>
           </p>
@@ -277,6 +282,8 @@ function StateOfMcpServersPage() {
       >
         <DistTable rows={TAG_DIST} />
       </DataSection>
+
+      <ReportDownloads exportSlug="mcp-servers" />
 
       <section className="mt-12">
         <div className="flex items-center gap-2">

--- a/tests/claude-tooling-stats-lib.test.ts
+++ b/tests/claude-tooling-stats-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeToolingReport } from "@/lib/claude-tooling-stats-lib";
+import { buildClaudeToolingReport as buildFromWrapper } from "@/lib/claude-tooling-stats";
+import { ENTRIES } from "@/data/entries";
+
+describe("claude-tooling-stats-lib", () => {
+  it("builds a deterministic report model with key dimensions", () => {
+    const a = buildClaudeToolingReport(ENTRIES, "2026-07-16");
+    const b = buildClaudeToolingReport(ENTRIES, "2026-07-16");
+    expect(a).toEqual(b);
+    expect(a.slug).toBe("/state-of-claude-tooling");
+    expect(a.exportSlug).toBe("claude-tooling");
+    expect(a.total).toBeGreaterThan(500);
+    expect(a.dimensions.map((dimension) => dimension.key)).toEqual(
+      expect.arrayContaining([
+        "categories",
+        "trust",
+        "source",
+        "platforms",
+        "install-methods",
+      ]),
+    );
+  });
+
+  it("keeps wrapper re-export aligned", () => {
+    expect(buildFromWrapper(ENTRIES, "2026-07-16")).toEqual(
+      buildClaudeToolingReport(ENTRIES, "2026-07-16"),
+    );
+  });
+});

--- a/tests/mcp-servers-stats-lib.test.ts
+++ b/tests/mcp-servers-stats-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildMcpServersReport } from "@/lib/mcp-servers-stats-lib";
+import { buildMcpServersReport as buildFromWrapper } from "@/lib/mcp-servers-stats";
+import { ENTRIES } from "@/data/entries";
+
+describe("mcp-servers-stats-lib", () => {
+  it("builds a deterministic MCP servers report model", () => {
+    const a = buildMcpServersReport(ENTRIES, "2026-07-16");
+    const b = buildMcpServersReport(ENTRIES, "2026-07-16");
+    expect(a).toEqual(b);
+    expect(a.slug).toBe("/state-of-mcp-servers");
+    expect(a.exportSlug).toBe("mcp-servers");
+    expect(a.total).toBeGreaterThan(100);
+    expect(a.dimensions.map((dimension) => dimension.key)).toEqual(
+      expect.arrayContaining([
+        "transport",
+        "hosting",
+        "trust",
+        "source",
+        "install-methods",
+      ]),
+    );
+  });
+
+  it("keeps wrapper re-export aligned", () => {
+    expect(buildFromWrapper(ENTRIES, "2026-07-16")).toEqual(
+      buildMcpServersReport(ENTRIES, "2026-07-16"),
+    );
+  });
+});

--- a/tests/report-exports-api.test.ts
+++ b/tests/report-exports-api.test.ts
@@ -51,6 +51,23 @@ describe("/api/reports/{report}", () => {
     expect(body.total).toBeGreaterThan(50);
   });
 
+  it("serves the state of Claude tooling report", async () => {
+    const res = await call("claude-tooling.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { report: string; total: number };
+    expect(body.report).toBe("claude-tooling");
+    expect(body.total).toBeGreaterThan(500);
+  });
+
+  it("serves the state of MCP servers report as CSV", async () => {
+    const res = await call("mcp-servers.csv");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/csv");
+    const text = await res.text();
+    expect(text.split("\r\n")[0]).toBe("dimension,label,count,percent");
+    expect(text).toContain("transport");
+  });
+
   it("sets caching and a download filename", async () => {
     const res = await call("agent-skills.csv");
     expect(res.headers.get("cache-control")).toContain("max-age");


### PR DESCRIPTION
## Summary
- Add deterministic report-model builders for `state-of-claude-tooling` and `state-of-mcp-servers` and expose them via new stats wrappers.
- Extend `/api/reports/{report}` to export `claude-tooling` and `mcp-servers` in JSON/CSV, then wire `ReportDownloads` cards into both report pages.
- Track the MCP report's quality-link egress consistently and add focused Vitest coverage for new builders and export endpoints.
- Avoid overlap with open PR paths (`README.md`, `tools.submit.tsx`, contributor/openapi/changelog files), so this remains merge-clean after current open PRs.

## Test plan
- [x] `npm test -- tests/report-exports-api.test.ts tests/claude-tooling-stats-lib.test.ts tests/mcp-servers-stats-lib.test.ts`
- [ ] CI `coverage` + `codecov/patch` + `codecov/project`
- [ ] CI `validate-web` + `required-pr-gate`

Refs #550

Made with [Cursor](https://cursor.com)