### PR TITLE
test(registry): cover mcp install config extraction edges in mcp-install-config-lib

### DIFF
--- a/tests/registry-mcp-install-config-edges.test.ts
+++ b/tests/registry-mcp-install-config-edges.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractMcpServerConfig,
+  resolveMcpInstallConfig,
+} from "../packages/registry/src/mcp-install-config-lib.js";
+
+function mcpEntry(snippet: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    category: "mcp",
+    slug: "my-slug",
+    configSnippet: JSON.stringify(snippet),
+    ...overrides,
+  };
+}
+
+describe("mcp-install-config-lib extractMcpServerConfig", () => {
+  it("rejects json payloads that are not records", () => {
+    expect(extractMcpServerConfig("[]")).toBeNull();
+    expect(extractMcpServerConfig('"just-a-string"')).toBeNull();
+  });
+
+  it("rejects a non-record mcpServers map", () => {
+    expect(extractMcpServerConfig({ mcpServers: "nope" })).toBeNull();
+  });
+
+  it("rejects a map that does not hold exactly one server", () => {
+    expect(
+      extractMcpServerConfig({
+        mcpServers: { a: { command: "x" }, b: { command: "y" } },
+      }),
+    ).toBeNull();
+    expect(extractMcpServerConfig({ mcpServers: {} })).toBeNull();
+  });
+
+  it("extracts a single normalized stdio server", () => {
+    expect(
+      extractMcpServerConfig({
+        mcpServers: { demo: { command: "npx", args: ["-y", "demo"] } },
+      }),
+    ).toEqual({
+      name: "demo",
+      config: { command: "npx", args: ["-y", "demo"], type: "stdio" },
+    });
+  });
+});
+
+describe("mcp-install-config-lib resolveMcpInstallConfig", () => {
+  it("ignores non-mcp entries and blank snippets", () => {
+    expect(
+      resolveMcpInstallConfig({ category: "skills", configSnippet: "{}" }),
+    ).toBeNull();
+    expect(
+      resolveMcpInstallConfig({ category: "mcp", configSnippet: "   " }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unparseable snippet", () => {
+    expect(
+      resolveMcpInstallConfig({ category: "mcp", configSnippet: "{oops" }),
+    ).toBeNull();
+  });
+
+  it("uses the extracted server name when present", () => {
+    expect(
+      resolveMcpInstallConfig(
+        mcpEntry({ mcpServers: { demo: { command: "npx" } } }),
+      )?.name,
+    ).toBe("demo");
+  });
+
+  it("falls back to the entry slug when the server name is blank", () => {
+    expect(
+      resolveMcpInstallConfig(
+        mcpEntry({ mcpServers: { "": { command: "npx" } } }),
+      )?.name,
+    ).toBe("my-slug");
+  });
+});


### PR DESCRIPTION
Adds a new test file covering the rejection and fallback edges in `mcp-install-config-lib`: `extractMcpServerConfig` rejecting non-record json payloads (array/string), a non-record `mcpServers` map, and maps that do not hold exactly one server, plus the happy path normalizing a single stdio server; and `resolveMcpInstallConfig` ignoring non-mcp entries and blank snippets, returning null for an unparseable snippet, using the extracted server name, and falling back to the entry slug when the server name is blank. Lib branch coverage 95.7% -> 97.2% (137/141). Test-only change; kept in its own file.