### PR TITLE
feat(web): add entry header source badge browse analytics

### DIFF
--- a/apps/web/src/lib/badge-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events-lib.ts
@@ -5,7 +5,7 @@
  * names without embedding titles or free-form note copy.
  */
 
-export type BadgeChromeSurface = "detail-sticky-meta" | "peek-panel";
+export type BadgeChromeSurface = "detail-sticky-meta" | "peek-panel" | "detail-header";
 
 export type BadgeChromeNoteKind = "safety" | "privacy";
 

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -82,6 +82,10 @@ import { useCompare, useIsCompared } from "@/lib/compare";
 import { serializeCompareItems } from "@/lib/compare-selection";
 import { trackEvent, outboundHost } from "@/lib/analytics";
 import {
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
+import {
   DOSSIER_TOC_CONTENT_OUTLINE_SURFACE,
   dossierTocSectionAnalyticsData,
   dossierTocSectionAnalyticsEvent,
@@ -636,7 +640,16 @@ function Dossier() {
           <div className="flex flex-wrap items-center gap-2">
             <CategoryPill>{entry.category}</CategoryPill>
             <TrustDrilldown entry={entry} />
-            <SourceBadge status={entry.source} />
+            <SourceBadge
+              status={entry.source}
+              asLink
+              onNavigate={() =>
+                trackEvent(
+                  badgeChromeSourceAnalyticsEvent(),
+                  badgeChromeSourceAnalyticsData(entry.source, "detail-header"),
+                )
+              }
+            />
             <InstallRiskBadge entry={entry} />
             <NotesPresenceChips entry={entry} className="ml-1" />
             {entry.claimed && (

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -28,6 +28,12 @@ describe("badge chrome cta events lib", () => {
       surface: "peek-panel",
       source: "source-backed",
     });
+    expect(
+      badgeChromeSourceAnalyticsData("first-party", "detail-header"),
+    ).toEqual({
+      surface: "detail-header",
+      source: "first-party",
+    });
     expect(badgeChromeCategoryAnalyticsEvent()).toBe(
       "badge_category_browse_click",
     );


### PR DESCRIPTION
﻿## Summary
- Make entry header `SourceBadge` navigable (`asLink`) with privacy-light analytics
- Event: `badge_source_browse_click`
- Payload: `{ surface: "detail-header", source }` (no titles/URLs)

## Test plan
- [ ] Vitest covers `detail-header` surface
- [ ] Click SourceBadge on an entry detail header
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
