### PR TITLE
test(web): cover trust signal facet counting and option labels in browse-trust-filters-lib

### DIFF
--- a/tests/browse-trust-filters-facets.test.ts
+++ b/tests/browse-trust-filters-facets.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BROWSE_TRUST_SIGNAL_OPTIONS,
+  buildBrowseTrustSignalCounts,
+  buildBrowseTrustUtilityOptions,
+  type BrowseTrustSearchSlice,
+} from "../apps/web/src/lib/browse-trust-filters-lib";
+
+const emptySlice: BrowseTrustSearchSlice = {
+  q: "",
+  category: "",
+  trust: "",
+  source: "",
+  signal: "",
+  platform: "",
+  sort: "newest",
+};
+
+const fullSlice: BrowseTrustSearchSlice = {
+  q: "browser",
+  category: "mcp",
+  trust: "verified",
+  source: "available",
+  signal: "",
+  platform: "cursor",
+  sort: "popular",
+};
+
+function recordingCountFn() {
+  const calls: Record<string, unknown>[] = [];
+  const countFn = ((filters: Record<string, unknown>) => {
+    calls.push(filters);
+    return 1;
+  }) as never;
+  return { calls, countFn };
+}
+
+describe("browse-trust-filters-lib buildBrowseTrustSignalCounts", () => {
+  it("counts every trust signal option once", () => {
+    const { calls, countFn } = recordingCountFn();
+    const counts = buildBrowseTrustSignalCounts(fullSlice, countFn);
+    expect(calls).toHaveLength(BROWSE_TRUST_SIGNAL_OPTIONS.length);
+    expect(Object.keys(counts)).toEqual(
+      BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => option.id),
+    );
+    expect(calls.map((call) => call.signal)).toEqual(
+      BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => option.id),
+    );
+  });
+
+  it("wraps populated facets into arrays for the search filters", () => {
+    const { calls, countFn } = recordingCountFn();
+    buildBrowseTrustSignalCounts(fullSlice, countFn);
+    expect(calls[0]).toMatchObject({
+      q: "browser",
+      categories: ["mcp"],
+      trust: ["verified"],
+      source: ["available"],
+      platforms: ["cursor"],
+      sort: "popular",
+    });
+  });
+
+  it("omits blank facets instead of sending empty arrays", () => {
+    const { calls, countFn } = recordingCountFn();
+    buildBrowseTrustSignalCounts(emptySlice, countFn);
+    expect(calls[0].categories).toBeUndefined();
+    expect(calls[0].trust).toBeUndefined();
+    expect(calls[0].source).toBeUndefined();
+    expect(calls[0].platforms).toBeUndefined();
+  });
+});
+
+describe("browse-trust-filters-lib buildBrowseTrustUtilityOptions", () => {
+  it("prepends an all-signals option and labels each count", () => {
+    const options = buildBrowseTrustUtilityOptions({
+      "safety-notes": 3,
+    } as never);
+    expect(options[0]).toEqual({
+      id: "",
+      label: "All trust signals",
+      count: 0,
+    });
+    expect(options[1]).toEqual({
+      id: "safety-notes",
+      label: "Safety notes (3)",
+      count: 3,
+    });
+  });
+
+  it("defaults a missing count to zero", () => {
+    const options = buildBrowseTrustUtilityOptions({} as never);
+    const privacy = options.find((option) => option.id === "privacy-notes");
+    expect(privacy).toEqual({
+      id: "privacy-notes",
+      label: "Privacy notes (0)",
+      count: 0,
+    });
+  });
+});


### PR DESCRIPTION
Adds a new test file covering the facet-counting surface in `browse-trust-filters-lib` using an injected count function: `buildBrowseTrustSignalCounts` counting every trust signal option once and passing each option id through as the signal, wrapping populated facets (category/trust/source/platform) into arrays for the search filters, and omitting blank facets rather than sending empty arrays; plus `buildBrowseTrustUtilityOptions` prepending the all-signals option, labelling each option with its count, and defaulting a missing count to zero. Lib branch coverage 81.8% -> 93.9% (31/33); the two remaining arms are only reachable from an internal caller that always supplies a valid signal override. Test-only change; kept in its own file.