### PR TITLE
feat(web): add trending, how-it-works, changelog, and setup analytics

### DIFF
--- a/apps/web/src/components/entry-setup-snapshot-panel.tsx
+++ b/apps/web/src/components/entry-setup-snapshot-panel.tsx
@@ -11,6 +11,14 @@ import {
 } from "lucide-react";
 import type { Entry, InstallType } from "@/types/registry";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import { ENTRY_COMMAND_CENTER_ID } from "@/lib/entry-detail-command-center";
+import {
+  entrySetupSnapshotAnalyticsData,
+  entrySetupSnapshotAnalyticsEvent,
+  type EntrySetupSnapshotDestination,
+  type EntrySetupSnapshotTileId,
+} from "@/lib/entry-setup-snapshot-cta-events";
 
 const INSTALL_TYPE_LABEL: Record<InstallType, string> = {
   cli: "CLI install",
@@ -34,20 +42,28 @@ function StatTile({
   label,
   value,
   tone,
+  href,
+  onNavigate,
 }: {
   icon: LucideIcon;
   label: string;
   value: string;
   tone: StatTone;
+  href: string;
+  onNavigate: () => void;
 }) {
   return (
-    <article className="rounded-lg border border-border bg-background p-3">
+    <a
+      href={href}
+      onClick={onNavigate}
+      className="rounded-lg border border-border bg-background p-3 transition-colors duration-200 ease-out hover:border-accent/40 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+    >
       <div className="flex items-center gap-2">
         <Icon className={cn("h-4 w-4 shrink-0", toneText(tone))} aria-hidden />
         <p className="text-xs font-medium text-ink-muted">{label}</p>
       </div>
       <p className={cn("mt-1.5 text-sm font-semibold", toneText(tone))}>{value}</p>
-    </article>
+    </a>
   );
 }
 
@@ -79,6 +95,19 @@ export function EntrySetupSnapshotPanel({
         ? "Add the configuration to enable it."
         : "Follow the manual setup steps.";
 
+  const trackTile = (
+    tileId: EntrySetupSnapshotTileId,
+    destination: EntrySetupSnapshotDestination,
+  ) => {
+    trackEvent(
+      entrySetupSnapshotAnalyticsEvent(),
+      entrySetupSnapshotAnalyticsData(entry.category, entry.slug, tileId, destination),
+    );
+  };
+
+  const commandHref = `#${ENTRY_COMMAND_CENTER_ID}`;
+  const prereqHref = "#prerequisites";
+
   return (
     <section
       id="setup-snapshot"
@@ -107,30 +136,40 @@ export function EntrySetupSnapshotPanel({
           label="Install command"
           value={hasCommand ? "Provided" : "Not provided"}
           tone={hasCommand ? "good" : "muted"}
+          href={commandHref}
+          onNavigate={() => trackTile("install", "entry-command-center")}
         />
         <StatTile
           icon={FileCog}
           label="Config snippet"
           value={hasConfig ? "Provided" : "Not provided"}
           tone={hasConfig ? "good" : "muted"}
+          href={commandHref}
+          onNavigate={() => trackTile("config", "entry-command-center")}
         />
         <StatTile
           icon={ClipboardCopy}
           label="Copy snippet"
           value={hasCopy ? "Provided" : "Not provided"}
           tone={hasCopy ? "good" : "muted"}
+          href={commandHref}
+          onNavigate={() => trackTile("copy", "entry-command-center")}
         />
         <StatTile
           icon={ListChecks}
           label="Prerequisites"
           value={prereqCount > 0 ? `${prereqCount} to clear` : "None"}
           tone={prereqCount > 0 ? "watch" : "good"}
+          href={prereqHref}
+          onNavigate={() => trackTile("prerequisites", "prerequisites")}
         />
         <StatTile
           icon={MonitorSmartphone}
           label="Platforms"
           value={platformCount > 0 ? `${platformCount} listed` : "Not listed"}
           tone="muted"
+          href={commandHref}
+          onNavigate={() => trackTile("platforms", "entry-command-center")}
         />
         {difficulty !== null ? (
           <StatTile
@@ -138,6 +177,8 @@ export function EntrySetupSnapshotPanel({
             label="Difficulty"
             value={`${difficulty}/100`}
             tone={difficulty >= 66 ? "risk" : difficulty >= 33 ? "watch" : "good"}
+            href={commandHref}
+            onNavigate={() => trackTile("difficulty", "entry-command-center")}
           />
         ) : (
           <StatTile
@@ -145,6 +186,8 @@ export function EntrySetupSnapshotPanel({
             label="Install type"
             value={INSTALL_TYPE_LABEL[entry.installType]}
             tone="muted"
+            href={commandHref}
+            onNavigate={() => trackTile("install-type", "entry-command-center")}
           />
         )}
       </div>

--- a/apps/web/src/components/how-it-works.tsx
+++ b/apps/web/src/components/how-it-works.tsx
@@ -1,23 +1,52 @@
-import { Search, ShieldCheck, ClipboardCopy } from "lucide-react";
+import { Search, ShieldCheck, ClipboardCopy, ArrowRight } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { trackEvent } from "@/lib/analytics";
+import {
+  howItWorksStepAnalyticsData,
+  howItWorksStepAnalyticsEvent,
+  type HowItWorksDestination,
+  type HowItWorksStepId,
+} from "@/lib/how-it-works-cta-events";
 
-const STEPS = [
+const STEPS: Array<{
+  n: string;
+  Icon: typeof Search;
+  title: string;
+  body: string;
+  stepId: HowItWorksStepId;
+  destination: HowItWorksDestination;
+  to: "/browse" | "/quality" | "/platforms";
+  cta: string;
+}> = [
   {
     n: "01",
     Icon: Search,
     title: "Search by intent",
     body: 'Find resources by what they do — "postgres mcp", "release notes", "safe hook". No category-hunting.',
+    stepId: "search",
+    destination: "browse",
+    to: "/browse",
+    cta: "Open browse",
   },
   {
     n: "02",
     Icon: ShieldCheck,
     title: "Inspect before installing",
     body: "See trust level, source, safety notes, privacy notes, and prerequisites — surfaced before the install button.",
+    stepId: "inspect",
+    destination: "quality",
+    to: "/quality",
+    cta: "See quality signals",
   },
   {
     n: "03",
     Icon: ClipboardCopy,
     title: "Copy what you need",
     body: "Install command, MCP config, or full asset. One click. Configs are pinned to verified package versions.",
+    stepId: "copy",
+    destination: "platforms",
+    to: "/platforms",
+    cta: "Pick a platform",
   },
 ];
 
@@ -33,10 +62,17 @@ export function HowItWorks() {
         </div>
       </div>
       <div className="mt-6 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3">
-        {STEPS.map(({ n, Icon, title, body }) => (
-          <div
+        {STEPS.map(({ n, Icon, title, body, stepId, destination, to, cta }, stepIndex) => (
+          <Link
             key={n}
-            className="group relative flex flex-col gap-3 bg-surface p-6 transition-colors duration-200 ease-out hover:bg-surface-2"
+            to={to}
+            onClick={() =>
+              trackEvent(
+                howItWorksStepAnalyticsEvent(),
+                howItWorksStepAnalyticsData(stepId, destination, stepIndex, STEPS.length),
+              )
+            }
+            className="group relative flex flex-col gap-3 bg-surface p-6 transition-colors duration-200 ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60"
           >
             <div className="flex items-center justify-between">
               <span className="font-mono text-[11px] tracking-wider text-ink-subtle">{n}</span>
@@ -44,11 +80,14 @@ export function HowItWorks() {
             </div>
             <div className="font-display text-base font-semibold text-ink">{title}</div>
             <p className="text-sm text-ink-muted">{body}</p>
+            <span className="mt-auto inline-flex items-center gap-1 text-xs font-medium text-ink-muted group-hover:text-ink">
+              {cta} <ArrowRight className="h-3 w-3" aria-hidden />
+            </span>
             <span
               aria-hidden
               className="absolute inset-x-0 top-0 h-px origin-left scale-x-0 bg-accent transition-transform duration-300 group-hover:scale-x-100"
             />
-          </div>
+          </Link>
         ))}
       </div>
     </section>

--- a/apps/web/src/components/share-menu.tsx
+++ b/apps/web/src/components/share-menu.tsx
@@ -30,6 +30,8 @@ export interface ShareMenuProps {
   raycastUrl?: string;
   /** When set, emits detail share analytics for dropdown actions. */
   analyticsEntry?: { category: string; slug: string };
+  /** Optional caller-owned share analytics (e.g. trending page share). */
+  onShareAction?: (action: EntryDetailShareAction) => void;
 }
 
 async function copy(value: string, label: string) {
@@ -49,6 +51,7 @@ export function ShareMenu({
   ogUrl,
   raycastUrl,
   analyticsEntry,
+  onShareAction,
 }: ShareMenuProps) {
   const absolute = absoluteShareUrl(
     url,
@@ -60,13 +63,14 @@ export function ShareMenu({
 
   const trackShare = React.useCallback(
     (action: EntryDetailShareAction) => {
+      onShareAction?.(action);
       if (!analyticsEntry) return;
       trackEvent(
         entryDetailShareAnalyticsEvent(),
         entryDetailShareAnalyticsData(analyticsEntry.category, analyticsEntry.slug, action),
       );
     },
-    [analyticsEntry],
+    [analyticsEntry, onShareAction],
   );
 
   const onNativeShare = async () => {

--- a/apps/web/src/lib/changelog-page-cta-events-lib.ts
+++ b/apps/web/src/lib/changelog-page-cta-events-lib.ts
@@ -99,3 +99,22 @@ export function changelogPollCopyAnalyticsData(matchCount: number) {
     matchCount,
   };
 }
+
+export function changelogDiffDisclosureAnalyticsEvent(): string {
+  return "changelog_diff_disclosure_toggle";
+}
+
+export function changelogDiffDisclosureAnalyticsData(
+  releaseStream: ReleaseStream,
+  rowIndex: number,
+  open: boolean,
+  matchCount: number,
+) {
+  return {
+    surface: CHANGELOG_PAGE_SURFACE,
+    releaseStream,
+    rowIndex,
+    open,
+    matchCount,
+  };
+}

--- a/apps/web/src/lib/changelog-page-cta-events.ts
+++ b/apps/web/src/lib/changelog-page-cta-events.ts
@@ -3,6 +3,8 @@
  */
 export {
   CHANGELOG_PAGE_SURFACE,
+  changelogDiffDisclosureAnalyticsData,
+  changelogDiffDisclosureAnalyticsEvent,
   changelogDiffEgressAnalyticsData,
   changelogDiffEgressAnalyticsEvent,
   changelogFeedEgressAnalyticsData,

--- a/apps/web/src/lib/entry-setup-snapshot-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-setup-snapshot-cta-events-lib.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure entry setup snapshot tile analytics helpers.
+ *
+ * Maps setup-at-a-glance tile navigation to privacy-light event names without
+ * embedding titles, install commands, or prerequisite copy.
+ */
+
+export const ENTRY_SETUP_SNAPSHOT_SURFACE = "detail-setup-snapshot";
+
+export type EntrySetupSnapshotTileId =
+  | "install"
+  | "config"
+  | "copy"
+  | "prerequisites"
+  | "platforms"
+  | "difficulty"
+  | "install-type";
+
+export type EntrySetupSnapshotDestination = "entry-command-center" | "prerequisites";
+
+export function entrySetupSnapshotEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entrySetupSnapshotAnalyticsEvent(): string {
+  return "detail_setup_snapshot_click";
+}
+
+export function entrySetupSnapshotAnalyticsData(
+  category: string,
+  slug: string,
+  tileId: EntrySetupSnapshotTileId,
+  destination: EntrySetupSnapshotDestination,
+) {
+  return {
+    entry: entrySetupSnapshotEntryKey(category, slug),
+    surface: ENTRY_SETUP_SNAPSHOT_SURFACE,
+    tileId,
+    destination,
+  };
+}

--- a/apps/web/src/lib/entry-setup-snapshot-cta-events.ts
+++ b/apps/web/src/lib/entry-setup-snapshot-cta-events.ts
@@ -1,0 +1,11 @@
+/**
+ * Entry setup snapshot tile CTA event surface.
+ */
+export {
+  ENTRY_SETUP_SNAPSHOT_SURFACE,
+  entrySetupSnapshotAnalyticsData,
+  entrySetupSnapshotAnalyticsEvent,
+  entrySetupSnapshotEntryKey,
+  type EntrySetupSnapshotDestination,
+  type EntrySetupSnapshotTileId,
+} from "@/lib/entry-setup-snapshot-cta-events-lib";

--- a/apps/web/src/lib/how-it-works-cta-events-lib.ts
+++ b/apps/web/src/lib/how-it-works-cta-events-lib.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure how-it-works step navigation analytics helpers.
+ *
+ * Maps home how-it-works step cards to privacy-light event names without
+ * embedding titles, body copy, or free-form search queries.
+ */
+
+export const HOW_IT_WORKS_SURFACE = "how-it-works";
+
+export type HowItWorksStepId = "search" | "inspect" | "copy";
+export type HowItWorksDestination = "browse" | "quality" | "platforms";
+
+export function howItWorksStepAnalyticsEvent(): string {
+  return "how_it_works_step_click";
+}
+
+export function howItWorksStepAnalyticsData(
+  stepId: HowItWorksStepId,
+  destination: HowItWorksDestination,
+  stepIndex: number,
+  stepCount: number,
+) {
+  return {
+    surface: HOW_IT_WORKS_SURFACE,
+    stepId,
+    destination,
+    stepIndex,
+    stepCount,
+  };
+}

--- a/apps/web/src/lib/how-it-works-cta-events.ts
+++ b/apps/web/src/lib/how-it-works-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * How-it-works step navigation CTA event surface.
+ */
+export {
+  HOW_IT_WORKS_SURFACE,
+  howItWorksStepAnalyticsData,
+  howItWorksStepAnalyticsEvent,
+  type HowItWorksDestination,
+  type HowItWorksStepId,
+} from "@/lib/how-it-works-cta-events-lib";

--- a/apps/web/src/lib/trending-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/trending-entry-cta-events-lib.ts
@@ -102,3 +102,48 @@ export function trendingChromeAnalyticsData(
     mode,
   };
 }
+
+export type TrendingShareAction = "copy-link" | "copy-markdown" | "system-share";
+
+export function trendingShareAnalyticsEvent(): string {
+  return "trending_share_click";
+}
+
+export function trendingShareAnalyticsData(
+  window: TrendingListWindow,
+  categoryFilter: string,
+  mode: TrendingListMode,
+  action: TrendingShareAction,
+) {
+  return {
+    surface: TRENDING_PAGE_SURFACE,
+    window,
+    categoryFilter,
+    mode,
+    action,
+  };
+}
+
+export function trendingRankingReasonOpenAnalyticsEvent(): string {
+  return "trending_ranking_reason_open";
+}
+
+export function trendingRankingReasonOpenAnalyticsData(
+  category: string,
+  slug: string,
+  window: TrendingListWindow,
+  categoryFilter: string,
+  mode: TrendingListMode,
+  reasonCount: number,
+  hasLiveScore: boolean,
+) {
+  return {
+    entry: trendingListEntryKey(category, slug),
+    surface: TRENDING_LIST_SURFACE,
+    window,
+    categoryFilter,
+    mode,
+    reasonCount,
+    hasLiveScore,
+  };
+}

--- a/apps/web/src/lib/trending-entry-cta-events.ts
+++ b/apps/web/src/lib/trending-entry-cta-events.ts
@@ -13,8 +13,13 @@ export {
   trendingListEntryAnalyticsData,
   trendingListEntryAnalyticsEvent,
   trendingListEntryKey,
+  trendingRankingReasonOpenAnalyticsData,
+  trendingRankingReasonOpenAnalyticsEvent,
+  trendingShareAnalyticsData,
+  trendingShareAnalyticsEvent,
   type TrendingChromeDestination,
   type TrendingChromePlacement,
   type TrendingListMode,
   type TrendingListWindow,
+  type TrendingShareAction,
 } from "@/lib/trending-entry-cta-events-lib";

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -11,6 +11,8 @@ import {
   changelogDiffEntryAnalyticsEvent,
 } from "@/lib/directory-page-entry-cta-events";
 import {
+  changelogDiffDisclosureAnalyticsData,
+  changelogDiffDisclosureAnalyticsEvent,
   changelogDiffEgressAnalyticsData,
   changelogDiffEgressAnalyticsEvent,
   changelogFeedEgressAnalyticsData,
@@ -236,7 +238,20 @@ function ChangelogPage() {
                     </div>
                   )}
                   {note.diff && (
-                    <details className="mt-3 group">
+                    <details
+                      className="mt-3 group"
+                      onToggle={(e) =>
+                        trackEvent(
+                          changelogDiffDisclosureAnalyticsEvent(),
+                          changelogDiffDisclosureAnalyticsData(
+                            note.stream,
+                            i,
+                            e.currentTarget.open,
+                            items.length,
+                          ),
+                        )
+                      }
+                    >
                       <summary className="inline-flex cursor-pointer items-center gap-1 text-xs font-medium text-ink-muted hover:text-ink">
                         What changed in this build →
                       </summary>

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -26,6 +26,12 @@ import {
   trendingFilterResetAnalyticsEvent,
   trendingListEntryAnalyticsData,
   trendingListEntryAnalyticsEvent,
+  trendingRankingReasonOpenAnalyticsData,
+  trendingRankingReasonOpenAnalyticsEvent,
+  trendingShareAnalyticsData,
+  trendingShareAnalyticsEvent,
+  type TrendingListWindow,
+  type TrendingShareAction,
 } from "@/lib/trending-entry-cta-events";
 import { cn } from "@/lib/utils";
 
@@ -158,7 +164,17 @@ function useTrendingRows() {
   return { rows, mode, signals, loading };
 }
 
-function MovementCell({ entry, mode }: { entry: TrendingEntry; mode: TrendingMode }) {
+function MovementCell({
+  entry,
+  mode,
+  window,
+  categoryFilter,
+}: {
+  entry: TrendingEntry;
+  mode: TrendingMode;
+  window: TrendingListWindow;
+  categoryFilter: string;
+}) {
   const score = entry.trendingScore ?? 0;
   const reasons = entry.trendingReasons ?? [];
   const live = mode === "live";
@@ -168,6 +184,20 @@ function MovementCell({ entry, mode }: { entry: TrendingEntry; mode: TrendingMod
         <TooltipTrigger asChild>
           <button
             type="button"
+            onClick={() =>
+              trackEvent(
+                trendingRankingReasonOpenAnalyticsEvent(),
+                trendingRankingReasonOpenAnalyticsData(
+                  entry.category,
+                  entry.slug,
+                  window,
+                  categoryFilter,
+                  mode,
+                  reasons.length,
+                  live && score > 0,
+                ),
+              )
+            }
             className={cn(
               "inline-flex items-center gap-1 rounded-sm font-mono text-sm tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
               live ? "text-trust-trusted" : "text-ink-muted",
@@ -269,6 +299,13 @@ function TrendingPage() {
     );
   };
 
+  const trackShare = (action: TrendingShareAction) => {
+    trackEvent(
+      trendingShareAnalyticsEvent(),
+      trendingShareAnalyticsData(sp.window, sp.category, mode, action),
+    );
+  };
+
   return (
     <PageContainer className="py-12">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -304,6 +341,15 @@ function TrendingPage() {
             url={shareUrl}
             title="Trending Claude workflows"
             description="Live ranking of MCP servers, agents, skills, and commands."
+            onShareAction={(action) => {
+              if (
+                action === "copy-link" ||
+                action === "copy-markdown" ||
+                action === "system-share"
+              ) {
+                trackShare(action);
+              }
+            }}
           />
           <a
             href="/feeds/trending.xml"
@@ -436,7 +482,12 @@ function TrendingPage() {
                   {entry.source === "unverified" ? "unverified source" : "source-backed"}
                 </div>
               </div>
-              <MovementCell entry={entry} mode={mode} />
+              <MovementCell
+                entry={entry}
+                mode={mode}
+                window={sp.window}
+                categoryFilter={sp.category}
+              />
             </li>
           ))}
         </ol>

--- a/tests/changelog-page-cta-events-lib.test.ts
+++ b/tests/changelog-page-cta-events-lib.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   CHANGELOG_PAGE_SURFACE,
+  changelogDiffDisclosureAnalyticsData,
+  changelogDiffDisclosureAnalyticsEvent,
   changelogDiffEgressAnalyticsData,
   changelogDiffEgressAnalyticsEvent,
   changelogFeedEgressAnalyticsData,
@@ -73,5 +75,29 @@ describe("changelog page cta events lib", () => {
       command: "diff-since",
       matchCount: 12,
     });
+  });
+
+  it("builds changelog diff disclosure toggle analytics", () => {
+    expect(changelogDiffDisclosureAnalyticsEvent()).toBe(
+      "changelog_diff_disclosure_toggle",
+    );
+    expect(
+      changelogDiffDisclosureAnalyticsData("release", 1, true, 12),
+    ).toEqual({
+      surface: CHANGELOG_PAGE_SURFACE,
+      releaseStream: "release",
+      rowIndex: 1,
+      open: true,
+      matchCount: 12,
+    });
+    expect(changelogDiffDisclosureAnalyticsData("policy", 0, false, 8)).toEqual(
+      {
+        surface: CHANGELOG_PAGE_SURFACE,
+        releaseStream: "policy",
+        rowIndex: 0,
+        open: false,
+        matchCount: 8,
+      },
+    );
   });
 });

--- a/tests/entry-setup-snapshot-cta-events-lib.test.ts
+++ b/tests/entry-setup-snapshot-cta-events-lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_SETUP_SNAPSHOT_SURFACE,
+  entrySetupSnapshotAnalyticsData,
+  entrySetupSnapshotAnalyticsEvent,
+} from "@/lib/entry-setup-snapshot-cta-events-lib";
+
+describe("entry setup snapshot cta events lib", () => {
+  it("builds privacy-light setup snapshot tile analytics", () => {
+    expect(entrySetupSnapshotAnalyticsEvent()).toBe(
+      "detail_setup_snapshot_click",
+    );
+    expect(
+      entrySetupSnapshotAnalyticsData(
+        "mcp",
+        "browser",
+        "install",
+        "entry-command-center",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_SETUP_SNAPSHOT_SURFACE,
+      tileId: "install",
+      destination: "entry-command-center",
+    });
+    expect(
+      entrySetupSnapshotAnalyticsData(
+        "skills",
+        "demo",
+        "prerequisites",
+        "prerequisites",
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: ENTRY_SETUP_SNAPSHOT_SURFACE,
+      tileId: "prerequisites",
+      destination: "prerequisites",
+    });
+  });
+});

--- a/tests/how-it-works-cta-events-lib.test.ts
+++ b/tests/how-it-works-cta-events-lib.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  HOW_IT_WORKS_SURFACE,
+  howItWorksStepAnalyticsData,
+  howItWorksStepAnalyticsEvent,
+} from "@/lib/how-it-works-cta-events-lib";
+
+describe("how it works cta events lib", () => {
+  it("builds privacy-light how-it-works step analytics", () => {
+    expect(howItWorksStepAnalyticsEvent()).toBe("how_it_works_step_click");
+    expect(howItWorksStepAnalyticsData("search", "browse", 0, 3)).toEqual({
+      surface: HOW_IT_WORKS_SURFACE,
+      stepId: "search",
+      destination: "browse",
+      stepIndex: 0,
+      stepCount: 3,
+    });
+    expect(howItWorksStepAnalyticsData("inspect", "quality", 1, 3)).toEqual({
+      surface: HOW_IT_WORKS_SURFACE,
+      stepId: "inspect",
+      destination: "quality",
+      stepIndex: 1,
+      stepCount: 3,
+    });
+    expect(howItWorksStepAnalyticsData("copy", "platforms", 2, 3)).toEqual({
+      surface: HOW_IT_WORKS_SURFACE,
+      stepId: "copy",
+      destination: "platforms",
+      stepIndex: 2,
+      stepCount: 3,
+    });
+  });
+});

--- a/tests/trending-entry-cta-events-lib.test.ts
+++ b/tests/trending-entry-cta-events-lib.test.ts
@@ -10,6 +10,10 @@ import {
   trendingFilterResetAnalyticsEvent,
   trendingListEntryAnalyticsData,
   trendingListEntryAnalyticsEvent,
+  trendingRankingReasonOpenAnalyticsData,
+  trendingRankingReasonOpenAnalyticsEvent,
+  trendingShareAnalyticsData,
+  trendingShareAnalyticsEvent,
 } from "@/lib/trending-entry-cta-events-lib";
 
 describe("trending entry cta events lib", () => {
@@ -107,6 +111,69 @@ describe("trending entry cta events lib", () => {
       window: "all",
       categoryFilter: "mcp",
       mode: "unavailable",
+    });
+  });
+
+  it("builds privacy-light trending share and ranking reason analytics", () => {
+    expect(trendingShareAnalyticsEvent()).toBe("trending_share_click");
+    expect(
+      trendingShareAnalyticsData("7d", "mcp", "live", "copy-link"),
+    ).toEqual({
+      surface: TRENDING_PAGE_SURFACE,
+      window: "7d",
+      categoryFilter: "mcp",
+      mode: "live",
+      action: "copy-link",
+    });
+    expect(
+      trendingShareAnalyticsData("all", "", "fallback", "system-share"),
+    ).toEqual({
+      surface: TRENDING_PAGE_SURFACE,
+      window: "all",
+      categoryFilter: "",
+      mode: "fallback",
+      action: "system-share",
+    });
+    expect(trendingRankingReasonOpenAnalyticsEvent()).toBe(
+      "trending_ranking_reason_open",
+    );
+    expect(
+      trendingRankingReasonOpenAnalyticsData(
+        "mcp",
+        "browser",
+        "7d",
+        "mcp",
+        "live",
+        3,
+        true,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: TRENDING_LIST_SURFACE,
+      window: "7d",
+      categoryFilter: "mcp",
+      mode: "live",
+      reasonCount: 3,
+      hasLiveScore: true,
+    });
+    expect(
+      trendingRankingReasonOpenAnalyticsData(
+        "skills",
+        "demo",
+        "30d",
+        "",
+        "fallback",
+        0,
+        false,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: TRENDING_LIST_SURFACE,
+      window: "30d",
+      categoryFilter: "",
+      mode: "fallback",
+      reasonCount: 0,
+      hasLiveScore: false,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Track trending page ShareMenu actions and ranking-reason opens with privacy-light payloads (no reason text / URLs)
- Make home how-it-works steps navigable (browse / quality / platforms) with step click analytics
- Track changelog “What changed in this build” disclosure open/close
- Make entry setup-snapshot tiles deep-link to command center / prerequisites with tile analytics

## Test plan
- [ ] Open `/trending`, use Share (copy link / markdown / system share) and confirm events fire without console errors
- [ ] Click a ranking score/info control and confirm the tooltip still opens
- [ ] On home, click each how-it-works step and land on browse / quality / platforms
- [ ] On `/changelog`, toggle a build diff disclosure open and closed
- [ ] On an entry with setup snapshot, click tiles and jump to `#entry-command-center` / `#prerequisites`

Refs #550

Made with [Cursor](https://cursor.com)