### PR TITLE
fix(web): rewire platform-category not-found egress analytics

### DIFF
--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -98,6 +98,12 @@ export const Route = createFileRoute("/for/$platform/$category")({
       <Link
         to="/for"
         className="mt-6 inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-4 font-medium text-background hover:opacity-90"
+        onClick={() =>
+          trackEvent(
+            platformCategoryNotFoundEgressAnalyticsEvent(),
+            platformCategoryNotFoundEgressAnalyticsData(),
+          )
+        }
       >
         All platforms <ArrowRight className="h-4 w-4" />
       </Link>


### PR DESCRIPTION
﻿## Summary
- Rewire privacy-light `platform_category_notfound_egress_click` on platform×category not-found "All platforms"
- Helpers were already imported/tested; the Link lost its `onClick` after duplicate-attribute cleanup on main

## Test plan
- [ ] Visit an empty `/for/$platform/$category` and click All platforms
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
