### PR TITLE
feat(web): add global app not-found egress analytics

### DIFF
--- a/apps/web/src/lib/app-error-cta-events-lib.ts
+++ b/apps/web/src/lib/app-error-cta-events-lib.ts
@@ -1,13 +1,15 @@
 /**
  * Pure app error chrome navigation analytics helpers.
  *
- * Maps root error retry and home egress to privacy-light event names without
- * embedding error messages or stack traces.
+ * Maps root error retry/home and global not-found egress to privacy-light event
+ * names without embedding error messages, stack traces, or pathnames.
  */
 
 export const APP_ERROR_SURFACE = "app-error";
+export const APP_NOTFOUND_SURFACE = "app-notfound";
 
 export type AppErrorDestination = "retry" | "home";
+export type AppNotFoundDestination = "browse" | "home";
 
 export function appErrorChromeAnalyticsEvent(): string {
   return "app_error_chrome_click";
@@ -16,6 +18,17 @@ export function appErrorChromeAnalyticsEvent(): string {
 export function appErrorChromeAnalyticsData(destination: AppErrorDestination) {
   return {
     surface: APP_ERROR_SURFACE,
+    destination,
+  };
+}
+
+export function appNotFoundEgressAnalyticsEvent(): string {
+  return "app_notfound_egress_click";
+}
+
+export function appNotFoundEgressAnalyticsData(destination: AppNotFoundDestination) {
+  return {
+    surface: APP_NOTFOUND_SURFACE,
     destination,
   };
 }

--- a/apps/web/src/lib/app-error-cta-events.ts
+++ b/apps/web/src/lib/app-error-cta-events.ts
@@ -3,7 +3,11 @@
  */
 export {
   APP_ERROR_SURFACE,
+  APP_NOTFOUND_SURFACE,
   appErrorChromeAnalyticsData,
   appErrorChromeAnalyticsEvent,
+  appNotFoundEgressAnalyticsData,
+  appNotFoundEgressAnalyticsEvent,
   type AppErrorDestination,
+  type AppNotFoundDestination,
 } from "@/lib/app-error-cta-events-lib";

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -32,6 +32,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   appErrorChromeAnalyticsData,
   appErrorChromeAnalyticsEvent,
+  appNotFoundEgressAnalyticsData,
+  appNotFoundEgressAnalyticsEvent,
 } from "@/lib/app-error-cta-events";
 import { twitterHandleFrom } from "@/lib/twitter-handle-lib";
 import { buildOrganizationJsonLd, buildWebsiteJsonLd } from "@heyclaude/registry/seo";
@@ -58,12 +60,24 @@ function NotFoundComponent() {
             <Link
               to="/browse"
               className="inline-flex h-9 items-center rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90"
+              onClick={() =>
+                trackEvent(
+                  appNotFoundEgressAnalyticsEvent(),
+                  appNotFoundEgressAnalyticsData("browse"),
+                )
+              }
             >
               Browse directory
             </Link>
             <Link
               to="/"
               className="inline-flex h-9 items-center rounded-md border border-border bg-surface px-4 text-sm font-medium text-ink hover:bg-surface-2"
+              onClick={() =>
+                trackEvent(
+                  appNotFoundEgressAnalyticsEvent(),
+                  appNotFoundEgressAnalyticsData("home"),
+                )
+              }
             >
               Home
             </Link>

--- a/tests/app-error-cta-events-lib.test.ts
+++ b/tests/app-error-cta-events-lib.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   APP_ERROR_SURFACE,
+  APP_NOTFOUND_SURFACE,
   appErrorChromeAnalyticsData,
   appErrorChromeAnalyticsEvent,
+  appNotFoundEgressAnalyticsData,
+  appNotFoundEgressAnalyticsEvent,
 } from "@/lib/app-error-cta-events-lib";
 
 describe("app error cta events lib", () => {
@@ -14,6 +17,18 @@ describe("app error cta events lib", () => {
     });
     expect(appErrorChromeAnalyticsData("home")).toEqual({
       surface: APP_ERROR_SURFACE,
+      destination: "home",
+    });
+  });
+
+  it("builds privacy-light app not-found egress analytics", () => {
+    expect(appNotFoundEgressAnalyticsEvent()).toBe("app_notfound_egress_click");
+    expect(appNotFoundEgressAnalyticsData("browse")).toEqual({
+      surface: APP_NOTFOUND_SURFACE,
+      destination: "browse",
+    });
+    expect(appNotFoundEgressAnalyticsData("home")).toEqual({
+      surface: APP_NOTFOUND_SURFACE,
       destination: "home",
     });
   });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `app_notfound_egress_click` on root 404 Browse directory / Home egress
- Payload: `{ surface: "app-notfound", destination: "browse" | "home" }` (no pathnames)

## Test plan
- [ ] Vitest covers app not-found egress helpers
- [ ] Hit a global 404 and click Browse directory / Home
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
