### PR TITLE
feat(web): add source citations methodology egress analytics

### DIFF
--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -16,6 +16,8 @@ import {
   SOURCE_CITATIONS_DETAIL_SURFACE,
   sourceCitationAnalyticsData,
   sourceCitationAnalyticsEvent,
+  sourceCitationEgressAnalyticsData,
+  sourceCitationEgressAnalyticsEvent,
   type SourceCitationKind,
 } from "@/lib/source-citations-cta-events";
 
@@ -182,6 +184,12 @@ export function SourceCitations({
         to="/quality"
         hash="source-provenance"
         className="mt-2 inline-flex text-xs text-ink-muted hover:text-ink"
+        onClick={() =>
+          trackEvent(
+            sourceCitationEgressAnalyticsEvent(),
+            sourceCitationEgressAnalyticsData("quality-source-provenance", surface),
+          )
+        }
       >
         Source methodology →
       </Link>

--- a/apps/web/src/lib/source-citations-cta-events-lib.ts
+++ b/apps/web/src/lib/source-citations-cta-events-lib.ts
@@ -8,6 +8,7 @@
 export const SOURCE_CITATIONS_DETAIL_SURFACE = "detail-source-citations";
 
 export type SourceCitationKind = "source-repo" | "repo" | "docs" | "website" | "package";
+export type SourceCitationEgressDestination = "quality-source-provenance";
 
 export function sourceCitationEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;
@@ -29,5 +30,19 @@ export function sourceCitationAnalyticsData(
     surface,
     citation: kind,
     host,
+  };
+}
+
+export function sourceCitationEgressAnalyticsEvent(): string {
+  return "detail_source_citations_egress_click";
+}
+
+export function sourceCitationEgressAnalyticsData(
+  destination: SourceCitationEgressDestination,
+  surface: string = SOURCE_CITATIONS_DETAIL_SURFACE,
+) {
+  return {
+    surface,
+    destination,
   };
 }

--- a/apps/web/src/lib/source-citations-cta-events.ts
+++ b/apps/web/src/lib/source-citations-cta-events.ts
@@ -5,6 +5,9 @@ export {
   SOURCE_CITATIONS_DETAIL_SURFACE,
   sourceCitationAnalyticsData,
   sourceCitationAnalyticsEvent,
+  sourceCitationEgressAnalyticsData,
+  sourceCitationEgressAnalyticsEvent,
   sourceCitationEntryKey,
+  type SourceCitationEgressDestination,
   type SourceCitationKind,
 } from "@/lib/source-citations-cta-events-lib";

--- a/tests/source-citations-cta-events-lib.test.ts
+++ b/tests/source-citations-cta-events-lib.test.ts
@@ -3,6 +3,8 @@ import {
   SOURCE_CITATIONS_DETAIL_SURFACE,
   sourceCitationAnalyticsData,
   sourceCitationAnalyticsEvent,
+  sourceCitationEgressAnalyticsData,
+  sourceCitationEgressAnalyticsEvent,
 } from "@/lib/source-citations-cta-events-lib";
 
 describe("source citations cta events lib", () => {
@@ -35,6 +37,27 @@ describe("source citations cta events lib", () => {
       surface: "compare-table",
       citation: "package",
       host: "cdn.example.com",
+    });
+  });
+
+  it("builds privacy-light source citations methodology egress analytics", () => {
+    expect(sourceCitationEgressAnalyticsEvent()).toBe(
+      "detail_source_citations_egress_click",
+    );
+    expect(
+      sourceCitationEgressAnalyticsData("quality-source-provenance"),
+    ).toEqual({
+      surface: "detail-source-citations",
+      destination: "quality-source-provenance",
+    });
+    expect(
+      sourceCitationEgressAnalyticsData(
+        "quality-source-provenance",
+        "compare-table",
+      ),
+    ).toEqual({
+      surface: "compare-table",
+      destination: "quality-source-provenance",
     });
   });
 });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `detail_source_citations_egress_click` on the Source methodology → link
- Payload: `{ surface, destination: "quality-source-provenance" }` (no URLs/titles)

## Test plan
- [ ] Vitest covers egress helpers
- [ ] Click Source methodology on an entry citations panel
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
