### PR TITLE
feat(web): add report dist/stat drill-downs and validators tool analytics

### DIFF
--- a/apps/web/src/components/data-report.tsx
+++ b/apps/web/src/components/data-report.tsx
@@ -1,14 +1,33 @@
 import * as React from "react";
+import { Link } from "@tanstack/react-router";
 import { BadgeCheck } from "lucide-react";
 
 import { CountUp } from "@/components/count-up";
 import { distBarWidths } from "@/lib/data-report-bars-lib";
+import { cn } from "@/lib/utils";
+
+/** Browse filter search used by distribution drill-downs. */
+export type DistBrowseSearch = {
+  category?: string;
+  trust?: string;
+  source?: string;
+};
+
+/** In-app destination for a clickable distribution row. */
+export type DistRowDrilldown =
+  | { kind: "browse"; search: DistBrowseSearch }
+  | { kind: "tag"; tag: string }
+  | { kind: "category"; category: string };
 
 /** A single labelled distribution row: a count and its share of the relevant total. */
 export interface DistRow {
   label: string;
   count: number;
   pct: number;
+  /** Stable privacy-light key for analytics (enum/slug — not display copy). */
+  rowKey?: string;
+  /** Optional in-app drill-down destination. */
+  drilldown?: DistRowDrilldown;
 }
 
 /** Round `n/total` to a whole-number percentage (0 when total is 0). */
@@ -22,14 +41,20 @@ export function DataStat({
   label,
   value,
   hint,
+  to,
+  search,
+  onNavigate,
 }: {
   icon: React.ElementType;
   label: string;
   value: number;
   hint: string;
+  to?: "/browse" | "/quality";
+  search?: DistBrowseSearch;
+  onNavigate?: () => void;
 }) {
-  return (
-    <div className="bg-surface p-5">
+  const body = (
+    <>
       <div className="flex items-center justify-between">
         <Icon className="h-4 w-4 text-ink-muted" />
         <BadgeCheck className="h-3.5 w-3.5 text-ink-subtle" aria-hidden />
@@ -41,8 +66,23 @@ export function DataStat({
         <div className="text-xs text-ink-muted">{label}</div>
         <span className="font-mono text-[11px] text-ink-subtle">{hint}</span>
       </div>
-    </div>
+    </>
   );
+
+  if (to) {
+    return (
+      <Link
+        to={to}
+        search={to === "/browse" ? search : undefined}
+        onClick={onNavigate}
+        className="block bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className="bg-surface p-5">{body}</div>;
 }
 
 /** A titled section with help text and arbitrary content (usually a DistTable). */
@@ -64,15 +104,91 @@ export function DataSection({
   );
 }
 
+function DistRowShell({
+  row,
+  className,
+  onActivate,
+  children,
+}: {
+  row: DistRow;
+  className: string;
+  onActivate?: () => void;
+  children: React.ReactNode;
+}) {
+  if (!row.drilldown) {
+    return <div className={className}>{children}</div>;
+  }
+
+  if (row.drilldown.kind === "browse") {
+    return (
+      <Link
+        to="/browse"
+        search={row.drilldown.search}
+        onClick={onActivate}
+        className={cn(
+          className,
+          "hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60",
+        )}
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  if (row.drilldown.kind === "tag") {
+    return (
+      <Link
+        to="/tags/$tag"
+        params={{ tag: row.drilldown.tag }}
+        onClick={onActivate}
+        className={cn(
+          className,
+          "hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60",
+        )}
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      to="/$category"
+      params={{ category: row.drilldown.category }}
+      onClick={onActivate}
+      className={cn(
+        className,
+        "hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60",
+      )}
+    >
+      {children}
+    </Link>
+  );
+}
+
 /** Horizontal-bar distribution table; bars are scaled to the largest row. */
-export function DistTable({ rows }: { rows: DistRow[] }) {
+export function DistTable({
+  rows,
+  onRowClick,
+}: {
+  rows: DistRow[];
+  onRowClick?: (row: DistRow, index: number) => void;
+}) {
   const widths = distBarWidths(rows);
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-surface">
       {rows.map((row, i) => (
-        <div
-          key={row.label}
+        <DistRowShell
+          key={row.rowKey ?? row.label}
+          row={row}
           className="grid grid-cols-[160px_1fr_56px_56px] items-center gap-4 border-b border-border px-5 py-3 last:border-0"
+          onActivate={
+            onRowClick
+              ? () => {
+                  onRowClick(row, i);
+                }
+              : undefined
+          }
         >
           <div className="font-display text-sm font-semibold text-ink">{row.label}</div>
           <div className="h-2 overflow-hidden rounded-full bg-surface-2">
@@ -82,7 +198,7 @@ export function DistTable({ rows }: { rows: DistRow[] }) {
           <div className="text-right font-mono text-xs tabular-nums text-ink-subtle">
             {row.pct}%
           </div>
-        </div>
+        </DistRowShell>
       ))}
     </div>
   );

--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure data-report distribution drill-down helpers.
+ *
+ * Attaches privacy-light browse/tag destinations to distribution rows using
+ * stable enum/slug keys — never free-form titles beyond registry tag slugs.
+ */
+
+import type { DistRow, DistRowDrilldown } from "@/components/data-report";
+import { SOURCE_LABEL, TRUST_LABEL, type SourceStatus, type TrustLevel } from "@/types/registry";
+
+const TRUST_BY_LABEL = Object.fromEntries(
+  (Object.entries(TRUST_LABEL) as Array<[TrustLevel, string]>).map(([key, label]) => [label, key]),
+) as Record<string, TrustLevel>;
+
+const SOURCE_BY_LABEL = Object.fromEntries(
+  (Object.entries(SOURCE_LABEL) as Array<[SourceStatus, string]>).map(([key, label]) => [
+    label,
+    key,
+  ]),
+) as Record<string, SourceStatus>;
+
+export function trustLevelFromLabel(label: string): TrustLevel | undefined {
+  return TRUST_BY_LABEL[label];
+}
+
+export function sourceStatusFromLabel(label: string): SourceStatus | undefined {
+  return SOURCE_BY_LABEL[label];
+}
+
+export function browseDrilldown(search: {
+  category?: string;
+  trust?: string;
+  source?: string;
+}): DistRowDrilldown {
+  return { kind: "browse", search };
+}
+
+export function tagDrilldown(tag: string): DistRowDrilldown {
+  return { kind: "tag", tag };
+}
+
+export function withTrustDrilldown(rows: DistRow[], category?: string): DistRow[] {
+  return rows.map((row) => {
+    const trust = trustLevelFromLabel(row.label);
+    if (!trust) return row;
+    return {
+      ...row,
+      rowKey: trust,
+      drilldown: browseDrilldown({
+        ...(category ? { category } : {}),
+        trust,
+      }),
+    };
+  });
+}
+
+export function withSourceDrilldown(rows: DistRow[], category?: string): DistRow[] {
+  return rows.map((row) => {
+    const source = sourceStatusFromLabel(row.label);
+    if (!source) return row;
+    return {
+      ...row,
+      rowKey: source,
+      drilldown: browseDrilldown({
+        ...(category ? { category } : {}),
+        source,
+      }),
+    };
+  });
+}
+
+export function withTagDrilldown(rows: DistRow[]): DistRow[] {
+  return rows.map((row) => ({
+    ...row,
+    rowKey: row.rowKey ?? row.label,
+    drilldown: tagDrilldown(row.label),
+  }));
+}
+
+export function withCategoryBrowseDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => ({
+    ...row,
+    rowKey: row.rowKey ?? row.label,
+    drilldown: browseDrilldown({ category }),
+  }));
+}
+
+/**
+ * Attach drill-downs for known report dimension keys. Unknown dimensions are
+ * returned unchanged (still display-only).
+ */
+export function withReportDimensionDrilldown(
+  dimensionKey: string,
+  rows: DistRow[],
+  category: string,
+): DistRow[] {
+  switch (dimensionKey) {
+    case "trust-level":
+      return withTrustDrilldown(rows, category);
+    case "source-provenance":
+      return withSourceDrilldown(rows, category);
+    case "use-cases":
+      return withTagDrilldown(rows);
+    case "prerequisites":
+    case "disclosure":
+    case "packaging":
+    case "skill-type":
+    case "maturity":
+    case "verification":
+    case "hook-events":
+      return withCategoryBrowseDrilldown(rows, category);
+    default:
+      return rows;
+  }
+}

--- a/apps/web/src/lib/data-reports-lib.ts
+++ b/apps/web/src/lib/data-reports-lib.ts
@@ -16,6 +16,8 @@ export interface DistRow {
   label: string;
   count: number;
   pct: number;
+  /** Optional stable key when a report attaches drill-down metadata. */
+  rowKey?: string;
 }
 
 /** Round `n/total` to a whole-number percentage (0 when total is 0). */

--- a/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
@@ -44,3 +44,37 @@ export function mcpSecurityReportCiteAnalyticsData() {
     destination: "canonical",
   };
 }
+
+export function mcpSecurityReportDistRowAnalyticsEvent(): string {
+  return "mcp_security_dist_row_click";
+}
+
+export function mcpSecurityReportDistRowAnalyticsData(
+  dimension: string,
+  rowKey: string,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    surface: MCP_SECURITY_REPORT_SURFACE,
+    dimension,
+    rowKey,
+    rowIndex,
+    rowCount,
+  };
+}
+
+export function mcpSecurityReportStatAnalyticsEvent(): string {
+  return "mcp_security_stat_click";
+}
+
+export function mcpSecurityReportStatAnalyticsData(
+  statKey: string,
+  destination: "browse" | "quality",
+) {
+  return {
+    surface: MCP_SECURITY_REPORT_SURFACE,
+    statKey,
+    destination,
+  };
+}

--- a/apps/web/src/lib/mcp-security-report-page-cta-events.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events.ts
@@ -7,7 +7,11 @@ export {
   mcpSecurityReportCategoryBrowseAnalyticsEvent,
   mcpSecurityReportCiteAnalyticsData,
   mcpSecurityReportCiteAnalyticsEvent,
+  mcpSecurityReportDistRowAnalyticsData,
+  mcpSecurityReportDistRowAnalyticsEvent,
   mcpSecurityReportEgressAnalyticsData,
   mcpSecurityReportEgressAnalyticsEvent,
+  mcpSecurityReportStatAnalyticsData,
+  mcpSecurityReportStatAnalyticsEvent,
   type McpSecurityReportEgressDestination,
 } from "@/lib/mcp-security-report-page-cta-events-lib";

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -66,3 +66,39 @@ export function stateReportCiteAnalyticsData(reportId: StateReportId) {
     destination: "canonical",
   };
 }
+
+export function stateReportDistRowAnalyticsEvent(): string {
+  return "state_report_dist_row_click";
+}
+
+export function stateReportDistRowAnalyticsData(
+  reportId: StateReportId,
+  dimension: string,
+  rowKey: string,
+  rowIndex: number,
+  rowCount: number,
+) {
+  return {
+    reportId,
+    dimension,
+    rowKey,
+    rowIndex,
+    rowCount,
+  };
+}
+
+export function stateReportStatAnalyticsEvent(): string {
+  return "state_report_stat_click";
+}
+
+export function stateReportStatAnalyticsData(
+  reportId: StateReportId,
+  statKey: string,
+  destination: "browse" | "quality",
+) {
+  return {
+    reportId,
+    statKey,
+    destination,
+  };
+}

--- a/apps/web/src/lib/state-report-page-cta-events.ts
+++ b/apps/web/src/lib/state-report-page-cta-events.ts
@@ -6,8 +6,12 @@ export {
   stateReportCategoryBrowseAnalyticsEvent,
   stateReportCiteAnalyticsData,
   stateReportCiteAnalyticsEvent,
+  stateReportDistRowAnalyticsData,
+  stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportStatAnalyticsData,
+  stateReportStatAnalyticsEvent,
   type StateReportEgressDestination,
   type StateReportId,
 } from "@/lib/state-report-page-cta-events-lib";

--- a/apps/web/src/lib/validators-tools-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-tools-cta-events-lib.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure validators local-tools CTA analytics helpers.
+ *
+ * Maps maintainer tool-card and summary-stat navigation to privacy-light event
+ * names without embedding titles or blurbs.
+ */
+
+export const VALIDATORS_TOOLS_SURFACE = "validators-tools";
+
+export type ValidatorsToolId = "skill-package" | "mcp-config";
+export type ValidatorsSummaryStatId =
+  | "entries"
+  | "source-backed"
+  | "safety-coverage"
+  | "needs-attention";
+
+export function validatorsToolCardAnalyticsEvent(): string {
+  return "validators_tool_card_click";
+}
+
+export function validatorsToolCardAnalyticsData(toolId: ValidatorsToolId, toolCount: number) {
+  return {
+    surface: VALIDATORS_TOOLS_SURFACE,
+    toolId,
+    toolCount,
+  };
+}
+
+export function validatorsSummaryStatAnalyticsEvent(): string {
+  return "validators_summary_stat_click";
+}
+
+export function validatorsSummaryStatAnalyticsData(
+  statId: ValidatorsSummaryStatId,
+  destination: "browse" | "quality" | "validators-skill-package" | "validators-mcp-config",
+) {
+  return {
+    surface: VALIDATORS_TOOLS_SURFACE,
+    statId,
+    destination,
+  };
+}

--- a/apps/web/src/lib/validators-tools-cta-events.ts
+++ b/apps/web/src/lib/validators-tools-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Validators local-tools CTA event surface.
+ */
+export {
+  VALIDATORS_TOOLS_SURFACE,
+  validatorsSummaryStatAnalyticsData,
+  validatorsSummaryStatAnalyticsEvent,
+  validatorsToolCardAnalyticsData,
+  validatorsToolCardAnalyticsEvent,
+  type ValidatorsSummaryStatId,
+  type ValidatorsToolId,
+} from "@/lib/validators-tools-cta-events-lib";

--- a/apps/web/src/routes/mcp-security-report.tsx
+++ b/apps/web/src/routes/mcp-security-report.tsx
@@ -11,14 +11,19 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
+import { withCategoryBrowseDrilldown } from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   mcpSecurityReportCategoryBrowseAnalyticsData,
   mcpSecurityReportCategoryBrowseAnalyticsEvent,
   mcpSecurityReportCiteAnalyticsData,
   mcpSecurityReportCiteAnalyticsEvent,
+  mcpSecurityReportDistRowAnalyticsData,
+  mcpSecurityReportDistRowAnalyticsEvent,
   mcpSecurityReportEgressAnalyticsData,
   mcpSecurityReportEgressAnalyticsEvent,
+  mcpSecurityReportStatAnalyticsData,
+  mcpSecurityReportStatAnalyticsEvent,
   type McpSecurityReportEgressDestination,
 } from "@/lib/mcp-security-report-page-cta-events";
 
@@ -26,6 +31,21 @@ function trackMcpSecurityReportEgress(destination: McpSecurityReportEgressDestin
   trackEvent(
     mcpSecurityReportEgressAnalyticsEvent(),
     mcpSecurityReportEgressAnalyticsData(destination),
+  );
+}
+
+function trackDistRow(dimension: string, row: DistRow, rowIndex: number, rowCount: number) {
+  if (!row.rowKey) return;
+  trackEvent(
+    mcpSecurityReportDistRowAnalyticsEvent(),
+    mcpSecurityReportDistRowAnalyticsData(dimension, row.rowKey, rowIndex, rowCount),
+  );
+}
+
+function trackStat(statKey: string, destination: "browse" | "quality" = "browse") {
+  trackEvent(
+    mcpSecurityReportStatAnalyticsEvent(),
+    mcpSecurityReportStatAnalyticsData(statKey, destination),
   );
 }
 
@@ -41,53 +61,103 @@ const MCP = ENTRIES.filter((e) => e.category === "mcp");
 const TOTAL = MCP.length;
 
 const NOTES = notesCoverage(MCP);
-const NOTES_DIST: DistRow[] = [
-  { label: "Safety notes", count: NOTES.safety, pct: pctOf(NOTES.safety, TOTAL) },
-  { label: "Privacy notes", count: NOTES.privacy, pct: pctOf(NOTES.privacy, TOTAL) },
-  { label: "Both", count: NOTES.both, pct: pctOf(NOTES.both, TOTAL) },
-];
+const NOTES_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  [
+    {
+      label: "Safety notes",
+      count: NOTES.safety,
+      pct: pctOf(NOTES.safety, TOTAL),
+      rowKey: "safety-notes",
+    },
+    {
+      label: "Privacy notes",
+      count: NOTES.privacy,
+      pct: pctOf(NOTES.privacy, TOTAL),
+      rowKey: "privacy-notes",
+    },
+    { label: "Both", count: NOTES.both, pct: pctOf(NOTES.both, TOTAL), rowKey: "both" },
+  ],
+  "mcp",
+);
 
 const AUTH = authDistribution(MCP);
-const AUTH_DIST: DistRow[] = AUTH.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, AUTH.total),
-}));
+const AUTH_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  AUTH.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, AUTH.total),
+    rowKey: r.label.toLowerCase().replace(/\s+/g, "-"),
+  })),
+  "mcp",
+);
 
 const HOSTING = hostingDistribution(MCP);
-const HOSTING_DIST: DistRow[] = HOSTING.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, HOSTING.total),
-}));
+const HOSTING_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  HOSTING.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, HOSTING.total),
+    rowKey:
+      r.label === "Local (stdio)"
+        ? "local"
+        : r.label === "Remote (hosted)"
+          ? "remote"
+          : "unspecified",
+  })),
+  "mcp",
+);
 
 const SUPPLY = supplyChainCoverage(MCP);
-const SUPPLY_DIST: DistRow[] = [
-  {
-    label: "Verified package",
-    count: SUPPLY.packageVerified,
-    pct: pctOf(SUPPLY.packageVerified, TOTAL),
-  },
-  {
-    label: "Checksummed download",
-    count: SUPPLY.checksummedDownload,
-    pct: pctOf(SUPPLY.checksummedDownload, TOTAL),
-  },
-];
+const SUPPLY_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  [
+    {
+      label: "Verified package",
+      count: SUPPLY.packageVerified,
+      pct: pctOf(SUPPLY.packageVerified, TOTAL),
+      rowKey: "verified-package",
+    },
+    {
+      label: "Checksummed download",
+      count: SUPPLY.checksummedDownload,
+      pct: pctOf(SUPPLY.checksummedDownload, TOTAL),
+      rowKey: "checksummed-download",
+    },
+  ],
+  "mcp",
+);
 
 // Documentation & disclosure coverage — how well servers are documented for safe rollout.
 const WITH_PREREQS = MCP.filter((e) => (e.prerequisites?.length ?? 0) > 0).length;
 const WITH_TROUBLESHOOTING = MCP.filter((e) => e.hasTroubleshooting).length;
-const DOCS_DIST: DistRow[] = [
-  { label: "Prerequisites listed", count: WITH_PREREQS, pct: pctOf(WITH_PREREQS, TOTAL) },
-  { label: "Safety notes", count: NOTES.safety, pct: pctOf(NOTES.safety, TOTAL) },
-  { label: "Privacy notes", count: NOTES.privacy, pct: pctOf(NOTES.privacy, TOTAL) },
-  {
-    label: "Troubleshooting",
-    count: WITH_TROUBLESHOOTING,
-    pct: pctOf(WITH_TROUBLESHOOTING, TOTAL),
-  },
-];
+const DOCS_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  [
+    {
+      label: "Prerequisites listed",
+      count: WITH_PREREQS,
+      pct: pctOf(WITH_PREREQS, TOTAL),
+      rowKey: "prerequisites",
+    },
+    {
+      label: "Safety notes",
+      count: NOTES.safety,
+      pct: pctOf(NOTES.safety, TOTAL),
+      rowKey: "safety-notes",
+    },
+    {
+      label: "Privacy notes",
+      count: NOTES.privacy,
+      pct: pctOf(NOTES.privacy, TOTAL),
+      rowKey: "privacy-notes",
+    },
+    {
+      label: "Troubleshooting",
+      count: WITH_TROUBLESHOOTING,
+      pct: pctOf(WITH_TROUBLESHOOTING, TOTAL),
+      rowKey: "troubleshooting",
+    },
+  ],
+  "mcp",
+);
 
 const OG_IMAGE = ogImageUrl({
   eyebrow: "Data report",
@@ -178,24 +248,41 @@ function McpSecurityReportPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        <DataStat icon={Boxes} label="MCP servers" value={TOTAL} hint="analyzed" />
+        <DataStat
+          icon={Boxes}
+          label="MCP servers"
+          value={TOTAL}
+          hint="analyzed"
+          to="/browse"
+          search={{ category: "mcp" }}
+          onNavigate={() => trackStat("total")}
+        />
         <DataStat
           icon={ShieldCheck}
           label="Safety notes"
           value={NOTES.safety}
           hint={`${pctOf(NOTES.safety, TOTAL)}% of total`}
+          to="/browse"
+          search={{ category: "mcp" }}
+          onNavigate={() => trackStat("safety-notes")}
         />
         <DataStat
           icon={Eye}
           label="Privacy notes"
           value={NOTES.privacy}
           hint={`${pctOf(NOTES.privacy, TOTAL)}% of total`}
+          to="/browse"
+          search={{ category: "mcp" }}
+          onNavigate={() => trackStat("privacy-notes")}
         />
         <DataStat
           icon={PackageCheck}
           label="Verified package"
           value={SUPPLY.packageVerified}
           hint={`${pctOf(SUPPLY.packageVerified, TOTAL)}% of total`}
+          to="/browse"
+          search={{ category: "mcp" }}
+          onNavigate={() => trackStat("verified-package")}
         />
       </div>
 
@@ -203,28 +290,44 @@ function McpSecurityReportPage() {
         title="Authentication methods"
         help="The strongest credential each server declares it needs, inferred from its prerequisites and notes. Servers may support more than one; the strongest identity (OAuth › API key › token) is counted."
       >
-        <DistTable rows={AUTH_DIST} />
+        <DistTable
+          rows={AUTH_DIST}
+          onRowClick={(row, rowIndex) => trackDistRow("auth", row, rowIndex, AUTH_DIST.length)}
+        />
       </DataSection>
 
       <DataSection
         title="Network exposure"
         help="Local (stdio) servers run as a process on your machine; hosted (HTTP/SSE) servers send your requests to a remote endpoint. Remote servers widen the trust boundary — review what they receive."
       >
-        <DistTable rows={HOSTING_DIST} />
+        <DistTable
+          rows={HOSTING_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("hosting", row, rowIndex, HOSTING_DIST.length)
+          }
+        />
       </DataSection>
 
       <DataSection
         title="Supply-chain verification"
         help="Servers whose package was verified by a maintainer, and those shipping a checksummed downloadable artifact. Both are signals that what you install matches what was reviewed."
       >
-        <DistTable rows={SUPPLY_DIST} />
+        <DistTable
+          rows={SUPPLY_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("supply-chain", row, rowIndex, SUPPLY_DIST.length)
+          }
+        />
       </DataSection>
 
       <DataSection
         title="Documentation coverage"
         help="Share of MCP servers carrying the metadata you need for a safe rollout — declared prerequisites, reviewer-checked safety and privacy notes, and troubleshooting guidance."
       >
-        <DistTable rows={DOCS_DIST} />
+        <DistTable
+          rows={DOCS_DIST}
+          onRowClick={(row, rowIndex) => trackDistRow("docs", row, rowIndex, DOCS_DIST.length)}
+        />
       </DataSection>
 
       <div className="mt-12 grid gap-6 lg:grid-cols-2">
@@ -235,7 +338,12 @@ function McpSecurityReportPage() {
             sets HeyClaude apart. Counts are of all {TOTAL} servers; entries can carry both.
           </p>
           <div className="mt-4">
-            <DistTable rows={NOTES_DIST} />
+            <DistTable
+              rows={NOTES_DIST}
+              onRowClick={(row, rowIndex) =>
+                trackDistRow("notes", row, rowIndex, NOTES_DIST.length)
+              }
+            />
           </div>
         </div>
         <div className="rounded-xl border border-border bg-surface p-6">

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -14,18 +14,24 @@ import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable } from "@/components/data-report";
+import { withReportDimensionDrilldown } from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
   stateReportCiteAnalyticsData,
   stateReportCiteAnalyticsEvent,
+  stateReportDistRowAnalyticsData,
+  stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportStatAnalyticsData,
+  stateReportStatAnalyticsEvent,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
 const REPORT_ID = "agent-skills" as const;
+const REPORT_CATEGORY = "skills";
 
 function trackStateReportEgress(destination: StateReportEgressDestination) {
   trackEvent(
@@ -36,6 +42,13 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
 
 function trackStateReportCite() {
   trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
+}
+
+function trackStat(statKey: string) {
+  trackEvent(
+    stateReportStatAnalyticsEvent(),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+  );
 }
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -120,15 +133,36 @@ function StateOfAgentSkillsPage() {
             label={stat.label}
             value={stat.value}
             hint={statHint(stat)}
+            to="/browse"
+            search={{ category: REPORT_CATEGORY }}
+            onNavigate={() => trackStat(stat.key)}
           />
         ))}
       </div>
 
-      {MODEL.dimensions.map((dimension) => (
-        <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
-          <DistTable rows={dimension.rows} />
-        </DataSection>
-      ))}
+      {MODEL.dimensions.map((dimension) => {
+        const rows = withReportDimensionDrilldown(dimension.key, dimension.rows, REPORT_CATEGORY);
+        return (
+          <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
+            <DistTable
+              rows={rows}
+              onRowClick={(row, rowIndex) => {
+                if (!row.rowKey) return;
+                trackEvent(
+                  stateReportDistRowAnalyticsEvent(),
+                  stateReportDistRowAnalyticsData(
+                    REPORT_ID,
+                    dimension.key,
+                    row.rowKey,
+                    rowIndex,
+                    rows.length,
+                  ),
+                );
+              }}
+            />
+          </DataSection>
+        );
+      })}
 
       <ReportDownloads exportSlug={MODEL.exportSlug} />
 

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -14,18 +14,24 @@ import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable } from "@/components/data-report";
+import { withReportDimensionDrilldown } from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
   stateReportCiteAnalyticsData,
   stateReportCiteAnalyticsEvent,
+  stateReportDistRowAnalyticsData,
+  stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportStatAnalyticsData,
+  stateReportStatAnalyticsEvent,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
 const REPORT_ID = "ai-agents" as const;
+const REPORT_CATEGORY = "agents";
 
 function trackStateReportEgress(destination: StateReportEgressDestination) {
   trackEvent(
@@ -36,6 +42,13 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
 
 function trackStateReportCite() {
   trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
+}
+
+function trackStat(statKey: string) {
+  trackEvent(
+    stateReportStatAnalyticsEvent(),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+  );
 }
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -120,15 +133,40 @@ function StateOfAiAgentsPage() {
             label={stat.label}
             value={stat.value}
             hint={statHint(stat)}
+            to="/browse"
+            search={
+              stat.key === "source-backed"
+                ? { category: REPORT_CATEGORY, source: "source-backed" }
+                : { category: REPORT_CATEGORY }
+            }
+            onNavigate={() => trackStat(stat.key)}
           />
         ))}
       </div>
 
-      {MODEL.dimensions.map((dimension) => (
-        <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
-          <DistTable rows={dimension.rows} />
-        </DataSection>
-      ))}
+      {MODEL.dimensions.map((dimension) => {
+        const rows = withReportDimensionDrilldown(dimension.key, dimension.rows, REPORT_CATEGORY);
+        return (
+          <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
+            <DistTable
+              rows={rows}
+              onRowClick={(row, rowIndex) => {
+                if (!row.rowKey) return;
+                trackEvent(
+                  stateReportDistRowAnalyticsEvent(),
+                  stateReportDistRowAnalyticsData(
+                    REPORT_ID,
+                    dimension.key,
+                    row.rowKey,
+                    rowIndex,
+                    rows.length,
+                  ),
+                );
+              }}
+            />
+          </DataSection>
+        );
+      })}
 
       <ReportDownloads exportSlug={MODEL.exportSlug} />
 

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -14,18 +14,24 @@ import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable } from "@/components/data-report";
+import { withReportDimensionDrilldown } from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   stateReportCategoryBrowseAnalyticsData,
   stateReportCategoryBrowseAnalyticsEvent,
   stateReportCiteAnalyticsData,
   stateReportCiteAnalyticsEvent,
+  stateReportDistRowAnalyticsData,
+  stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportStatAnalyticsData,
+  stateReportStatAnalyticsEvent,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
 const REPORT_ID = "claude-code-hooks" as const;
+const REPORT_CATEGORY = "hooks";
 
 function trackStateReportEgress(destination: StateReportEgressDestination) {
   trackEvent(
@@ -36,6 +42,13 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
 
 function trackStateReportCite() {
   trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
+}
+
+function trackStat(statKey: string) {
+  trackEvent(
+    stateReportStatAnalyticsEvent(),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+  );
 }
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -120,15 +133,36 @@ function StateOfClaudeCodeHooksPage() {
             label={stat.label}
             value={stat.value}
             hint={statHint(stat)}
+            to="/browse"
+            search={{ category: REPORT_CATEGORY }}
+            onNavigate={() => trackStat(stat.key)}
           />
         ))}
       </div>
 
-      {MODEL.dimensions.map((dimension) => (
-        <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
-          <DistTable rows={dimension.rows} />
-        </DataSection>
-      ))}
+      {MODEL.dimensions.map((dimension) => {
+        const rows = withReportDimensionDrilldown(dimension.key, dimension.rows, REPORT_CATEGORY);
+        return (
+          <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
+            <DistTable
+              rows={rows}
+              onRowClick={(row, rowIndex) => {
+                if (!row.rowKey) return;
+                trackEvent(
+                  stateReportDistRowAnalyticsEvent(),
+                  stateReportDistRowAnalyticsData(
+                    REPORT_ID,
+                    dimension.key,
+                    row.rowKey,
+                    rowIndex,
+                    rows.length,
+                  ),
+                );
+              }}
+            />
+          </DataSection>
+        );
+      })}
 
       <ReportDownloads exportSlug={MODEL.exportSlug} />
 

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -18,6 +18,11 @@ import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
+import {
+  withSourceDrilldown,
+  withTagDrilldown,
+  withTrustDrilldown,
+} from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   stateReportEntryAnalyticsData,
@@ -28,8 +33,12 @@ import {
   stateReportCategoryBrowseAnalyticsEvent,
   stateReportCiteAnalyticsData,
   stateReportCiteAnalyticsEvent,
+  stateReportDistRowAnalyticsData,
+  stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportStatAnalyticsData,
+  stateReportStatAnalyticsEvent,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
@@ -44,6 +53,21 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
 
 function trackStateReportCite() {
   trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
+}
+
+function trackDistRow(dimension: string, row: DistRow, rowIndex: number, rowCount: number) {
+  if (!row.rowKey) return;
+  trackEvent(
+    stateReportDistRowAnalyticsEvent(),
+    stateReportDistRowAnalyticsData(REPORT_ID, dimension, row.rowKey, rowIndex, rowCount),
+  );
+}
+
+function trackStat(statKey: string, destination: "browse" | "quality" = "browse") {
+  trackEvent(
+    stateReportStatAnalyticsEvent(),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, destination),
+  );
 }
 
 const PATH = "/state-of-mcp-servers";
@@ -75,19 +99,25 @@ const REMOTE = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Remote (ho
 const LOCAL = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Local (stdio)").length;
 
 const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
-const TRUST_DIST: DistRow[] = TRUST_ORDER.map((level) => {
-  const count = MCP.filter((e) => e.trust === level).length;
-  return { label: TRUST_LABEL[level], count, pct: pctOf(count, TOTAL) };
-}).filter((r) => r.count > 0);
+const TRUST_DIST: DistRow[] = withTrustDrilldown(
+  TRUST_ORDER.map((level) => {
+    const count = MCP.filter((e) => e.trust === level).length;
+    return { label: TRUST_LABEL[level], count, pct: pctOf(count, TOTAL) };
+  }).filter((r) => r.count > 0),
+  "mcp",
+);
 
 const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
 const SOURCE_BACKED = MCP.filter(
   (e) => e.source === "source-backed" || e.source === "first-party",
 ).length;
-const SOURCE_DIST: DistRow[] = SOURCE_ORDER.map((status) => {
-  const count = MCP.filter((e) => e.source === status).length;
-  return { label: SOURCE_LABEL[status], count, pct: pctOf(count, TOTAL) };
-}).filter((r) => r.count > 0);
+const SOURCE_DIST: DistRow[] = withSourceDrilldown(
+  SOURCE_ORDER.map((status) => {
+    const count = MCP.filter((e) => e.source === status).length;
+    return { label: SOURCE_LABEL[status], count, pct: pctOf(count, TOTAL) };
+  }).filter((r) => r.count > 0),
+  "mcp",
+);
 
 const INSTALL = installMethodDistribution(MCP);
 const INSTALL_DIST: DistRow[] = INSTALL.rows.map((r) => ({
@@ -106,10 +136,12 @@ for (const e of MCP) {
     TAG_COUNTS.set(t, (TAG_COUNTS.get(t) ?? 0) + 1);
   }
 }
-const TAG_DIST: DistRow[] = [...TAG_COUNTS.entries()]
-  .map(([label, count]) => ({ label, count, pct: pctOf(count, TOTAL) }))
-  .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
-  .slice(0, 12);
+const TAG_DIST: DistRow[] = withTagDrilldown(
+  [...TAG_COUNTS.entries()]
+    .map(([label, count]) => ({ label, count, pct: pctOf(count, TOTAL) }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+    .slice(0, 12),
+);
 
 const RECENT = [...MCP]
   .sort((a, b) => String(b.dateAdded).localeCompare(String(a.dateAdded)))
@@ -205,24 +237,41 @@ function StateOfMcpServersPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        <DataStat icon={Boxes} label="MCP servers" value={TOTAL} hint="in the registry" />
+        <DataStat
+          icon={Boxes}
+          label="MCP servers"
+          value={TOTAL}
+          hint="in the registry"
+          to="/browse"
+          search={{ category: "mcp" }}
+          onNavigate={() => trackStat("total")}
+        />
         <DataStat
           icon={Cloud}
           label="Hosted (remote)"
           value={REMOTE}
           hint={`${pctOf(REMOTE, TOTAL)}% of total`}
+          to="/browse"
+          search={{ category: "mcp" }}
+          onNavigate={() => trackStat("remote")}
         />
         <DataStat
           icon={HardDrive}
           label="Local (stdio)"
           value={LOCAL}
           hint={`${pctOf(LOCAL, TOTAL)}% of total`}
+          to="/browse"
+          search={{ category: "mcp" }}
+          onNavigate={() => trackStat("local")}
         />
         <DataStat
           icon={GitBranch}
           label="Source-backed"
           value={SOURCE_BACKED}
           hint={`${pctOf(SOURCE_BACKED, TOTAL)}% of total`}
+          to="/browse"
+          search={{ category: "mcp", source: "source-backed" }}
+          onNavigate={() => trackStat("source-backed")}
         />
       </div>
 
@@ -254,7 +303,12 @@ function StateOfMcpServersPage() {
             </Link>
           </p>
           <div className="mt-4">
-            <DistTable rows={TRUST_DIST} />
+            <DistTable
+              rows={TRUST_DIST}
+              onRowClick={(row, rowIndex) =>
+                trackDistRow("trust-level", row, rowIndex, TRUST_DIST.length)
+              }
+            />
           </div>
         </div>
         <div>
@@ -264,7 +318,12 @@ function StateOfMcpServersPage() {
             registry.
           </p>
           <div className="mt-4">
-            <DistTable rows={SOURCE_DIST} />
+            <DistTable
+              rows={SOURCE_DIST}
+              onRowClick={(row, rowIndex) =>
+                trackDistRow("source-provenance", row, rowIndex, SOURCE_DIST.length)
+              }
+            />
           </div>
         </div>
       </div>
@@ -280,7 +339,12 @@ function StateOfMcpServersPage() {
         title="Most common integrations"
         help="The services and capabilities these servers connect Claude to most often, by tag. Generic tags (mcp, claude) are excluded."
       >
-        <DistTable rows={TAG_DIST} />
+        <DistTable
+          rows={TAG_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("integrations", row, rowIndex, TAG_DIST.length)
+          }
+        />
       </DataSection>
 
       <ReportDownloads exportSlug="mcp-servers" />

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -26,7 +26,17 @@ import {
   validatorsExpertiseFilterAnalyticsData,
   validatorsExpertiseFilterAnalyticsEvent,
 } from "@/lib/validators-expertise-cta-events";
+import {
+  validatorsSummaryStatAnalyticsData,
+  validatorsSummaryStatAnalyticsEvent,
+  validatorsToolCardAnalyticsData,
+  validatorsToolCardAnalyticsEvent,
+  type ValidatorsSummaryStatId,
+  type ValidatorsToolId,
+} from "@/lib/validators-tools-cta-events";
 import atlasRegistry from "@/generated/atlas-registry.json";
+
+const VALIDATOR_TOOL_COUNT = 2;
 
 export const Route = createFileRoute("/validators")({
   head: () => ({
@@ -108,18 +118,37 @@ function ValidatorsPage() {
       />
 
       <div className="mt-8 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
-        <SummaryStat label="Entries" value={REVIEW_SUMMARY.total} />
+        <SummaryStat
+          label="Entries"
+          value={REVIEW_SUMMARY.total}
+          to="/browse"
+          statId="entries"
+          destination="browse"
+        />
         <SummaryStat
           label="Reviewed"
           value={`${REVIEW_SUMMARY.pct(REVIEW_SUMMARY.reviewed, REVIEW_SUMMARY.total)}%`}
           help={`${REVIEW_SUMMARY.reviewed} entries`}
+          to="/quality"
+          statId="safety-coverage"
+          destination="quality"
         />
         <SummaryStat
           label="Source-backed"
           value={`${REVIEW_SUMMARY.pct(REVIEW_SUMMARY.sourceBacked, REVIEW_SUMMARY.total)}%`}
           help={`${REVIEW_SUMMARY.sourceBacked} entries`}
+          to="/browse"
+          search={{ source: "source-backed" }}
+          statId="source-backed"
+          destination="browse"
         />
-        <SummaryStat label="Needs attention" value={REVIEW_SUMMARY.needsAttention} />
+        <SummaryStat
+          label="Needs attention"
+          value={REVIEW_SUMMARY.needsAttention}
+          to="/quality"
+          statId="needs-attention"
+          destination="quality"
+        />
       </div>
 
       <div className="mt-8 flex flex-wrap items-center gap-2">
@@ -291,11 +320,15 @@ function ValidatorsPage() {
             icon={FileJson}
             title="SKILL.md package"
             blurb="Frontmatter, package references, checksum facts, submission metadata."
+            toolId="skill-package"
+            to="/validators/skill-package"
           />
           <ToolCard
             icon={Terminal}
             title="MCP config JSON"
             blurb="Server shape, package targets, placeholders, risky shell syntax, secret-like values."
+            toolId="mcp-config"
+            to="/validators/mcp-config"
           />
         </div>
       </section>
@@ -312,21 +345,49 @@ function SummaryStat({
   label,
   value,
   help,
+  to,
+  search,
+  statId,
+  destination,
 }: {
   label: string;
   value: React.ReactNode;
   help?: string;
+  to?: "/browse" | "/quality";
+  search?: { source?: string };
+  statId?: ValidatorsSummaryStatId;
+  destination?: "browse" | "quality" | "validators-skill-package" | "validators-mcp-config";
 }) {
-  return (
-    <div className="bg-surface p-5">
+  const body = (
+    <>
       <div className="flex items-center justify-between">
         <ShieldCheck className="h-4 w-4 text-ink-subtle" />
         <span className="font-mono text-[11px] text-ink-subtle">{label}</span>
       </div>
       <div className="mt-3 font-display text-2xl font-semibold tabular-nums text-ink">{value}</div>
       {help && <div className="mt-1 font-mono text-[11px] text-ink-subtle">{help}</div>}
-    </div>
+    </>
   );
+
+  if (to && statId && destination) {
+    return (
+      <Link
+        to={to}
+        search={to === "/browse" ? search : undefined}
+        onClick={() =>
+          trackEvent(
+            validatorsSummaryStatAnalyticsEvent(),
+            validatorsSummaryStatAnalyticsData(statId, destination),
+          )
+        }
+        className="block bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className="bg-surface p-5">{body}</div>;
 }
 
 function Metric({ label, value, total }: { label: string; value: number; total: number }) {
@@ -348,18 +409,32 @@ function ToolCard({
   icon: Icon,
   title,
   blurb,
+  toolId,
+  to,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   title: string;
   blurb: string;
+  toolId: ValidatorsToolId;
+  to: "/validators/skill-package" | "/validators/mcp-config";
 }) {
   return (
-    <div className="rounded-xl border border-border bg-surface p-5">
+    <Link
+      to={to}
+      onClick={() =>
+        trackEvent(
+          validatorsToolCardAnalyticsEvent(),
+          validatorsToolCardAnalyticsData(toolId, VALIDATOR_TOOL_COUNT),
+        )
+      }
+      className="rounded-xl border border-border bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+    >
       <div className="flex items-center gap-2">
         <Icon className="h-4 w-4 text-ink-muted" />
         <h3 className="font-display text-base font-semibold text-ink">{title}</h3>
       </div>
       <p className="mt-2 text-sm text-ink-muted">{blurb}</p>
-    </div>
+      <span className="mt-3 inline-flex text-xs font-medium text-ink-muted">Open tool →</span>
+    </Link>
   );
 }

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  browseDrilldown,
+  sourceStatusFromLabel,
+  tagDrilldown,
+  trustLevelFromLabel,
+  withReportDimensionDrilldown,
+  withSourceDrilldown,
+  withTagDrilldown,
+  withTrustDrilldown,
+} from "@/lib/data-report-drilldown-lib";
+
+describe("data report drilldown lib", () => {
+  it("maps trust and source labels to registry enums", () => {
+    expect(trustLevelFromLabel("Trusted")).toBe("trusted");
+    expect(trustLevelFromLabel("Review first")).toBe("review");
+    expect(sourceStatusFromLabel("Source-backed")).toBe("source-backed");
+    expect(sourceStatusFromLabel("First-party")).toBe("first-party");
+  });
+
+  it("attaches browse and tag drilldowns with privacy-light keys", () => {
+    expect(browseDrilldown({ category: "mcp", trust: "trusted" })).toEqual({
+      kind: "browse",
+      search: { category: "mcp", trust: "trusted" },
+    });
+    expect(tagDrilldown("postgres")).toEqual({ kind: "tag", tag: "postgres" });
+
+    expect(
+      withTrustDrilldown([{ label: "Trusted", count: 4, pct: 40 }], "mcp"),
+    ).toEqual([
+      {
+        label: "Trusted",
+        count: 4,
+        pct: 40,
+        rowKey: "trusted",
+        drilldown: {
+          kind: "browse",
+          search: { category: "mcp", trust: "trusted" },
+        },
+      },
+    ]);
+
+    expect(
+      withSourceDrilldown(
+        [{ label: "Unverified", count: 2, pct: 20 }],
+        "skills",
+      ),
+    ).toEqual([
+      {
+        label: "Unverified",
+        count: 2,
+        pct: 20,
+        rowKey: "unverified",
+        drilldown: {
+          kind: "browse",
+          search: { category: "skills", source: "unverified" },
+        },
+      },
+    ]);
+
+    expect(
+      withTagDrilldown([{ label: "postgres", count: 3, pct: 30 }]),
+    ).toEqual([
+      {
+        label: "postgres",
+        count: 3,
+        pct: 30,
+        rowKey: "postgres",
+        drilldown: { kind: "tag", tag: "postgres" },
+      },
+    ]);
+  });
+
+  it("attaches dimension drilldowns for known report keys", () => {
+    expect(
+      withReportDimensionDrilldown(
+        "trust-level",
+        [{ label: "Trusted", count: 1, pct: 100 }],
+        "agents",
+      )[0]?.rowKey,
+    ).toBe("trusted");
+    expect(
+      withReportDimensionDrilldown(
+        "use-cases",
+        [{ label: "research", count: 2, pct: 50 }],
+        "agents",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "tag", tag: "research" });
+    expect(
+      withReportDimensionDrilldown(
+        "unknown-dimension",
+        [{ label: "x", count: 1, pct: 100 }],
+        "agents",
+      )[0]?.drilldown,
+    ).toBeUndefined();
+  });
+});

--- a/tests/mcp-security-report-page-cta-events-lib.test.ts
+++ b/tests/mcp-security-report-page-cta-events-lib.test.ts
@@ -5,8 +5,12 @@ import {
   mcpSecurityReportCategoryBrowseAnalyticsEvent,
   mcpSecurityReportCiteAnalyticsData,
   mcpSecurityReportCiteAnalyticsEvent,
+  mcpSecurityReportDistRowAnalyticsData,
+  mcpSecurityReportDistRowAnalyticsEvent,
   mcpSecurityReportEgressAnalyticsData,
   mcpSecurityReportEgressAnalyticsEvent,
+  mcpSecurityReportStatAnalyticsData,
+  mcpSecurityReportStatAnalyticsEvent,
 } from "@/lib/mcp-security-report-page-cta-events-lib";
 
 describe("mcp security report page cta events lib", () => {
@@ -32,6 +36,29 @@ describe("mcp security report page cta events lib", () => {
     expect(mcpSecurityReportCiteAnalyticsData()).toEqual({
       surface: MCP_SECURITY_REPORT_SURFACE,
       destination: "canonical",
+    });
+  });
+
+  it("builds mcp security dist-row and stat analytics", () => {
+    expect(mcpSecurityReportDistRowAnalyticsEvent()).toBe(
+      "mcp_security_dist_row_click",
+    );
+    expect(
+      mcpSecurityReportDistRowAnalyticsData("hosting", "remote", 1, 2),
+    ).toEqual({
+      surface: MCP_SECURITY_REPORT_SURFACE,
+      dimension: "hosting",
+      rowKey: "remote",
+      rowIndex: 1,
+      rowCount: 2,
+    });
+    expect(mcpSecurityReportStatAnalyticsEvent()).toBe(
+      "mcp_security_stat_click",
+    );
+    expect(mcpSecurityReportStatAnalyticsData("total", "browse")).toEqual({
+      surface: MCP_SECURITY_REPORT_SURFACE,
+      statKey: "total",
+      destination: "browse",
     });
   });
 });

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -4,8 +4,12 @@ import {
   stateReportCategoryBrowseAnalyticsEvent,
   stateReportCiteAnalyticsData,
   stateReportCiteAnalyticsEvent,
+  stateReportDistRowAnalyticsData,
+  stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportStatAnalyticsData,
+  stateReportStatAnalyticsEvent,
 } from "@/lib/state-report-page-cta-events-lib";
 
 describe("state report page cta events lib", () => {
@@ -45,6 +49,35 @@ describe("state report page cta events lib", () => {
     expect(stateReportCiteAnalyticsData("agent-skills")).toEqual({
       reportId: "agent-skills",
       destination: "canonical",
+    });
+  });
+
+  it("builds state report dist-row and stat analytics", () => {
+    expect(stateReportDistRowAnalyticsEvent()).toBe(
+      "state_report_dist_row_click",
+    );
+    expect(
+      stateReportDistRowAnalyticsData(
+        "mcp-servers",
+        "trust-level",
+        "trusted",
+        0,
+        4,
+      ),
+    ).toEqual({
+      reportId: "mcp-servers",
+      dimension: "trust-level",
+      rowKey: "trusted",
+      rowIndex: 0,
+      rowCount: 4,
+    });
+    expect(stateReportStatAnalyticsEvent()).toBe("state_report_stat_click");
+    expect(
+      stateReportStatAnalyticsData("ai-agents", "total", "browse"),
+    ).toEqual({
+      reportId: "ai-agents",
+      statKey: "total",
+      destination: "browse",
     });
   });
 });

--- a/tests/validators-tools-cta-events-lib.test.ts
+++ b/tests/validators-tools-cta-events-lib.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  VALIDATORS_TOOLS_SURFACE,
+  validatorsSummaryStatAnalyticsData,
+  validatorsSummaryStatAnalyticsEvent,
+  validatorsToolCardAnalyticsData,
+  validatorsToolCardAnalyticsEvent,
+} from "@/lib/validators-tools-cta-events-lib";
+
+describe("validators tools cta events lib", () => {
+  it("builds privacy-light validators tool and summary analytics", () => {
+    expect(validatorsToolCardAnalyticsEvent()).toBe(
+      "validators_tool_card_click",
+    );
+    expect(validatorsToolCardAnalyticsData("skill-package", 2)).toEqual({
+      surface: VALIDATORS_TOOLS_SURFACE,
+      toolId: "skill-package",
+      toolCount: 2,
+    });
+    expect(validatorsToolCardAnalyticsData("mcp-config", 2)).toEqual({
+      surface: VALIDATORS_TOOLS_SURFACE,
+      toolId: "mcp-config",
+      toolCount: 2,
+    });
+    expect(validatorsSummaryStatAnalyticsEvent()).toBe(
+      "validators_summary_stat_click",
+    );
+    expect(validatorsSummaryStatAnalyticsData("entries", "browse")).toEqual({
+      surface: VALIDATORS_TOOLS_SURFACE,
+      statId: "entries",
+      destination: "browse",
+    });
+    expect(
+      validatorsSummaryStatAnalyticsData("needs-attention", "quality"),
+    ).toEqual({
+      surface: VALIDATORS_TOOLS_SURFACE,
+      statId: "needs-attention",
+      destination: "quality",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Make shared DistTable/DataStat rows navigable (browse filters / tags) across MCP, security, agents, skills, and hooks reports
- Add privacy-light dist-row and headline-stat analytics for state + MCP security reports
- Link validators summary stats and local tool cards to browse/quality/tool routes with CTA tracking

## Test plan
- [ ] On `/state-of-mcp-servers`, click trust/source/tag rows and headline stats; land in browse/tags
- [ ] On `/mcp-security-report`, click distribution rows and stats
- [ ] On agents/skills/hooks state reports, click drillable dimensions and stats
- [ ] On `/validators`, click summary stats and both local tool cards

Refs #550

Made with [Cursor](https://cursor.com)