### PR TITLE
feat(web): add entry detail badge preview click analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-badge-cta-events-lib.ts
@@ -1,8 +1,8 @@
 /**
  * Pure entry detail badge CTA analytics helpers.
  *
- * Maps README badge markdown copy actions to privacy-light event names
- * without embedding the copied markdown payload.
+ * Maps README badge markdown copy and badge preview opens to privacy-light
+ * event names without embedding URLs or the copied markdown payload.
  */
 
 export const ENTRY_DETAIL_BADGE_SURFACE = "detail-badge";
@@ -16,6 +16,17 @@ export function entryDetailBadgeCopyAnalyticsEvent(): string {
 }
 
 export function entryDetailBadgeCopyAnalyticsData(category: string, slug: string) {
+  return {
+    entry: entryDetailBadgeEntryKey(category, slug),
+    surface: ENTRY_DETAIL_BADGE_SURFACE,
+  };
+}
+
+export function entryDetailBadgePreviewAnalyticsEvent(): string {
+  return "detail_badge_preview_click";
+}
+
+export function entryDetailBadgePreviewAnalyticsData(category: string, slug: string) {
   return {
     entry: entryDetailBadgeEntryKey(category, slug),
     surface: ENTRY_DETAIL_BADGE_SURFACE,

--- a/apps/web/src/lib/entry-detail-badge-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-badge-cta-events.ts
@@ -6,4 +6,6 @@ export {
   entryDetailBadgeCopyAnalyticsData,
   entryDetailBadgeCopyAnalyticsEvent,
   entryDetailBadgeEntryKey,
+  entryDetailBadgePreviewAnalyticsData,
+  entryDetailBadgePreviewAnalyticsEvent,
 } from "@/lib/entry-detail-badge-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -118,6 +118,8 @@ import {
 import {
   entryDetailBadgeCopyAnalyticsData,
   entryDetailBadgeCopyAnalyticsEvent,
+  entryDetailBadgePreviewAnalyticsData,
+  entryDetailBadgePreviewAnalyticsEvent,
 } from "@/lib/entry-detail-badge-cta-events";
 import {
   ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
@@ -1183,7 +1185,17 @@ function BadgeSection({
         Markdown into your README — it renders the badge and links back to this page.
       </p>
       <div className="mt-3 flex items-center gap-3">
-        <a href={entryUrl} target="_blank" rel="noreferrer">
+        <a
+          href={entryUrl}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() =>
+            trackEvent(
+              entryDetailBadgePreviewAnalyticsEvent(),
+              entryDetailBadgePreviewAnalyticsData(category, slug),
+            )
+          }
+        >
           <img src={badgeUrl} alt="Listed on HeyClaude" height={20} className="h-5 w-auto" />
         </a>
       </div>

--- a/tests/entry-detail-badge-cta-events-lib.test.ts
+++ b/tests/entry-detail-badge-cta-events-lib.test.ts
@@ -3,6 +3,8 @@ import {
   ENTRY_DETAIL_BADGE_SURFACE,
   entryDetailBadgeCopyAnalyticsData,
   entryDetailBadgeCopyAnalyticsEvent,
+  entryDetailBadgePreviewAnalyticsData,
+  entryDetailBadgePreviewAnalyticsEvent,
 } from "@/lib/entry-detail-badge-cta-events-lib";
 
 describe("entry detail badge cta events lib", () => {
@@ -12,6 +14,16 @@ describe("entry detail badge cta events lib", () => {
     );
     expect(entryDetailBadgeCopyAnalyticsData("mcp", "browser")).toEqual({
       entry: "mcp/browser",
+      surface: ENTRY_DETAIL_BADGE_SURFACE,
+    });
+  });
+
+  it("builds privacy-light badge preview click analytics", () => {
+    expect(entryDetailBadgePreviewAnalyticsEvent()).toBe(
+      "detail_badge_preview_click",
+    );
+    expect(entryDetailBadgePreviewAnalyticsData("skills", "demo")).toEqual({
+      entry: "skills/demo",
       surface: ENTRY_DETAIL_BADGE_SURFACE,
     });
   });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `detail_badge_preview_click` on the entry detail badge preview link
- Payload: `{ entry, surface: "detail-badge" }` (no URLs or markdown)

## Test plan
- [ ] Vitest covers preview helpers
- [ ] Click badge preview on an entry detail page
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
