### PR TITLE
feat(web): add badge chrome, readiness, trust-hint, and npm badge analytics

### DIFF
--- a/apps/web/src/components/badges.tsx
+++ b/apps/web/src/components/badges.tsx
@@ -50,20 +50,47 @@ const trustIcon: Record<TrustLevel, React.ElementType> = {
   blocked: OctagonX,
 };
 
-export function TrustBadge({ level, className }: { level: TrustLevel; className?: string }) {
+export function TrustBadge({
+  level,
+  className,
+  asLink = false,
+  onNavigate,
+}: {
+  level: TrustLevel;
+  className?: string;
+  /** Opt-in browse link — never use inside card `<Link>`s. */
+  asLink?: boolean;
+  onNavigate?: () => void;
+}) {
   const s = trustStyles[level];
   const Icon = trustIcon[level];
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface px-2 py-0.5 text-[11px] font-medium leading-none",
-        s.text,
-        className,
-      )}
-      title={`${TRUST_LABEL[level]} — review before installing`}
-    >
+  const content = (
+    <>
       <Icon className="h-3 w-3" aria-hidden />
       {TRUST_LABEL[level]}
+    </>
+  );
+  const classes = cn(
+    "inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface px-2 py-0.5 text-[11px] font-medium leading-none",
+    s.text,
+    className,
+  );
+  if (asLink) {
+    return (
+      <Link
+        to="/browse"
+        search={{ trust: level }}
+        onClick={onNavigate}
+        className={cn(classes, "transition-colors hover:border-ink/20")}
+        title={`${TRUST_LABEL[level]} — browse by trust`}
+      >
+        {content}
+      </Link>
+    );
+  }
+  return (
+    <span className={classes} title={`${TRUST_LABEL[level]} — review before installing`}>
+      {content}
     </span>
   );
 }
@@ -75,19 +102,43 @@ const sourceIcon: Record<SourceStatus, React.ElementType> = {
   unverified: HelpCircle,
 };
 
-export function SourceBadge({ status, className }: { status: SourceStatus; className?: string }) {
+export function SourceBadge({
+  status,
+  className,
+  asLink = false,
+  onNavigate,
+}: {
+  status: SourceStatus;
+  className?: string;
+  /** Opt-in browse link — never use inside card `<Link>`s. */
+  asLink?: boolean;
+  onNavigate?: () => void;
+}) {
   const Icon = sourceIcon[status];
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 whitespace-nowrap rounded-md bg-surface-2 px-2 py-0.5 text-[11px] font-medium leading-none text-ink-muted",
-        className,
-      )}
-    >
+  const content = (
+    <>
       <Icon className="h-3 w-3" aria-hidden />
       {SOURCE_LABEL[status]}
-    </span>
+    </>
   );
+  const classes = cn(
+    "inline-flex items-center gap-1 whitespace-nowrap rounded-md bg-surface-2 px-2 py-0.5 text-[11px] font-medium leading-none text-ink-muted",
+    className,
+  );
+  if (asLink) {
+    return (
+      <Link
+        to="/browse"
+        search={{ source: status }}
+        onClick={onNavigate}
+        className={cn(classes, "transition-colors hover:text-ink")}
+        title={`${SOURCE_LABEL[status]} — browse by source`}
+      >
+        {content}
+      </Link>
+    );
+  }
+  return <span className={classes}>{content}</span>;
 }
 
 export function PlatformChip({ id, asLink = false }: { id: Platform; asLink?: boolean }) {
@@ -159,55 +210,134 @@ export function InstallRiskBadge({
   entry,
   className,
   size = "sm",
+  asButton = false,
+  onActivate,
 }: {
   entry: Entry;
   className?: string;
   size?: "sm" | "xs";
+  /** Opt-in scroll control — never use inside card `<Link>`s. */
+  asButton?: boolean;
+  onActivate?: (risk: InstallRisk) => void;
 }) {
   const level = React.useMemo(() => installRiskLevel(entry), [entry]);
   const s = installRiskStyles[level];
   const Icon = installRiskIcon[level];
+  const classes = cn(
+    "inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface font-medium leading-none",
+    s.text,
+    size === "xs" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-[11px]",
+    className,
+  );
+  const content = (
+    <>
+      <Icon className={size === "xs" ? "h-2.5 w-2.5" : "h-3 w-3"} aria-hidden />
+      {INSTALL_RISK_LABEL[level]}
+    </>
+  );
+  if (asButton) {
+    return (
+      <button
+        type="button"
+        title={`${INSTALL_RISK_LABEL[level]} — jump to install risk`}
+        onClick={() => {
+          onActivate?.(level);
+          document.getElementById("risk-callout")?.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }}
+        className={cn(
+          classes,
+          "transition-colors hover:border-ink/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+        )}
+      >
+        {content}
+      </button>
+    );
+  }
   return (
     <span
       title={`${INSTALL_RISK_LABEL[level]} — ${INSTALL_RISK_DETAIL[level]}`}
-      className={cn(
-        "inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border bg-surface font-medium leading-none",
-        s.text,
-        size === "xs" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-[11px]",
-        className,
-      )}
+      className={classes}
     >
-      <Icon className={size === "xs" ? "h-2.5 w-2.5" : "h-3 w-3"} aria-hidden />
-      {INSTALL_RISK_LABEL[level]}
+      {content}
     </span>
   );
 }
 
 /** Tiny presence chips for safety/privacy notes — muted when missing. */
-export function NotesPresenceChips({ entry, className }: { entry: Entry; className?: string }) {
+export function NotesPresenceChips({
+  entry,
+  className,
+  interactive = false,
+  onNoteClick,
+}: {
+  entry: Entry;
+  className?: string;
+  /** Opt-in scroll buttons — never use inside card `<Link>`s. */
+  interactive?: boolean;
+  onNoteClick?: (noteKind: "safety" | "privacy", present: boolean) => void;
+}) {
   const hasSafety = !!(entry.safetyNotes || entry.safetyNotesList?.length);
   const hasPrivacy = !!(entry.privacyNotes || entry.privacyNotesList?.length);
+
+  const chipClass = (present: boolean) =>
+    cn(
+      "inline-flex items-center gap-1 whitespace-nowrap rounded-md border px-1.5 py-0.5 font-mono text-[10px] leading-none",
+      present ? "border-trust-trusted/30 text-trust-trusted" : "border-border text-ink-subtle/70",
+    );
+
+  const activate = (noteKind: "safety" | "privacy", present: boolean, targetId: string) => {
+    onNoteClick?.(noteKind, present);
+    document.getElementById(targetId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  if (interactive) {
+    return (
+      <span className={cn("inline-flex items-center gap-1", className)}>
+        <button
+          type="button"
+          title={hasSafety ? "Jump to safety notes" : "Safety notes missing"}
+          onClick={() => activate("safety", hasSafety, "safety")}
+          className={cn(
+            chipClass(hasSafety),
+            "transition-colors hover:border-ink/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+          )}
+        >
+          <Lock className="h-2.5 w-2.5" aria-hidden /> Safety {hasSafety ? "✓" : "·"}
+        </button>
+        <button
+          type="button"
+          title={hasPrivacy ? "Jump to privacy notes" : "Privacy notes missing"}
+          onClick={() => activate("privacy", hasPrivacy, "privacy")}
+          className={cn(
+            chipClass(hasPrivacy),
+            "transition-colors hover:border-ink/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+          )}
+        >
+          {hasPrivacy ? (
+            <Eye className="h-2.5 w-2.5" aria-hidden />
+          ) : (
+            <EyeOff className="h-2.5 w-2.5" aria-hidden />
+          )}{" "}
+          Privacy {hasPrivacy ? "✓" : "·"}
+        </button>
+      </span>
+    );
+  }
+
   return (
     <span className={cn("inline-flex items-center gap-1", className)}>
       <span
         title={hasSafety ? "Safety notes present" : "Safety notes missing"}
-        className={cn(
-          "inline-flex items-center gap-1 whitespace-nowrap rounded-md border px-1.5 py-0.5 font-mono text-[10px] leading-none",
-          hasSafety
-            ? "border-trust-trusted/30 text-trust-trusted"
-            : "border-border text-ink-subtle/70",
-        )}
+        className={chipClass(hasSafety)}
       >
         <Lock className="h-2.5 w-2.5" aria-hidden /> Safety {hasSafety ? "✓" : "·"}
       </span>
       <span
         title={hasPrivacy ? "Privacy notes present" : "Privacy notes missing"}
-        className={cn(
-          "inline-flex items-center gap-1 whitespace-nowrap rounded-md border px-1.5 py-0.5 font-mono text-[10px] leading-none",
-          hasPrivacy
-            ? "border-trust-trusted/30 text-trust-trusted"
-            : "border-border text-ink-subtle/70",
-        )}
+        className={chipClass(hasPrivacy)}
       >
         {hasPrivacy ? (
           <Eye className="h-2.5 w-2.5" aria-hidden />

--- a/apps/web/src/components/entry-detail-rail.tsx
+++ b/apps/web/src/components/entry-detail-rail.tsx
@@ -30,7 +30,12 @@ export function EntryDetailRail({
       {children}
       {readinessRows && readinessRows.length > 0 ? (
         <div className="overflow-hidden rounded-xl border border-border bg-surface">
-          <EntryDetailReadinessPanel rows={readinessRows} className="border-t-0" />
+          <EntryDetailReadinessPanel
+            rows={readinessRows}
+            category={entry.category}
+            slug={entry.slug}
+            className="border-t-0"
+          />
         </div>
       ) : null}
       {quickLinks && quickLinks.length > 0 ? (

--- a/apps/web/src/components/entry-detail-readiness.tsx
+++ b/apps/web/src/components/entry-detail-readiness.tsx
@@ -1,12 +1,21 @@
 import { CheckCircle2, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
 import type { EntryReadinessRow } from "@/lib/entry-detail-sidebar-lib";
+import {
+  entryReadinessRowAnalyticsData,
+  entryReadinessRowAnalyticsEvent,
+} from "@/lib/entry-readiness-cta-events";
 
 export function EntryDetailReadinessPanel({
   rows,
+  category,
+  slug,
   className,
 }: {
   rows: EntryReadinessRow[];
+  category: string;
+  slug: string;
   className?: string;
 }) {
   return (
@@ -14,21 +23,42 @@ export function EntryDetailReadinessPanel({
       <div className="eyebrow mb-2">Readiness</div>
       <ul className="space-y-1.5 text-xs">
         {rows.map((row) => (
-          <li key={row.label} className="flex items-center justify-between gap-2">
-            <span className="text-ink-muted">{row.label}</span>
-            <span
-              className={cn(
-                "inline-flex items-center gap-1 font-medium",
-                row.ok ? "text-trust-trusted" : "text-ink-muted",
-              )}
+          <li key={row.id}>
+            <button
+              type="button"
+              onClick={() => {
+                trackEvent(
+                  entryReadinessRowAnalyticsEvent(),
+                  entryReadinessRowAnalyticsData(
+                    category,
+                    slug,
+                    row.id,
+                    row.ok,
+                    row.scrollTargetId,
+                  ),
+                );
+                document.getElementById(row.scrollTargetId)?.scrollIntoView({
+                  behavior: "smooth",
+                  block: "start",
+                });
+              }}
+              className="flex w-full items-center justify-between gap-2 rounded-sm text-left transition-colors hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
             >
-              {row.ok ? (
-                <CheckCircle2 className="h-3 w-3" aria-hidden />
-              ) : (
-                <Circle className="h-3 w-3" aria-hidden />
-              )}
-              {row.value}
-            </span>
+              <span className="text-ink-muted">{row.label}</span>
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 font-medium",
+                  row.ok ? "text-trust-trusted" : "text-ink-muted",
+                )}
+              >
+                {row.ok ? (
+                  <CheckCircle2 className="h-3 w-3" aria-hidden />
+                ) : (
+                  <Circle className="h-3 w-3" aria-hidden />
+                )}
+                {row.value}
+              </span>
+            </button>
           </li>
         ))}
       </ul>

--- a/apps/web/src/components/integration-card.tsx
+++ b/apps/web/src/components/integration-card.tsx
@@ -109,6 +109,8 @@ export function IntegrationCard({
               fallbackVersion={integration.version}
               fallbackUpdatedAt={integration.updatedAt}
               showDownloads={false}
+              asLink
+              analyticsSurface="integration-card"
             />
           ) : (
             <>

--- a/apps/web/src/components/live-version-badge.tsx
+++ b/apps/web/src/components/live-version-badge.tsx
@@ -3,6 +3,12 @@ import { useQuery } from "@tanstack/react-query";
 import { Package } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCompact, timeAgo } from "@/lib/format";
+import { trackEvent } from "@/lib/analytics";
+import {
+  liveVersionBadgeAnalyticsData,
+  liveVersionBadgeAnalyticsEvent,
+  type LiveVersionBadgeSurface,
+} from "@/lib/live-version-cta-events";
 
 interface NpmMeta {
   name: string;
@@ -21,6 +27,9 @@ async function fetchNpm(pkg: string): Promise<NpmMeta> {
  * Compact live version chip backed by /api/public/npm proxy.
  * Falls back to `fallbackVersion` and `fallbackUpdatedAt` while loading or
  * if the proxy fails. Always renders something — never blank.
+ *
+ * `asLink` is opt-in so callers that already wrap the badge in a `<Link>`
+ * (e.g. home hero) do not nest anchors.
  */
 export function LiveVersionBadge({
   pkg,
@@ -28,12 +37,16 @@ export function LiveVersionBadge({
   fallbackUpdatedAt,
   showDownloads = true,
   className,
+  asLink = false,
+  analyticsSurface = "integration-card",
 }: {
   pkg: string;
   fallbackVersion?: string;
   fallbackUpdatedAt?: string;
   showDownloads?: boolean;
   className?: string;
+  asLink?: boolean;
+  analyticsSurface?: LiveVersionBadgeSurface;
 }) {
   const { data, isError } = useQuery({
     queryKey: ["npm", pkg],
@@ -48,14 +61,8 @@ export function LiveVersionBadge({
   const downloads = data?.weeklyDownloads;
   const live = !!data && !isError;
 
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-0.5 font-mono text-[11px] text-ink-muted",
-        className,
-      )}
-      title={live ? `Latest on npm · published ${timeAgo(updatedAt)}` : "Last known release"}
-    >
+  const body = (
+    <>
       <Package className="h-3 w-3" aria-hidden />
       {version ? <span className="text-ink">v{version.replace(/^v/, "")}</span> : <span>—</span>}
       {showDownloads && downloads != null && (
@@ -71,6 +78,38 @@ export function LiveVersionBadge({
           title="Live from npm registry"
         />
       )}
+    </>
+  );
+
+  const classes = cn(
+    "inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2 py-0.5 font-mono text-[11px] text-ink-muted",
+    className,
+  );
+  const title = live ? `Latest on npm · published ${timeAgo(updatedAt)}` : "Last known release";
+
+  if (asLink) {
+    return (
+      <a
+        href={`https://www.npmjs.com/package/${encodeURIComponent(pkg)}`}
+        target="_blank"
+        rel="noreferrer"
+        onClick={() =>
+          trackEvent(
+            liveVersionBadgeAnalyticsEvent(),
+            liveVersionBadgeAnalyticsData(analyticsSurface, live),
+          )
+        }
+        className={cn(classes, "transition-colors hover:border-ink/20 hover:text-ink")}
+        title={title}
+      >
+        {body}
+      </a>
+    );
+  }
+
+  return (
+    <span className={classes} title={title}>
+      {body}
     </span>
   );
 }

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -42,6 +42,14 @@ import {
   PEEK_PANEL_SURFACE,
 } from "@/lib/peek-panel-cta-events";
 import {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
+import {
   harnessVariantSelectAnalyticsData,
   harnessVariantSelectAnalyticsEvent,
 } from "@/lib/harness-variant-cta-events";
@@ -171,9 +179,38 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
     <>
       <SheetHeader className="space-y-3 text-left">
         <div className="flex flex-wrap items-center gap-1.5">
-          <CategoryPill>{entry.category}</CategoryPill>
-          <TrustBadge level={entry.trust} />
-          <SourceBadge status={entry.source} />
+          <Link
+            to="/browse"
+            search={{ category: entry.category }}
+            onClick={() =>
+              trackEvent(
+                badgeChromeCategoryAnalyticsEvent(),
+                badgeChromeCategoryAnalyticsData(entry.category, "peek-panel"),
+              )
+            }
+          >
+            <CategoryPill>{entry.category}</CategoryPill>
+          </Link>
+          <TrustBadge
+            level={entry.trust}
+            asLink
+            onNavigate={() =>
+              trackEvent(
+                badgeChromeTrustAnalyticsEvent(),
+                badgeChromeTrustAnalyticsData(entry.trust, "peek-panel"),
+              )
+            }
+          />
+          <SourceBadge
+            status={entry.source}
+            asLink
+            onNavigate={() =>
+              trackEvent(
+                badgeChromeSourceAnalyticsEvent(),
+                badgeChromeSourceAnalyticsData(entry.source, "peek-panel"),
+              )
+            }
+          />
           <InstallRiskBadge entry={entry} size="xs" />
         </div>
         <div className="flex min-w-0 items-start gap-3">
@@ -206,7 +243,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
         <div className="mt-4 flex flex-wrap items-center gap-1">
           <span className="eyebrow mr-1">Platforms</span>
           {entry.platforms.map((p) => (
-            <PlatformChip key={p} id={p} />
+            <PlatformChip key={p} id={p} asLink />
           ))}
         </div>
       )}

--- a/apps/web/src/components/resource-card-trust-hint.tsx
+++ b/apps/web/src/components/resource-card-trust-hint.tsx
@@ -6,21 +6,43 @@ import { cn } from "@/lib/utils";
 export function ResourceCardTrustHint({
   state,
   className,
+  onActivate,
 }: {
   state: ResourceCardTrustDecisionState;
   className?: string;
+  /** When set, renders as a compare-tray CTA button. */
+  onActivate?: () => void;
 }) {
   if (!state.showHint) return null;
 
+  const classes = cn(
+    "inline-flex items-start gap-1.5 rounded-md border px-2 py-1 text-left text-[11px] leading-snug",
+    resourceCardTrustHintToneClass(state.kind),
+    className,
+  );
+
+  if (onActivate) {
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onActivate();
+        }}
+        className={cn(
+          classes,
+          "transition-colors hover:border-ink/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+        )}
+      >
+        <GitCompare className="mt-0.5 h-3 w-3 shrink-0 opacity-70" aria-hidden />
+        <span>{state.hint}</span>
+      </button>
+    );
+  }
+
   return (
-    <p
-      className={cn(
-        "inline-flex items-start gap-1.5 rounded-md border px-2 py-1 text-[11px] leading-snug",
-        resourceCardTrustHintToneClass(state.kind),
-        className,
-      )}
-      role="status"
-    >
+    <p className={classes} role="status">
       <GitCompare className="mt-0.5 h-3 w-3 shrink-0 opacity-70" aria-hidden />
       <span>{state.hint}</span>
     </p>

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -31,6 +31,8 @@ import {
   resourceCardInstallAnalyticsData,
   resourceCardInstallAnalyticsEvent,
   resourceCardInstallIntentType,
+  resourceCardTrustHintAnalyticsData,
+  resourceCardTrustHintAnalyticsEvent,
   RESOURCE_CARD_SURFACE,
   type ResourceCardSurface,
 } from "@/lib/resource-card-cta-events";
@@ -148,6 +150,29 @@ function ResourceCardInner({
     }
   };
 
+  const onTrustHintActivate = () => {
+    if (!trustDecision) return;
+    trackEvent(
+      resourceCardTrustHintAnalyticsEvent(),
+      resourceCardTrustHintAnalyticsData(
+        entry.category,
+        entry.slug,
+        trustDecision.kind,
+        inCompare,
+        compareItems.length,
+        analyticsSurface,
+      ),
+    );
+    if (!inCompare) {
+      const changed = toggle(entry);
+      if (!changed) {
+        toast.error(resourceCardCompareFullMessage());
+        return;
+      }
+    }
+    setOpen(true);
+  };
+
   const onInstallCopied = () => {
     void recordIntentEvent(resourceCardInstallIntentType(entry), entry);
   };
@@ -232,9 +257,6 @@ function ResourceCardInner({
               <p className="mt-1.5 line-clamp-2 text-sm text-ink-muted">
                 {entry.cardDescription ?? entry.description}
               </p>
-              {trustDecision ? (
-                <ResourceCardTrustHint state={trustDecision} className="mt-2" />
-              ) : null}
             </div>
             <EntryFacets entry={entry} density="card" />
             <div className="mt-auto flex flex-wrap items-center gap-1.5">
@@ -249,6 +271,13 @@ function ResourceCardInner({
             </div>
             <NotesPresenceChips entry={entry} />
           </Link>
+          {trustDecision ? (
+            <ResourceCardTrustHint
+              state={trustDecision}
+              className="mt-1"
+              onActivate={onTrustHintActivate}
+            />
+          ) : null}
           <LazyEntryAuthorAttribution entry={entry} className="text-xs text-ink-subtle" />
         </div>
         <div className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1 rounded-md border border-border bg-surface/95 p-0.5 opacity-0 shadow-sm backdrop-blur transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100 group-focus-within:opacity-100">
@@ -327,7 +356,13 @@ function ResourceCardInner({
             <LazyEntryAuthorAttribution entry={entry} />
           </div>
           <p className="line-clamp-2 max-w-3xl text-sm text-ink-muted">{entry.description}</p>
-          {trustDecision ? <ResourceCardTrustHint state={trustDecision} className="mt-1" /> : null}
+          {trustDecision ? (
+            <ResourceCardTrustHint
+              state={trustDecision}
+              className="mt-1"
+              onActivate={onTrustHintActivate}
+            />
+          ) : null}
           <div className="flex flex-wrap items-center gap-2 pt-0.5">
             <EntryFacets entry={entry} density="card" />
             <NotesPresenceChips entry={entry} />

--- a/apps/web/src/components/sticky-meta-bar.tsx
+++ b/apps/web/src/components/sticky-meta-bar.tsx
@@ -27,6 +27,14 @@ import {
   entryDetailStickyCopyVariantSelectAnalyticsData,
   entryDetailStickyCopyVariantSelectAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
+import {
+  badgeChromeInstallRiskAnalyticsData,
+  badgeChromeInstallRiskAnalyticsEvent,
+  badgeChromeNotesAnalyticsData,
+  badgeChromeNotesAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
 
 /**
  * Appears once the user scrolls past the dossier header.
@@ -204,10 +212,38 @@ export function StickyMetaBar({
 
           {/* Row 2: trust + risk + copy switcher */}
           <div className="flex flex-wrap items-center gap-2 px-3 pb-2 pt-1.5">
-            <TrustBadge level={entry.trust} />
-            <InstallRiskBadge entry={entry} size="xs" />
+            <TrustBadge
+              level={entry.trust}
+              asLink
+              onNavigate={() =>
+                trackEvent(
+                  badgeChromeTrustAnalyticsEvent(),
+                  badgeChromeTrustAnalyticsData(entry.trust, "detail-sticky-meta"),
+                )
+              }
+            />
+            <InstallRiskBadge
+              entry={entry}
+              size="xs"
+              asButton
+              onActivate={(risk) =>
+                trackEvent(
+                  badgeChromeInstallRiskAnalyticsEvent(),
+                  badgeChromeInstallRiskAnalyticsData(risk, "detail-sticky-meta"),
+                )
+              }
+            />
             <span className="hidden md:inline-flex">
-              <NotesPresenceChips entry={entry} />
+              <NotesPresenceChips
+                entry={entry}
+                interactive
+                onNoteClick={(noteKind, present) =>
+                  trackEvent(
+                    badgeChromeNotesAnalyticsEvent(),
+                    badgeChromeNotesAnalyticsData(noteKind, present, "detail-sticky-meta"),
+                  )
+                }
+              />
             </span>
 
             <div className="ml-auto inline-flex items-center gap-1.5">

--- a/apps/web/src/lib/badge-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events-lib.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure badge chrome navigation analytics helpers.
+ *
+ * Maps opt-in trust/source/notes/risk badge navigation to privacy-light event
+ * names without embedding titles or free-form note copy.
+ */
+
+export type BadgeChromeSurface = "detail-sticky-meta" | "peek-panel";
+
+export type BadgeChromeNoteKind = "safety" | "privacy";
+
+export function badgeChromeTrustAnalyticsEvent(): string {
+  return "badge_trust_browse_click";
+}
+
+export function badgeChromeTrustAnalyticsData(trust: string, surface: BadgeChromeSurface) {
+  return {
+    surface,
+    trust,
+  };
+}
+
+export function badgeChromeSourceAnalyticsEvent(): string {
+  return "badge_source_browse_click";
+}
+
+export function badgeChromeSourceAnalyticsData(source: string, surface: BadgeChromeSurface) {
+  return {
+    surface,
+    source,
+  };
+}
+
+export function badgeChromeCategoryAnalyticsEvent(): string {
+  return "badge_category_browse_click";
+}
+
+export function badgeChromeCategoryAnalyticsData(category: string, surface: BadgeChromeSurface) {
+  return {
+    surface,
+    category,
+  };
+}
+
+export function badgeChromeNotesAnalyticsEvent(): string {
+  return "badge_notes_scroll_click";
+}
+
+export function badgeChromeNotesAnalyticsData(
+  noteKind: BadgeChromeNoteKind,
+  present: boolean,
+  surface: BadgeChromeSurface,
+) {
+  return {
+    surface,
+    noteKind,
+    present,
+  };
+}
+
+export function badgeChromeInstallRiskAnalyticsEvent(): string {
+  return "badge_install_risk_scroll_click";
+}
+
+export function badgeChromeInstallRiskAnalyticsData(risk: string, surface: BadgeChromeSurface) {
+  return {
+    surface,
+    risk,
+  };
+}

--- a/apps/web/src/lib/badge-chrome-cta-events.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events.ts
@@ -1,0 +1,17 @@
+/**
+ * Badge chrome navigation CTA event surface.
+ */
+export {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
+  badgeChromeInstallRiskAnalyticsData,
+  badgeChromeInstallRiskAnalyticsEvent,
+  badgeChromeNotesAnalyticsData,
+  badgeChromeNotesAnalyticsEvent,
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+  type BadgeChromeNoteKind,
+  type BadgeChromeSurface,
+} from "@/lib/badge-chrome-cta-events-lib";

--- a/apps/web/src/lib/entry-detail-sidebar-lib.ts
+++ b/apps/web/src/lib/entry-detail-sidebar-lib.ts
@@ -1,10 +1,14 @@
 import { TRUST_LABEL, type Entry } from "@/types/registry";
 import type { InstallRisk } from "@/lib/trust";
+import type { EntryReadinessRowId } from "@/lib/entry-readiness-cta-events-lib";
 
 export type EntryReadinessRow = {
+  id: EntryReadinessRowId;
   label: string;
   value: string;
   ok: boolean;
+  /** In-page section id to scroll to when the row is activated. */
+  scrollTargetId: string;
 };
 
 export type EntryQuickLink = {
@@ -18,24 +22,32 @@ export type EntryQuickLink = {
 export function entryReadinessRows(entry: Entry): EntryReadinessRow[] {
   return [
     {
+      id: "trust",
       label: "Trust",
       value: TRUST_LABEL[entry.trust],
       ok: entry.trust === "trusted",
+      scrollTargetId: "citation-facts",
     },
     {
+      id: "source",
       label: "Source",
       value: entry.source,
       ok: entry.source !== "unverified",
+      scrollTargetId: "citations",
     },
     {
+      id: "safety",
       label: "Safety notes",
       value: entry.safetyNotes ? "Present" : "Missing",
       ok: Boolean(entry.safetyNotes),
+      scrollTargetId: "safety",
     },
     {
+      id: "reviewed",
       label: "Reviewed",
       value: entry.reviewed ? "Yes" : "No",
       ok: Boolean(entry.reviewed),
+      scrollTargetId: "about",
     },
   ];
 }

--- a/apps/web/src/lib/entry-readiness-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-readiness-cta-events-lib.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure entry readiness rail analytics helpers.
+ *
+ * Maps readiness row navigation to privacy-light event names without embedding
+ * trust labels, source strings, or free-form note copy.
+ */
+
+export const ENTRY_READINESS_SURFACE = "detail-rail";
+
+export type EntryReadinessRowId = "trust" | "source" | "safety" | "reviewed";
+
+export function entryReadinessEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryReadinessRowAnalyticsEvent(): string {
+  return "entry_readiness_row_click";
+}
+
+export function entryReadinessRowAnalyticsData(
+  category: string,
+  slug: string,
+  rowId: EntryReadinessRowId,
+  ok: boolean,
+  destination: string,
+) {
+  return {
+    entry: entryReadinessEntryKey(category, slug),
+    surface: ENTRY_READINESS_SURFACE,
+    rowId,
+    ok,
+    destination,
+  };
+}

--- a/apps/web/src/lib/entry-readiness-cta-events.ts
+++ b/apps/web/src/lib/entry-readiness-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Entry readiness rail CTA event surface.
+ */
+export {
+  ENTRY_READINESS_SURFACE,
+  entryReadinessEntryKey,
+  entryReadinessRowAnalyticsData,
+  entryReadinessRowAnalyticsEvent,
+  type EntryReadinessRowId,
+} from "@/lib/entry-readiness-cta-events-lib";

--- a/apps/web/src/lib/live-version-cta-events-lib.ts
+++ b/apps/web/src/lib/live-version-cta-events-lib.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure live npm version badge analytics helpers.
+ *
+ * Maps badge opens to privacy-light event names without embedding package
+ * names, versions, or download counts.
+ */
+
+export type LiveVersionBadgeSurface = "integrations-detail" | "integration-card";
+
+export function liveVersionBadgeAnalyticsEvent(): string {
+  return "live_version_badge_click";
+}
+
+export function liveVersionBadgeAnalyticsData(
+  surface: LiveVersionBadgeSurface,
+  hasLiveVersion: boolean,
+) {
+  return {
+    surface,
+    hasLiveVersion,
+  };
+}

--- a/apps/web/src/lib/live-version-cta-events.ts
+++ b/apps/web/src/lib/live-version-cta-events.ts
@@ -1,0 +1,8 @@
+/**
+ * Live npm version badge CTA event surface.
+ */
+export {
+  liveVersionBadgeAnalyticsData,
+  liveVersionBadgeAnalyticsEvent,
+  type LiveVersionBadgeSurface,
+} from "@/lib/live-version-cta-events-lib";

--- a/apps/web/src/lib/resource-card-cta-events-lib.ts
+++ b/apps/web/src/lib/resource-card-cta-events-lib.ts
@@ -124,3 +124,24 @@ export function resourceCardEntryAnalyticsData(
     compareCount,
   };
 }
+
+export function resourceCardTrustHintAnalyticsEvent(): string {
+  return "browse_card_trust_hint_click";
+}
+
+export function resourceCardTrustHintAnalyticsData(
+  category: string,
+  slug: string,
+  kind: string,
+  inCompareTray: boolean,
+  compareCount: number,
+  surface: ResourceCardSurface = RESOURCE_CARD_SURFACE,
+) {
+  return {
+    entry: resourceCardEntryKey(category, slug),
+    surface,
+    kind,
+    inCompareTray,
+    compareCount,
+  };
+}

--- a/apps/web/src/lib/resource-card-cta-events.ts
+++ b/apps/web/src/lib/resource-card-cta-events.ts
@@ -15,6 +15,8 @@ export {
   resourceCardInstallAnalyticsData,
   resourceCardInstallAnalyticsEvent,
   resourceCardInstallIntentType,
+  resourceCardTrustHintAnalyticsData,
+  resourceCardTrustHintAnalyticsEvent,
   type ResourceCardSurface,
   type ResourceCardVariant,
 } from "@/lib/resource-card-cta-events-lib";

--- a/apps/web/src/routes/integrations.$slug.tsx
+++ b/apps/web/src/routes/integrations.$slug.tsx
@@ -144,6 +144,8 @@ function IntegrationDetail() {
                 pkg={integration.npmPackage}
                 fallbackVersion={integration.version}
                 fallbackUpdatedAt={integration.updatedAt}
+                asLink
+                analyticsSurface="integrations-detail"
               />
             </div>
           ) : null}

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
+  badgeChromeInstallRiskAnalyticsData,
+  badgeChromeInstallRiskAnalyticsEvent,
+  badgeChromeNotesAnalyticsData,
+  badgeChromeNotesAnalyticsEvent,
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events-lib";
+
+describe("badge chrome cta events lib", () => {
+  it("builds privacy-light badge chrome analytics", () => {
+    expect(badgeChromeTrustAnalyticsEvent()).toBe("badge_trust_browse_click");
+    expect(
+      badgeChromeTrustAnalyticsData("trusted", "detail-sticky-meta"),
+    ).toEqual({
+      surface: "detail-sticky-meta",
+      trust: "trusted",
+    });
+    expect(badgeChromeSourceAnalyticsEvent()).toBe("badge_source_browse_click");
+    expect(
+      badgeChromeSourceAnalyticsData("source-backed", "peek-panel"),
+    ).toEqual({
+      surface: "peek-panel",
+      source: "source-backed",
+    });
+    expect(badgeChromeCategoryAnalyticsEvent()).toBe(
+      "badge_category_browse_click",
+    );
+    expect(badgeChromeCategoryAnalyticsData("mcp", "peek-panel")).toEqual({
+      surface: "peek-panel",
+      category: "mcp",
+    });
+    expect(badgeChromeNotesAnalyticsEvent()).toBe("badge_notes_scroll_click");
+    expect(
+      badgeChromeNotesAnalyticsData("safety", true, "detail-sticky-meta"),
+    ).toEqual({
+      surface: "detail-sticky-meta",
+      noteKind: "safety",
+      present: true,
+    });
+    expect(badgeChromeInstallRiskAnalyticsEvent()).toBe(
+      "badge_install_risk_scroll_click",
+    );
+    expect(badgeChromeInstallRiskAnalyticsData("review", "peek-panel")).toEqual(
+      {
+        surface: "peek-panel",
+        risk: "review",
+      },
+    );
+  });
+});

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -49,10 +49,34 @@ describe("entry-detail-sidebar-lib", () => {
       }),
     );
     expect(rows).toEqual([
-      { label: "Trust", value: "Review first", ok: false },
-      { label: "Source", value: "unverified", ok: false },
-      { label: "Safety notes", value: "Missing", ok: false },
-      { label: "Reviewed", value: "No", ok: false },
+      {
+        id: "trust",
+        label: "Trust",
+        value: "Review first",
+        ok: false,
+        scrollTargetId: "citation-facts",
+      },
+      {
+        id: "source",
+        label: "Source",
+        value: "unverified",
+        ok: false,
+        scrollTargetId: "citations",
+      },
+      {
+        id: "safety",
+        label: "Safety notes",
+        value: "Missing",
+        ok: false,
+        scrollTargetId: "safety",
+      },
+      {
+        id: "reviewed",
+        label: "Reviewed",
+        value: "No",
+        ok: false,
+        scrollTargetId: "about",
+      },
     ]);
   });
 

--- a/tests/entry-readiness-cta-events-lib.test.ts
+++ b/tests/entry-readiness-cta-events-lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_READINESS_SURFACE,
+  entryReadinessRowAnalyticsData,
+  entryReadinessRowAnalyticsEvent,
+} from "@/lib/entry-readiness-cta-events-lib";
+
+describe("entry readiness cta events lib", () => {
+  it("builds privacy-light readiness row analytics", () => {
+    expect(entryReadinessRowAnalyticsEvent()).toBe("entry_readiness_row_click");
+    expect(
+      entryReadinessRowAnalyticsData(
+        "mcp",
+        "browser",
+        "trust",
+        true,
+        "citation-facts",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_READINESS_SURFACE,
+      rowId: "trust",
+      ok: true,
+      destination: "citation-facts",
+    });
+    expect(
+      entryReadinessRowAnalyticsData(
+        "skills",
+        "demo",
+        "safety",
+        false,
+        "safety",
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: ENTRY_READINESS_SURFACE,
+      rowId: "safety",
+      ok: false,
+      destination: "safety",
+    });
+  });
+});

--- a/tests/live-version-cta-events-lib.test.ts
+++ b/tests/live-version-cta-events-lib.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  liveVersionBadgeAnalyticsData,
+  liveVersionBadgeAnalyticsEvent,
+} from "@/lib/live-version-cta-events-lib";
+
+describe("live version cta events lib", () => {
+  it("builds privacy-light live version badge analytics", () => {
+    expect(liveVersionBadgeAnalyticsEvent()).toBe("live_version_badge_click");
+    expect(liveVersionBadgeAnalyticsData("integrations-detail", true)).toEqual({
+      surface: "integrations-detail",
+      hasLiveVersion: true,
+    });
+    expect(liveVersionBadgeAnalyticsData("integration-card", false)).toEqual({
+      surface: "integration-card",
+      hasLiveVersion: false,
+    });
+  });
+});

--- a/tests/resource-card-cta-events-lib.test.ts
+++ b/tests/resource-card-cta-events-lib.test.ts
@@ -11,6 +11,8 @@ import {
   resourceCardInstallAnalyticsData,
   resourceCardInstallAnalyticsEvent,
   resourceCardInstallIntentType,
+  resourceCardTrustHintAnalyticsData,
+  resourceCardTrustHintAnalyticsEvent,
 } from "@/lib/resource-card-cta-events-lib";
 
 describe("resource card cta events lib", () => {
@@ -84,6 +86,25 @@ describe("resource card cta events lib", () => {
       variant: "grid",
       rank: null,
       compareCount: 0,
+    });
+    expect(resourceCardTrustHintAnalyticsEvent()).toBe(
+      "browse_card_trust_hint_click",
+    );
+    expect(
+      resourceCardTrustHintAnalyticsData(
+        "mcp",
+        "browser",
+        "stronger",
+        false,
+        1,
+        "browse-grid",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "browse-grid",
+      kind: "stronger",
+      inCompareTray: false,
+      compareCount: 1,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Opt-in navigable Trust/Source/Notes/Risk badge chrome on sticky meta + peek (browse filters / section scroll / platform links)
- Entry readiness rail rows scroll to dossier sections with privacy-light analytics
- Resource-card trust hints open the compare tray (moved outside nested grid links)
- Live npm version badges link out on integrations surfaces with click analytics

## Test plan
- [ ] On an entry dossier, use sticky trust/risk/notes chips; confirm browse/scroll works
- [ ] Open peek: category/trust/source/platform chips navigate; no nested-link console errors
- [ ] Click readiness rows in the rail; land on citation-facts / citations / safety / about
- [ ] With compare items selected, click a trust hint on browse cards; tray opens
- [ ] On `/integrations` card + detail, click the npm version badge

Refs #550

Made with [Cursor](https://cursor.com)