### PR TITLE
feat(web): add entry detail content outline TOC analytics

### DIFF
--- a/apps/web/src/lib/dossier-toc-cta-events-lib.ts
+++ b/apps/web/src/lib/dossier-toc-cta-events-lib.ts
@@ -6,6 +6,7 @@
  */
 
 export const DOSSIER_TOC_DETAIL_RAIL_SURFACE = "detail-dossier-toc";
+export const DOSSIER_TOC_CONTENT_OUTLINE_SURFACE = "detail-content-outline";
 
 export function dossierTocEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;

--- a/apps/web/src/lib/dossier-toc-cta-events.ts
+++ b/apps/web/src/lib/dossier-toc-cta-events.ts
@@ -2,6 +2,7 @@
  * Dossier TOC CTA event surface.
  */
 export {
+  DOSSIER_TOC_CONTENT_OUTLINE_SURFACE,
   DOSSIER_TOC_DETAIL_RAIL_SURFACE,
   dossierTocEntryKey,
   dossierTocSectionAnalyticsData,

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -82,6 +82,11 @@ import { useCompare, useIsCompared } from "@/lib/compare";
 import { serializeCompareItems } from "@/lib/compare-selection";
 import { trackEvent } from "@/lib/analytics";
 import {
+  DOSSIER_TOC_CONTENT_OUTLINE_SURFACE,
+  dossierTocSectionAnalyticsData,
+  dossierTocSectionAnalyticsEvent,
+} from "@/lib/dossier-toc-cta-events";
+import {
   entryDetailCategoryHubAnalyticsData,
   entryDetailCategoryHubAnalyticsEvent,
   entryDetailTagAnalyticsData,
@@ -871,7 +876,21 @@ function Dossier() {
                 <ul className="grid gap-1 text-xs text-ink-muted sm:grid-cols-2">
                   {entry.headings.slice(0, 16).map((heading) => (
                     <li key={heading.id}>
-                      <a href={`#${heading.id}`} className="hover:text-ink">
+                      <a
+                        href={`#${heading.id}`}
+                        className="hover:text-ink"
+                        onClick={() =>
+                          trackEvent(
+                            dossierTocSectionAnalyticsEvent(),
+                            dossierTocSectionAnalyticsData(
+                              entry.category,
+                              entry.slug,
+                              heading.id,
+                              DOSSIER_TOC_CONTENT_OUTLINE_SURFACE,
+                            ),
+                          )
+                        }
+                      >
                         {heading.text}
                       </a>
                     </li>

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -97,12 +97,6 @@ export const Route = createFileRoute("/for/$platform/$category")({
       </p>
       <Link
         to="/for"
-        onClick={() =>
-          trackEvent(
-            platformCategoryNotFoundEgressAnalyticsEvent(),
-            platformCategoryNotFoundEgressAnalyticsData(),
-          )
-        }
         className="mt-6 inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-4 font-medium text-background hover:opacity-90"
         onClick={() =>
           trackEvent(

--- a/tests/dossier-toc-cta-events-lib.test.ts
+++ b/tests/dossier-toc-cta-events-lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  DOSSIER_TOC_CONTENT_OUTLINE_SURFACE,
   DOSSIER_TOC_DETAIL_RAIL_SURFACE,
   dossierTocSectionAnalyticsData,
   dossierTocSectionAnalyticsEvent,
@@ -27,5 +28,17 @@ describe("dossier toc cta events lib", () => {
         section: "signals",
       },
     );
+    expect(
+      dossierTocSectionAnalyticsData(
+        "mcp",
+        "browser",
+        "install",
+        DOSSIER_TOC_CONTENT_OUTLINE_SURFACE,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-content-outline",
+      section: "install",
+    });
   });
 });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `detail_toc_section_click` on entry detail Content outline anchors
- Payload: `{ entry, surface: "detail-content-outline", section }` (no heading text)

## Test plan
- [ ] Vitest covers content-outline surface
- [ ] Click a Content outline link on an entry detail page
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
