### PR TITLE
feat(web): add source citations contributor egress analytics

### DIFF
--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -160,6 +160,12 @@ export function SourceCitations({
                   to="/contributors/$slug"
                   params={{ slug: c.contributorSlug }}
                   className="block rounded-md px-2 transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                  onClick={() =>
+                    trackEvent(
+                      sourceCitationEgressAnalyticsEvent(),
+                      sourceCitationEgressAnalyticsData("contributor-profile", surface),
+                    )
+                  }
                 >
                   {body}
                 </Link>

--- a/apps/web/src/lib/source-citations-cta-events-lib.ts
+++ b/apps/web/src/lib/source-citations-cta-events-lib.ts
@@ -8,7 +8,7 @@
 export const SOURCE_CITATIONS_DETAIL_SURFACE = "detail-source-citations";
 
 export type SourceCitationKind = "source-repo" | "repo" | "docs" | "website" | "package";
-export type SourceCitationEgressDestination = "quality-source-provenance";
+export type SourceCitationEgressDestination = "quality-source-provenance" | "contributor-profile";
 
 export function sourceCitationEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;

--- a/tests/source-citations-cta-events-lib.test.ts
+++ b/tests/source-citations-cta-events-lib.test.ts
@@ -59,9 +59,7 @@ describe("source citations cta events lib", () => {
       surface: "compare-table",
       destination: "quality-source-provenance",
     });
-    expect(
-      sourceCitationEgressAnalyticsData("contributor-profile"),
-    ).toEqual({
+    expect(sourceCitationEgressAnalyticsData("contributor-profile")).toEqual({
       surface: "detail-source-citations",
       destination: "contributor-profile",
     });

--- a/tests/source-citations-cta-events-lib.test.ts
+++ b/tests/source-citations-cta-events-lib.test.ts
@@ -59,5 +59,11 @@ describe("source citations cta events lib", () => {
       surface: "compare-table",
       destination: "quality-source-provenance",
     });
+    expect(
+      sourceCitationEgressAnalyticsData("contributor-profile"),
+    ).toEqual({
+      surface: "detail-source-citations",
+      destination: "contributor-profile",
+    });
   });
 });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `detail_source_citations_egress_click` on Submitted-by contributor profile links
- Payload: `{ surface, destination: "contributor-profile" }` (no slug/name/URL)

## Test plan
- [ ] Vitest covers contributor-profile destination
- [ ] Click Submitted-by contributor link on an entry citations panel
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
