### PR TITLE
feat(web): add entry detail schema link analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -472,3 +472,25 @@ export function entryDetailCodeDisclosureAnalyticsData(
     open,
   };
 }
+
+export const ENTRY_DETAIL_SCHEMA_SURFACE = "detail-schema";
+
+export type EntryDetailSchemaLinkKind = "website" | "download";
+
+export function entryDetailSchemaLinkAnalyticsEvent(): string {
+  return "detail_schema_link_click";
+}
+
+export function entryDetailSchemaLinkAnalyticsData(
+  category: string,
+  slug: string,
+  kind: EntryDetailSchemaLinkKind,
+  host: string,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_SCHEMA_SURFACE,
+    kind,
+    host,
+  };
+}

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -9,6 +9,7 @@ export {
   ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
   ENTRY_DETAIL_MOBILE_SURFACE,
   ENTRY_DETAIL_RAIL_SURFACE,
+  ENTRY_DETAIL_SCHEMA_SURFACE,
   ENTRY_DETAIL_STICKY_META_SURFACE,
   browseCompareOpenAnalyticsData,
   browseCompareOpenAnalyticsEvent,
@@ -74,4 +75,7 @@ export {
   entryDetailCodeDisclosureAnalyticsData,
   entryDetailCodeDisclosureAnalyticsEvent,
   type EntryDetailCodeDisclosureKind,
+  entryDetailSchemaLinkAnalyticsData,
+  entryDetailSchemaLinkAnalyticsEvent,
+  type EntryDetailSchemaLinkKind,
 } from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -80,7 +80,7 @@ import { toast } from "sonner";
 import { useRecents } from "@/lib/recents";
 import { useCompare, useIsCompared } from "@/lib/compare";
 import { serializeCompareItems } from "@/lib/compare-selection";
-import { trackEvent } from "@/lib/analytics";
+import { trackEvent, outboundHost } from "@/lib/analytics";
 import {
   DOSSIER_TOC_CONTENT_OUTLINE_SURFACE,
   dossierTocSectionAnalyticsData,
@@ -114,6 +114,8 @@ import {
   entryDetailCitationPlainTextAnalyticsEvent,
   entryDetailCodeDisclosureAnalyticsData,
   entryDetailCodeDisclosureAnalyticsEvent,
+  entryDetailSchemaLinkAnalyticsData,
+  entryDetailSchemaLinkAnalyticsEvent,
   type EntryDetailCodeDisclosureKind,
 } from "@/lib/entry-detail-cta-events";
 import {
@@ -1279,7 +1281,22 @@ function SchemaDetails({ entry }: { entry: Entry }) {
         {(entry.downloadUrl || entry.packageVerified !== undefined || entry.downloadSha256) && (
           <MetadataGroup title="Package metadata" icon={Package}>
             <FieldGrid>
-              <FieldRow label="Download URL" value={entry.downloadUrl} href={entry.downloadUrl} />
+              <FieldRow
+                label="Download URL"
+                value={entry.downloadUrl}
+                href={entry.downloadUrl}
+                onLinkClick={() =>
+                  trackEvent(
+                    entryDetailSchemaLinkAnalyticsEvent(),
+                    entryDetailSchemaLinkAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      "download",
+                      outboundHost(entry.downloadUrl!),
+                    ),
+                  )
+                }
+              />
               <FieldRow label="Package verified" value={booleanLabel(entry.packageVerified)} />
               <FieldRow label="SHA-256" value={entry.downloadSha256} mono />
             </FieldGrid>
@@ -1384,7 +1401,22 @@ function SchemaDetails({ entry }: { entry: Entry }) {
           entry.operatingSystem) && (
           <MetadataGroup title="Tool listing metadata" icon={Globe2}>
             <FieldGrid>
-              <FieldRow label="Website" value={entry.websiteUrl} href={entry.websiteUrl} />
+              <FieldRow
+                label="Website"
+                value={entry.websiteUrl}
+                href={entry.websiteUrl}
+                onLinkClick={() =>
+                  trackEvent(
+                    entryDetailSchemaLinkAnalyticsEvent(),
+                    entryDetailSchemaLinkAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      "website",
+                      outboundHost(entry.websiteUrl!),
+                    ),
+                  )
+                }
+              />
               <FieldRow label="Pricing" value={entry.pricingModel} />
               <FieldRow label="Disclosure" value={entry.disclosure} />
               <FieldRow label="Application category" value={entry.applicationCategory} />
@@ -1434,11 +1466,13 @@ function FieldRow({
   value,
   href,
   mono,
+  onLinkClick,
 }: {
   label: string;
   value?: string;
   href?: string;
   mono?: boolean;
+  onLinkClick?: () => void;
 }) {
   if (!value) return null;
   return (
@@ -1446,7 +1480,13 @@ function FieldRow({
       <dt className="text-[10px] uppercase tracking-wider text-ink-subtle">{label}</dt>
       <dd className={cn("mt-0.5 break-words text-sm text-ink", mono && "font-mono text-xs")}>
         {href ? (
-          <a href={href} target="_blank" rel="noreferrer" className="hover:underline">
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className="hover:underline"
+            onClick={onLinkClick}
+          >
             {value}
           </a>
         ) : (

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -62,7 +62,10 @@ import {
   entryDetailCitationPlainTextAnalyticsEvent,
   entryDetailCodeDisclosureAnalyticsData,
   entryDetailCodeDisclosureAnalyticsEvent,
+  entryDetailSchemaLinkAnalyticsData,
+  entryDetailSchemaLinkAnalyticsEvent,
   ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+  ENTRY_DETAIL_SCHEMA_SURFACE,
 } from "@/lib/entry-detail-cta-events-lib";
 
 describe("entry detail cta events lib", () => {
@@ -473,6 +476,35 @@ describe("entry detail cta events lib", () => {
       surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
       kind: "full-copy",
       open: true,
+    });
+    expect(entryDetailSchemaLinkAnalyticsEvent()).toBe(
+      "detail_schema_link_click",
+    );
+    expect(
+      entryDetailSchemaLinkAnalyticsData(
+        "tools",
+        "demo",
+        "website",
+        "example.com",
+      ),
+    ).toEqual({
+      entry: "tools/demo",
+      surface: ENTRY_DETAIL_SCHEMA_SURFACE,
+      kind: "website",
+      host: "example.com",
+    });
+    expect(
+      entryDetailSchemaLinkAnalyticsData(
+        "mcp",
+        "browser",
+        "download",
+        "cdn.example.com",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_DETAIL_SCHEMA_SURFACE,
+      kind: "download",
+      host: "cdn.example.com",
     });
   });
 });


### PR DESCRIPTION
﻿## Summary
- Wire privacy-light `detail_schema_link_click` on schema Website and Download URL links
- Payload: `{ entry, surface: "detail-schema", kind: "website" | "download", host }` (no URLs)

## Test plan
- [ ] Vitest covers schema link helpers
- [ ] Click Website / Download URL on an entry schema section
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
