### PR TITLE
test(mcp): cover unscoped listings and platform selection in tool-orchestration

### DIFF
--- a/tests/mcp-registry-tool-orchestration-lib-i.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-i.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getInstallGuidance,
+  listCategoryEntries,
+  recommendForTask,
+} from "../packages/mcp/src/registry-tool-orchestration-lib.js";
+
+const entry = {
+  category: "skills",
+  slug: "demo",
+  title: "Demo Skill",
+  description: "browser automation demo skill",
+  installCommand: "npx -y demo",
+  platforms: ["claude-code"],
+  tags: ["demo"],
+};
+
+const artifactOptions = {
+  readJsonArtifact: async (relativePath: string) =>
+    relativePath === "entries/skills/demo.json"
+      ? { entry }
+      : { entries: [entry] },
+  readTextArtifact: async () => JSON.stringify({ entry }),
+};
+
+describe("registry-tool-orchestration unscoped listings", () => {
+  it("recommends across every category when none is requested", async () => {
+    const result = await recommendForTask(
+      { task: "browser automation demo" },
+      artifactOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.category).toBe("");
+  });
+
+  it("lists entries across every category when none is requested", async () => {
+    const result = await listCategoryEntries({}, artifactOptions);
+    expect(result.ok).toBe(true);
+    expect(result.category).toBe("");
+    expect(result.total).toBe(1);
+  });
+});
+
+describe("registry-tool-orchestration install guidance platform selection", () => {
+  it("leaves compatibility unselected when no platform is requested", async () => {
+    const result = await getInstallGuidance(
+      { category: "skills", slug: "demo" },
+      artifactOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.selectedCompatibility).toBeNull();
+  });
+
+  it("returns null compatibility when the platform has no matching row", async () => {
+    const result = await getInstallGuidance(
+      { category: "skills", slug: "demo", platform: "zed" },
+      artifactOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.selectedCompatibility).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds a new test file covering the unscoped-filter and platform-selection branches in `registry-tool-orchestration-lib`: `recommendForTask` and `listCategoryEntries` running without a category (the `!category` arm of their entry filters), and `getInstallGuidance` leaving `selectedCompatibility` null both when no platform is requested and when the requested platform has no matching compatibility row. Lib branch coverage 86.6% -> 87.4% (229/262). Test-only change; kept in its own `-i` file.