### PR TITLE
feat(web): add feeds email expand analytics

### DIFF
--- a/apps/web/src/lib/feeds-page-cta-events-lib.ts
+++ b/apps/web/src/lib/feeds-page-cta-events-lib.ts
@@ -73,3 +73,15 @@ export function feedsPageEmailFollowAnalyticsData(
     pending,
   };
 }
+
+export function feedsPageEmailExpandAnalyticsEvent(): string {
+  return "feeds_page_email_expand_click";
+}
+
+export function feedsPageEmailExpandAnalyticsData(feedKey: string, feedKind: FeedsPageFeedKind) {
+  return {
+    surface: FEEDS_PAGE_SURFACE,
+    feedKey,
+    feedKind,
+  };
+}

--- a/apps/web/src/lib/feeds-page-cta-events.ts
+++ b/apps/web/src/lib/feeds-page-cta-events.ts
@@ -5,6 +5,8 @@ export {
   FEEDS_PAGE_SURFACE,
   feedsPageApiDocsAnalyticsData,
   feedsPageApiDocsAnalyticsEvent,
+  feedsPageEmailExpandAnalyticsData,
+  feedsPageEmailExpandAnalyticsEvent,
   feedsPageEmailFollowAnalyticsData,
   feedsPageEmailFollowAnalyticsEvent,
   feedsPageFeedCopyAnalyticsData,

--- a/apps/web/src/routes/feeds.tsx
+++ b/apps/web/src/routes/feeds.tsx
@@ -9,6 +9,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   feedsPageApiDocsAnalyticsData,
   feedsPageApiDocsAnalyticsEvent,
+  feedsPageEmailExpandAnalyticsData,
+  feedsPageEmailExpandAnalyticsEvent,
   feedsPageEmailFollowAnalyticsData,
   feedsPageEmailFollowAnalyticsEvent,
   feedsPageFeedCopyAnalyticsData,
@@ -96,7 +98,17 @@ function FeedRow({
           event={feedsPageFeedCopyAnalyticsEvent()}
           eventData={feedsPageFeedCopyAnalyticsData(feedKey, feedKind, rowIndex, sectionCount)}
         />
-        <details className="inline-block">
+        <details
+          className="inline-block"
+          onToggle={(event) => {
+            if (event.currentTarget.open) {
+              trackEvent(
+                feedsPageEmailExpandAnalyticsEvent(),
+                feedsPageEmailExpandAnalyticsData(feedKey, feedKind),
+              );
+            }
+          }}
+        >
           <summary className="inline-flex h-8 cursor-pointer items-center rounded-md border border-border bg-surface px-2.5 text-xs text-ink hover:bg-surface-2">
             Email
           </summary>

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -97,12 +97,6 @@ export const Route = createFileRoute("/for/$platform/$category")({
       </p>
       <Link
         to="/for"
-        onClick={() =>
-          trackEvent(
-            platformCategoryNotFoundEgressAnalyticsEvent(),
-            platformCategoryNotFoundEgressAnalyticsData(),
-          )
-        }
         className="mt-6 inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-4 font-medium text-background hover:opacity-90"
         onClick={() =>
           trackEvent(

--- a/tests/feeds-page-cta-events-lib.test.ts
+++ b/tests/feeds-page-cta-events-lib.test.ts
@@ -5,6 +5,8 @@ import {
   feedsPageApiDocsAnalyticsEvent,
   feedsPageFeedCopyAnalyticsData,
   feedsPageFeedCopyAnalyticsEvent,
+  feedsPageEmailExpandAnalyticsData,
+  feedsPageEmailExpandAnalyticsEvent,
   feedsPageEmailFollowAnalyticsData,
   feedsPageEmailFollowAnalyticsEvent,
   feedsPageFeedOpenAnalyticsData,
@@ -47,6 +49,14 @@ describe("feeds page cta events lib", () => {
       feedKey: "changelog",
       feedKind: "changelog",
       pending: true,
+    });
+    expect(feedsPageEmailExpandAnalyticsEvent()).toBe(
+      "feeds_page_email_expand_click",
+    );
+    expect(feedsPageEmailExpandAnalyticsData("mcp", "category")).toEqual({
+      surface: FEEDS_PAGE_SURFACE,
+      feedKey: "mcp",
+      feedKind: "category",
     });
   });
 });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `feeds_page_email_expand_click` when expanding a feed row Email disclosure
- Payload: `{ surface: "feeds-page", feedKey, feedKind }` (no email/URLs)
- Fix duplicate `onClick` on platform×category not-found egress (unblocks type-check)

## Test plan
- [ ] Vitest covers email expand helpers
- [ ] Expand Email on `/feeds` and confirm event fires once on open
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
