### PR TITLE
feat(web): add hub, browse, and compare signal drill-down analytics

### DIFF
--- a/apps/web/src/components/badges.tsx
+++ b/apps/web/src/components/badges.tsx
@@ -30,6 +30,10 @@ import {
   platformChipAnalyticsEvent,
 } from "@/lib/platform-chip-cta-events";
 import {
+  categoryPillAnalyticsData,
+  categoryPillAnalyticsEvent,
+} from "@/lib/category-pill-cta-events";
+import {
   installRiskLevel,
   INSTALL_RISK_LABEL,
   INSTALL_RISK_DETAIL,
@@ -141,7 +145,16 @@ export function SourceBadge({
   return <span className={classes}>{content}</span>;
 }
 
-export function PlatformChip({ id, asLink = false }: { id: Platform; asLink?: boolean }) {
+export function PlatformChip({
+  id,
+  asLink = false,
+  surface,
+}: {
+  id: Platform;
+  asLink?: boolean;
+  /** Optional analytics surface when asLink is set. */
+  surface?: string;
+}) {
   const mark = platformMark(id);
   const base =
     "inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border px-2 py-0.5 font-mono text-[10px] leading-none text-ink-muted";
@@ -158,7 +171,9 @@ export function PlatformChip({ id, asLink = false }: { id: Platform; asLink?: bo
         to="/for/$platform"
         params={{ platform: id }}
         className={cn(base, "transition-colors hover:border-ink/20 hover:text-ink")}
-        onClick={() => trackEvent(platformChipAnalyticsEvent(), platformChipAnalyticsData(id))}
+        onClick={() =>
+          trackEvent(platformChipAnalyticsEvent(), platformChipAnalyticsData(id, surface))
+        }
       >
         {content}
       </Link>
@@ -170,20 +185,41 @@ export function PlatformChip({ id, asLink = false }: { id: Platform; asLink?: bo
 export function CategoryPill({
   children,
   className,
+  asLink = false,
+  category,
+  surface,
+  onNavigate,
 }: {
   children: React.ReactNode;
   className?: string;
+  /** Opt-in browse link — never use inside card `<Link>`s. */
+  asLink?: boolean;
+  category?: string;
+  surface?: "compare-table" | "compare-drawer";
+  onNavigate?: () => void;
 }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center whitespace-nowrap rounded-md bg-ink px-2 py-0.5 font-mono text-[10px] uppercase leading-none tracking-wider text-background",
-        className,
-      )}
-    >
-      {children}
-    </span>
+  const classes = cn(
+    "inline-flex items-center whitespace-nowrap rounded-md bg-ink px-2 py-0.5 font-mono text-[10px] uppercase leading-none tracking-wider text-background",
+    className,
   );
+  if (asLink && category) {
+    return (
+      <Link
+        to="/browse"
+        search={{ category }}
+        onClick={() => {
+          onNavigate?.();
+          if (surface) {
+            trackEvent(categoryPillAnalyticsEvent(), categoryPillAnalyticsData(category, surface));
+          }
+        }}
+        className={cn(classes, "transition-opacity hover:opacity-90")}
+      >
+        {children}
+      </Link>
+    );
+  }
+  return <span className={classes}>{children}</span>;
 }
 
 export function Kbd({ children }: { children: React.ReactNode }) {

--- a/apps/web/src/components/browse-results-trust-panel.tsx
+++ b/apps/web/src/components/browse-results-trust-panel.tsx
@@ -5,6 +5,13 @@ import {
   browseCompareOpenAnalyticsData,
   browseCompareOpenAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
+import {
+  browseTrustCoverageFilterAnalyticsData,
+  browseTrustCoverageFilterAnalyticsEvent,
+  browseTrustCoverageSignal,
+  browseTrustLevelFilterAnalyticsData,
+  browseTrustLevelFilterAnalyticsEvent,
+} from "@/lib/browse-trust-panel-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
@@ -24,10 +31,14 @@ type CompareLink = {
 export function BrowseResultsTrustPanel({
   state,
   compareLink,
+  onTrustLevelSelect,
+  onCoverageSelect,
   className,
 }: {
   state: Extract<BrowseResultsTrustDecisionUiState, { showPanel: true }>;
   compareLink?: CompareLink | null;
+  onTrustLevelSelect?: (level: string) => void;
+  onCoverageSelect?: (coverageId: string, signal: string) => void;
   className?: string;
 }) {
   const hint = state.decisionHint ?? state.compareNudge;
@@ -47,14 +58,45 @@ export function BrowseResultsTrustPanel({
           </p>
           {state.hasMixedTrust ? (
             <div className="mt-2 flex flex-wrap gap-1.5">
-              {state.trustLevels.map((item) => (
-                <span
-                  key={item.level}
-                  className="inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] font-medium capitalize text-ink"
-                >
-                  {item.count} {item.level}
-                </span>
-              ))}
+              {state.trustLevels.map((item) => {
+                const chip = (
+                  <>
+                    {item.count} {item.level}
+                  </>
+                );
+                const classes =
+                  "inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] font-medium capitalize text-ink";
+                if (onTrustLevelSelect) {
+                  return (
+                    <button
+                      key={item.level}
+                      type="button"
+                      onClick={() => {
+                        trackEvent(
+                          browseTrustLevelFilterAnalyticsEvent(),
+                          browseTrustLevelFilterAnalyticsData(
+                            item.level,
+                            item.count,
+                            state.resultCount,
+                          ),
+                        );
+                        onTrustLevelSelect(item.level);
+                      }}
+                      className={cn(
+                        classes,
+                        "transition-colors hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+                      )}
+                    >
+                      {chip}
+                    </button>
+                  );
+                }
+                return (
+                  <span key={item.level} className={classes}>
+                    {chip}
+                  </span>
+                );
+              })}
             </div>
           ) : null}
         </div>
@@ -80,18 +122,17 @@ export function BrowseResultsTrustPanel({
       <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
         {state.coverage.map((chip) => {
           const Icon = COVERAGE_ICONS[chip.id as keyof typeof COVERAGE_ICONS] ?? Shield;
-          return (
-            <div
-              key={chip.id}
-              className={cn(
-                "rounded-lg border px-3 py-2",
-                chip.emphasis === "high"
-                  ? "border-trust-trusted/30 bg-trust-trusted/5"
-                  : chip.emphasis === "low"
-                    ? "border-trust-review/30 bg-trust-review/5"
-                    : "border-border bg-background",
-              )}
-            >
+          const signal = browseTrustCoverageSignal(chip.id);
+          const classes = cn(
+            "rounded-lg border px-3 py-2 text-left",
+            chip.emphasis === "high"
+              ? "border-trust-trusted/30 bg-trust-trusted/5"
+              : chip.emphasis === "low"
+                ? "border-trust-review/30 bg-trust-review/5"
+                : "border-border bg-background",
+          );
+          const body = (
+            <>
               <div className="flex items-center gap-1.5 text-[11px] font-medium text-ink">
                 <Icon className="h-3.5 w-3.5 text-ink-muted" aria-hidden />
                 {chip.label}
@@ -102,6 +143,37 @@ export function BrowseResultsTrustPanel({
                   ({chip.count}/{chip.total})
                 </span>
               </div>
+            </>
+          );
+          if (onCoverageSelect && signal) {
+            return (
+              <button
+                key={chip.id}
+                type="button"
+                onClick={() => {
+                  trackEvent(
+                    browseTrustCoverageFilterAnalyticsEvent(),
+                    browseTrustCoverageFilterAnalyticsData(
+                      chip.id,
+                      chip.count,
+                      chip.percent,
+                      state.resultCount,
+                    ),
+                  );
+                  onCoverageSelect(chip.id, signal);
+                }}
+                className={cn(
+                  classes,
+                  "transition-colors hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+                )}
+              >
+                {body}
+              </button>
+            );
+          }
+          return (
+            <div key={chip.id} className={classes}>
+              {body}
             </div>
           );
         })}

--- a/apps/web/src/components/browse-rollout-signals-panel.tsx
+++ b/apps/web/src/components/browse-rollout-signals-panel.tsx
@@ -4,6 +4,9 @@ import type { BrowseRolloutSignalsState } from "@/lib/browse-rollout-signals";
 import {
   browseRolloutFlaggedEntryAnalyticsData,
   browseRolloutFlaggedEntryAnalyticsEvent,
+  browseRolloutSignalRowAnalyticsData,
+  browseRolloutSignalRowAnalyticsEvent,
+  browseRolloutSignalSearch,
   parseBrowseRolloutEntryRef,
 } from "@/lib/browse-rollout-cta-events";
 import { trackEvent } from "@/lib/analytics";
@@ -11,9 +14,11 @@ import { cn } from "@/lib/utils";
 
 export function BrowseRolloutSignalsPanel({
   state,
+  onSignalRowSelect,
   className,
 }: {
   state: BrowseRolloutSignalsState;
+  onSignalRowSelect?: (signalId: string, patch: { signal?: string; source?: string }) => void;
   className?: string;
 }) {
   if (!state.showPanel) return null;
@@ -31,27 +36,58 @@ export function BrowseRolloutSignalsPanel({
       </div>
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
-        {state.rows.map((row) => (
-          <article key={row.id} className="rounded-md border border-border bg-background p-2.5">
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <p className="text-xs font-medium text-ink">{row.label}</p>
-                <p className="mt-0.5 text-[11px] text-ink-muted">{row.message}</p>
+        {state.rows.map((row) => {
+          const patch = browseRolloutSignalSearch(row.id);
+          const body = (
+            <>
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-ink">{row.label}</p>
+                  <p className="mt-0.5 text-[11px] text-ink-muted">{row.message}</p>
+                </div>
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                    toneClass(row.tone),
+                  )}
+                >
+                  {row.tone}
+                </span>
               </div>
-              <span
-                className={cn(
-                  "inline-flex rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
-                  toneClass(row.tone),
-                )}
+              <p className="mt-1.5 font-mono text-[11px] text-ink">
+                {row.coveragePercent}% ({row.presentCount}/{row.presentCount + row.missingCount})
+              </p>
+            </>
+          );
+          if (onSignalRowSelect && patch) {
+            return (
+              <button
+                key={row.id}
+                type="button"
+                onClick={() => {
+                  trackEvent(
+                    browseRolloutSignalRowAnalyticsEvent(),
+                    browseRolloutSignalRowAnalyticsData(
+                      row.id,
+                      row.tone,
+                      row.coveragePercent,
+                      state.scannedCount,
+                    ),
+                  );
+                  onSignalRowSelect(row.id, patch);
+                }}
+                className="rounded-md border border-border bg-background p-2.5 text-left transition-colors hover:border-ink/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
               >
-                {row.tone}
-              </span>
-            </div>
-            <p className="mt-1.5 font-mono text-[11px] text-ink">
-              {row.coveragePercent}% ({row.presentCount}/{row.presentCount + row.missingCount})
-            </p>
-          </article>
-        ))}
+                {body}
+              </button>
+            );
+          }
+          return (
+            <article key={row.id} className="rounded-md border border-border bg-background p-2.5">
+              {body}
+            </article>
+          );
+        })}
       </div>
 
       {state.flaggedEntries.length > 0 ? (

--- a/apps/web/src/components/category-ranking-table.tsx
+++ b/apps/web/src/components/category-ranking-table.tsx
@@ -80,7 +80,7 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                 <td className="px-3 py-2.5 align-top">
                   <div className="flex flex-wrap gap-1">
                     {e.platforms.slice(0, 3).map((p) => (
-                      <PlatformChip key={p} id={p} />
+                      <PlatformChip key={p} id={p} asLink surface="category-ranking" />
                     ))}
                     {e.platforms.length > 3 ? (
                       <span className="text-xs text-ink-subtle">+{e.platforms.length - 3}</span>

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -191,7 +191,11 @@ const ROWS: RowDef[] = [
   },
   {
     label: "Category",
-    render: (e) => <CategoryPill>{e.category}</CategoryPill>,
+    render: (e) => (
+      <CategoryPill asLink category={e.category} surface="compare-drawer">
+        {e.category}
+      </CategoryPill>
+    ),
   },
   {
     label: "Author",
@@ -202,7 +206,7 @@ const ROWS: RowDef[] = [
     render: (e) => (
       <div className="flex flex-wrap gap-1">
         {e.platforms.map((p) => (
-          <PlatformChip key={p} id={p} />
+          <PlatformChip key={p} id={p} asLink surface="compare-drawer" />
         ))}
       </div>
     ),

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -181,7 +181,14 @@ export const COMPARISON_ROWS: RowDef[] = [
       );
     },
   },
-  { label: "Category", render: (e) => <CategoryPill>{e.category}</CategoryPill> },
+  {
+    label: "Category",
+    render: (e) => (
+      <CategoryPill asLink category={e.category} surface="compare-table">
+        {e.category}
+      </CategoryPill>
+    ),
+  },
   {
     label: "Source",
     render: (e) => <span className="text-sm capitalize text-ink">{e.source}</span>,
@@ -196,7 +203,7 @@ export const COMPARISON_ROWS: RowDef[] = [
     render: (e) => (
       <div className="flex flex-wrap gap-1">
         {e.platforms.map((p) => (
-          <PlatformChip key={p} id={p} />
+          <PlatformChip key={p} id={p} asLink surface="compare-table" />
         ))}
       </div>
     ),

--- a/apps/web/src/components/hub-highlights.tsx
+++ b/apps/web/src/components/hub-highlights.tsx
@@ -15,6 +15,14 @@ import {
   hubHighlightEntryAnalyticsData,
   hubHighlightEntryAnalyticsEvent,
 } from "@/lib/hub-entry-cta-events";
+import {
+  hubSignalStatAnalyticsData,
+  hubSignalStatAnalyticsEvent,
+  hubStatBrowseSearch,
+  type HubSignalBrowseSearch,
+  type HubSignalSurface,
+} from "@/lib/hub-signal-cta-events";
+import { cn } from "@/lib/utils";
 
 const HIGHLIGHT_ICON: Record<HighlightKind, LucideIcon> = {
   trusted: ShieldCheck,
@@ -86,9 +94,17 @@ export function HubHighlights({
   );
 }
 
-function StatBar({ stat }: { stat: HubStat }) {
-  return (
-    <div className="rounded-xl border border-border bg-surface p-4">
+function StatBar({
+  stat,
+  browseSearch,
+  surface,
+}: {
+  stat: HubStat;
+  browseSearch: HubSignalBrowseSearch | null;
+  surface?: HubSignalSurface;
+}) {
+  const body = (
+    <>
       <div className="flex items-baseline justify-between gap-2">
         <span className="text-xs font-medium text-ink-muted">{stat.label}</span>
         <span className="font-mono text-[11px] tabular-nums text-ink-subtle">{stat.pct}%</span>
@@ -99,8 +115,30 @@ function StatBar({ stat }: { stat: HubStat }) {
       <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-surface-2">
         <div className="h-full bg-ink" style={{ width: `${stat.pct}%` }} />
       </div>
-    </div>
+    </>
   );
+
+  if (browseSearch && surface) {
+    return (
+      <Link
+        to="/browse"
+        search={browseSearch}
+        onClick={() =>
+          trackEvent(
+            hubSignalStatAnalyticsEvent(),
+            hubSignalStatAnalyticsData(surface, stat.key, stat.count, stat.pct),
+          )
+        }
+        className={cn(
+          "block rounded-xl border border-border bg-surface p-4 transition-colors hover:border-ink/20 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+        )}
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className="rounded-xl border border-border bg-surface p-4">{body}</div>;
 }
 
 /**
@@ -108,7 +146,17 @@ function StatBar({ stat }: { stat: HubStat }) {
  * notes, review status. Every number is counted from the entries actually on the page,
  * so no two hubs render the same breakdown unless their data is genuinely identical.
  */
-export function HubSignalStats({ stats, total }: { stats: HubStat[]; total: number }) {
+export function HubSignalStats({
+  stats,
+  total,
+  surface,
+  browseBase,
+}: {
+  stats: HubStat[];
+  total: number;
+  surface?: HubSignalSurface;
+  browseBase?: { category?: string; platform?: string; q?: string };
+}) {
   if (stats.length === 0 || total < 2) return null;
   return (
     <section className="mt-12">
@@ -119,7 +167,12 @@ export function HubSignalStats({ stats, total }: { stats: HubStat[]; total: numb
       </p>
       <div className="mt-5 grid gap-3 sm:grid-cols-3 lg:grid-cols-5">
         {stats.map((s) => (
-          <StatBar key={s.key} stat={s} />
+          <StatBar
+            key={s.key}
+            stat={s}
+            surface={surface}
+            browseSearch={surface ? hubStatBrowseSearch(s.key, browseBase) : null}
+          />
         ))}
       </div>
     </section>

--- a/apps/web/src/lib/browse-rollout-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-rollout-cta-events-lib.ts
@@ -36,3 +36,42 @@ export function parseBrowseRolloutEntryRef(
     slug: entryRef.slice(slash + 1),
   };
 }
+
+export function browseRolloutSignalRowAnalyticsEvent(): string {
+  return "browse_rollout_signal_row_click";
+}
+
+export function browseRolloutSignalRowAnalyticsData(
+  signalId: string,
+  tone: string,
+  coveragePercent: number,
+  scannedCount: number,
+) {
+  return {
+    surface: BROWSE_ROLLOUT_SIGNALS_SURFACE,
+    signalId,
+    tone,
+    coveragePercent,
+    scannedCount,
+  };
+}
+
+/** Map rollout row ids to browse `signal` (or `source`) search values. */
+export function browseRolloutSignalSearch(
+  signalId: string,
+): { signal?: string; source?: string } | null {
+  switch (signalId) {
+    case "source":
+      return { signal: "source-backed" };
+    case "reviewed":
+      return { signal: "reviewed" };
+    case "safety":
+      return { signal: "safety-notes" };
+    case "privacy":
+      return { signal: "privacy-notes" };
+    case "package":
+      return { signal: "trusted-package" };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/browse-rollout-cta-events.ts
+++ b/apps/web/src/lib/browse-rollout-cta-events.ts
@@ -5,5 +5,8 @@ export {
   BROWSE_ROLLOUT_SIGNALS_SURFACE,
   browseRolloutFlaggedEntryAnalyticsData,
   browseRolloutFlaggedEntryAnalyticsEvent,
+  browseRolloutSignalRowAnalyticsData,
+  browseRolloutSignalRowAnalyticsEvent,
+  browseRolloutSignalSearch,
   parseBrowseRolloutEntryRef,
 } from "@/lib/browse-rollout-cta-events-lib";

--- a/apps/web/src/lib/browse-trust-panel-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-trust-panel-cta-events-lib.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure browse trust-panel chip analytics helpers.
+ *
+ * Maps trust-level and coverage chip filter refinements to privacy-light event
+ * names without embedding titles or free-form coverage copy.
+ */
+
+export const BROWSE_TRUST_PANEL_SURFACE = "browse-trust-panel";
+
+export function browseTrustLevelFilterAnalyticsEvent(): string {
+  return "browse_trust_level_filter_click";
+}
+
+export function browseTrustLevelFilterAnalyticsData(
+  level: string,
+  count: number,
+  resultCount: number,
+) {
+  return {
+    surface: BROWSE_TRUST_PANEL_SURFACE,
+    level,
+    count,
+    resultCount,
+  };
+}
+
+export function browseTrustCoverageFilterAnalyticsEvent(): string {
+  return "browse_trust_coverage_filter_click";
+}
+
+export function browseTrustCoverageFilterAnalyticsData(
+  coverageId: string,
+  count: number,
+  percent: number,
+  resultCount: number,
+) {
+  return {
+    surface: BROWSE_TRUST_PANEL_SURFACE,
+    coverageId,
+    count,
+    percent,
+    resultCount,
+  };
+}
+
+/** Map trust-panel coverage chip ids to browse `signal` search values. */
+export function browseTrustCoverageSignal(coverageId: string): string | null {
+  switch (coverageId) {
+    case "safety":
+      return "safety-notes";
+    case "privacy":
+      return "privacy-notes";
+    case "reviewed":
+      return "reviewed";
+    case "source-backed":
+      return "source-backed";
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/browse-trust-panel-cta-events.ts
+++ b/apps/web/src/lib/browse-trust-panel-cta-events.ts
@@ -1,0 +1,11 @@
+/**
+ * Browse trust-panel CTA event surface.
+ */
+export {
+  BROWSE_TRUST_PANEL_SURFACE,
+  browseTrustCoverageFilterAnalyticsData,
+  browseTrustCoverageFilterAnalyticsEvent,
+  browseTrustCoverageSignal,
+  browseTrustLevelFilterAnalyticsData,
+  browseTrustLevelFilterAnalyticsEvent,
+} from "@/lib/browse-trust-panel-cta-events-lib";

--- a/apps/web/src/lib/category-pill-cta-events-lib.ts
+++ b/apps/web/src/lib/category-pill-cta-events-lib.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure category pill navigation analytics helpers.
+ *
+ * Maps opt-in category pill browse egress to privacy-light event names without
+ * embedding titles.
+ */
+
+export type CategoryPillSurface = "compare-table" | "compare-drawer";
+
+export function categoryPillAnalyticsEvent(): string {
+  return "category_pill_click";
+}
+
+export function categoryPillAnalyticsData(category: string, surface: CategoryPillSurface) {
+  return {
+    surface,
+    category,
+  };
+}

--- a/apps/web/src/lib/category-pill-cta-events.ts
+++ b/apps/web/src/lib/category-pill-cta-events.ts
@@ -1,0 +1,8 @@
+/**
+ * Category pill CTA event surface.
+ */
+export {
+  categoryPillAnalyticsData,
+  categoryPillAnalyticsEvent,
+  type CategoryPillSurface,
+} from "@/lib/category-pill-cta-events-lib";

--- a/apps/web/src/lib/hub-signal-cta-events-lib.ts
+++ b/apps/web/src/lib/hub-signal-cta-events-lib.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure hub signal-stat navigation analytics helpers.
+ *
+ * Maps hub coverage bars to privacy-light browse egress without embedding
+ * hub titles or free-form labels beyond stable stat keys.
+ */
+
+export type HubSignalSurface = "category-hub" | "platform-hub" | "tag-hub";
+
+export type HubSignalStatKey = "trusted" | "sourced" | "safety" | "privacy" | "reviewed";
+
+export type HubSignalBrowseSearch = {
+  category?: string;
+  platform?: string;
+  q?: string;
+  trust?: string;
+  signal?: string;
+};
+
+export function hubSignalStatAnalyticsEvent(): string {
+  return "hub_signal_stat_click";
+}
+
+export function hubSignalStatAnalyticsData(
+  surface: HubSignalSurface,
+  statKey: string,
+  count: number,
+  pct: number,
+) {
+  return {
+    surface,
+    statKey,
+    count,
+    pct,
+  };
+}
+
+export function hubStatBrowseSearch(
+  statKey: string,
+  base: { category?: string; platform?: string; q?: string } = {},
+): HubSignalBrowseSearch | null {
+  switch (statKey) {
+    case "trusted":
+      return { ...base, trust: "trusted" };
+    case "sourced":
+      return { ...base, signal: "source-backed" };
+    case "safety":
+      return { ...base, signal: "safety-notes" };
+    case "privacy":
+      return { ...base, signal: "privacy-notes" };
+    case "reviewed":
+      return { ...base, signal: "reviewed" };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/hub-signal-cta-events.ts
+++ b/apps/web/src/lib/hub-signal-cta-events.ts
@@ -1,0 +1,11 @@
+/**
+ * Hub signal-stat CTA event surface.
+ */
+export {
+  hubSignalStatAnalyticsData,
+  hubSignalStatAnalyticsEvent,
+  hubStatBrowseSearch,
+  type HubSignalBrowseSearch,
+  type HubSignalStatKey,
+  type HubSignalSurface,
+} from "@/lib/hub-signal-cta-events-lib";

--- a/apps/web/src/lib/platform-chip-cta-events-lib.ts
+++ b/apps/web/src/lib/platform-chip-cta-events-lib.ts
@@ -11,9 +11,12 @@ export function platformChipAnalyticsEvent(): string {
   return "platform_chip_click";
 }
 
-export function platformChipAnalyticsData(platform: string) {
+export function platformChipAnalyticsData(
+  platform: string,
+  surface: string = PLATFORM_CHIP_SURFACE,
+) {
   return {
-    surface: PLATFORM_CHIP_SURFACE,
+    surface,
     platform,
   };
 }

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -220,7 +220,12 @@ function CategoryHub() {
 
       <CategoryRankingTable entries={entries.slice(0, 12)} label={label} />
 
-      <HubSignalStats stats={stats} total={entries.length} />
+      <HubSignalStats
+        stats={stats}
+        total={entries.length}
+        surface="category-hub"
+        browseBase={{ category: id }}
+      />
 
       <section className="mt-14">
         <h2 className="h-display-2 text-ink">Frequently asked</h2>

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -1079,10 +1079,22 @@ function Browse() {
                     }
                   : null
               }
+              onTrustLevelSelect={(level) => set({ trust: level === sp.trust ? "" : level })}
+              onCoverageSelect={(_coverageId, signal) =>
+                set({ signal: signal === sp.signal ? "" : signal })
+              }
               className="mt-3"
             />
           ) : null}
-          <BrowseRolloutSignalsPanel state={browseRolloutSignals} className="mt-3" />
+          <BrowseRolloutSignalsPanel
+            state={browseRolloutSignals}
+            onSignalRowSelect={(_signalId, patch) => {
+              if (patch.signal != null) {
+                set({ signal: patch.signal === sp.signal ? "" : patch.signal });
+              }
+            }}
+            className="mt-3"
+          />
           <BrowseAdoptionQueuePanel
             state={browseAdoptionQueue}
             selectedPreset={adoptionPreset}

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -144,7 +144,12 @@ function PlatformPage() {
         caption={`Standout ${label}-compatible resources, picked from their own metadata — trust tier, provenance, documentation, and recency.`}
       />
 
-      <HubSignalStats stats={stats} total={all.length} />
+      <HubSignalStats
+        stats={stats}
+        total={all.length}
+        surface="platform-hub"
+        browseBase={{ platform }}
+      />
 
       {sections.map((section, rowIndex) => (
         <section key={section.category.id} className="mt-12">

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -183,7 +183,12 @@ function TagHub() {
         ))}
       </div>
 
-      <HubSignalStats stats={stats} total={entries.length} />
+      <HubSignalStats
+        stats={stats}
+        total={entries.length}
+        surface="tag-hub"
+        browseBase={{ q: group.slug }}
+      />
 
       <NewsletterInline
         variant="quiet"

--- a/tests/browse-rollout-cta-events-lib.test.ts
+++ b/tests/browse-rollout-cta-events-lib.test.ts
@@ -45,6 +45,18 @@ describe("browse rollout cta events lib", () => {
     expect(browseRolloutSignalSearch("safety")).toEqual({
       signal: "safety-notes",
     });
+    expect(browseRolloutSignalSearch("source")).toEqual({
+      signal: "source-backed",
+    });
+    expect(browseRolloutSignalSearch("reviewed")).toEqual({
+      signal: "reviewed",
+    });
+    expect(browseRolloutSignalSearch("privacy")).toEqual({
+      signal: "privacy-notes",
+    });
+    expect(browseRolloutSignalSearch("package")).toEqual({
+      signal: "trusted-package",
+    });
     expect(browseRolloutSignalSearch("install")).toBeNull();
   });
 });

--- a/tests/browse-rollout-cta-events-lib.test.ts
+++ b/tests/browse-rollout-cta-events-lib.test.ts
@@ -3,6 +3,9 @@ import {
   BROWSE_ROLLOUT_SIGNALS_SURFACE,
   browseRolloutFlaggedEntryAnalyticsData,
   browseRolloutFlaggedEntryAnalyticsEvent,
+  browseRolloutSignalRowAnalyticsData,
+  browseRolloutSignalRowAnalyticsEvent,
+  browseRolloutSignalSearch,
   parseBrowseRolloutEntryRef,
 } from "@/lib/browse-rollout-cta-events-lib";
 
@@ -24,5 +27,24 @@ describe("browse rollout cta events lib", () => {
       slug: "browser",
     });
     expect(parseBrowseRolloutEntryRef("invalid")).toBeNull();
+  });
+
+  it("maps rollout rows to browse signal search patches", () => {
+    expect(browseRolloutSignalRowAnalyticsEvent()).toBe(
+      "browse_rollout_signal_row_click",
+    );
+    expect(
+      browseRolloutSignalRowAnalyticsData("safety", "watch", 40, 12),
+    ).toEqual({
+      surface: BROWSE_ROLLOUT_SIGNALS_SURFACE,
+      signalId: "safety",
+      tone: "watch",
+      coveragePercent: 40,
+      scannedCount: 12,
+    });
+    expect(browseRolloutSignalSearch("safety")).toEqual({
+      signal: "safety-notes",
+    });
+    expect(browseRolloutSignalSearch("install")).toBeNull();
   });
 });

--- a/tests/browse-trust-panel-cta-events-lib.test.ts
+++ b/tests/browse-trust-panel-cta-events-lib.test.ts
@@ -32,6 +32,9 @@ describe("browse trust panel cta events lib", () => {
       },
     );
     expect(browseTrustCoverageSignal("safety")).toBe("safety-notes");
+    expect(browseTrustCoverageSignal("privacy")).toBe("privacy-notes");
+    expect(browseTrustCoverageSignal("reviewed")).toBe("reviewed");
+    expect(browseTrustCoverageSignal("source-backed")).toBe("source-backed");
     expect(browseTrustCoverageSignal("claimed")).toBeNull();
   });
 });

--- a/tests/browse-trust-panel-cta-events-lib.test.ts
+++ b/tests/browse-trust-panel-cta-events-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSE_TRUST_PANEL_SURFACE,
+  browseTrustCoverageFilterAnalyticsData,
+  browseTrustCoverageFilterAnalyticsEvent,
+  browseTrustCoverageSignal,
+  browseTrustLevelFilterAnalyticsData,
+  browseTrustLevelFilterAnalyticsEvent,
+} from "@/lib/browse-trust-panel-cta-events-lib";
+
+describe("browse trust panel cta events lib", () => {
+  it("builds privacy-light trust panel filter analytics", () => {
+    expect(browseTrustLevelFilterAnalyticsEvent()).toBe(
+      "browse_trust_level_filter_click",
+    );
+    expect(browseTrustLevelFilterAnalyticsData("trusted", 4, 20)).toEqual({
+      surface: BROWSE_TRUST_PANEL_SURFACE,
+      level: "trusted",
+      count: 4,
+      resultCount: 20,
+    });
+    expect(browseTrustCoverageFilterAnalyticsEvent()).toBe(
+      "browse_trust_coverage_filter_click",
+    );
+    expect(browseTrustCoverageFilterAnalyticsData("safety", 8, 40, 20)).toEqual(
+      {
+        surface: BROWSE_TRUST_PANEL_SURFACE,
+        coverageId: "safety",
+        count: 8,
+        percent: 40,
+        resultCount: 20,
+      },
+    );
+    expect(browseTrustCoverageSignal("safety")).toBe("safety-notes");
+    expect(browseTrustCoverageSignal("claimed")).toBeNull();
+  });
+});

--- a/tests/category-pill-cta-events-lib.test.ts
+++ b/tests/category-pill-cta-events-lib.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  categoryPillAnalyticsData,
+  categoryPillAnalyticsEvent,
+} from "@/lib/category-pill-cta-events-lib";
+
+describe("category pill cta events lib", () => {
+  it("builds privacy-light category pill analytics", () => {
+    expect(categoryPillAnalyticsEvent()).toBe("category_pill_click");
+    expect(categoryPillAnalyticsData("mcp", "compare-table")).toEqual({
+      surface: "compare-table",
+      category: "mcp",
+    });
+    expect(categoryPillAnalyticsData("skills", "compare-drawer")).toEqual({
+      surface: "compare-drawer",
+      category: "skills",
+    });
+  });
+});

--- a/tests/hub-signal-cta-events-lib.test.ts
+++ b/tests/hub-signal-cta-events-lib.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  hubSignalStatAnalyticsData,
+  hubSignalStatAnalyticsEvent,
+  hubStatBrowseSearch,
+} from "@/lib/hub-signal-cta-events-lib";
+
+describe("hub signal cta events lib", () => {
+  it("builds privacy-light hub signal analytics and browse search", () => {
+    expect(hubSignalStatAnalyticsEvent()).toBe("hub_signal_stat_click");
+    expect(
+      hubSignalStatAnalyticsData("category-hub", "trusted", 12, 40),
+    ).toEqual({
+      surface: "category-hub",
+      statKey: "trusted",
+      count: 12,
+      pct: 40,
+    });
+    expect(hubStatBrowseSearch("trusted", { category: "mcp" })).toEqual({
+      category: "mcp",
+      trust: "trusted",
+    });
+    expect(hubStatBrowseSearch("sourced", { platform: "claude-code" })).toEqual(
+      {
+        platform: "claude-code",
+        signal: "source-backed",
+      },
+    );
+    expect(hubStatBrowseSearch("safety", { q: "postgres" })).toEqual({
+      q: "postgres",
+      signal: "safety-notes",
+    });
+    expect(hubStatBrowseSearch("unknown")).toBeNull();
+  });
+});

--- a/tests/hub-signal-cta-events-lib.test.ts
+++ b/tests/hub-signal-cta-events-lib.test.ts
@@ -30,6 +30,13 @@ describe("hub signal cta events lib", () => {
       q: "postgres",
       signal: "safety-notes",
     });
+    expect(hubStatBrowseSearch("privacy", { category: "hooks" })).toEqual({
+      category: "hooks",
+      signal: "privacy-notes",
+    });
+    expect(hubStatBrowseSearch("reviewed")).toEqual({
+      signal: "reviewed",
+    });
     expect(hubStatBrowseSearch("unknown")).toBeNull();
   });
 });

--- a/tests/platform-chip-cta-events-lib.test.ts
+++ b/tests/platform-chip-cta-events-lib.test.ts
@@ -12,11 +12,11 @@ describe("platform chip cta events lib", () => {
       surface: PLATFORM_CHIP_SURFACE,
       platform: "claude-code",
     });
-    expect(platformChipAnalyticsData("claude-desktop", "compare-table")).toEqual(
-      {
-        surface: "compare-table",
-        platform: "claude-desktop",
-      },
-    );
+    expect(
+      platformChipAnalyticsData("claude-desktop", "compare-table"),
+    ).toEqual({
+      surface: "compare-table",
+      platform: "claude-desktop",
+    });
   });
 });

--- a/tests/platform-chip-cta-events-lib.test.ts
+++ b/tests/platform-chip-cta-events-lib.test.ts
@@ -12,5 +12,11 @@ describe("platform chip cta events lib", () => {
       surface: PLATFORM_CHIP_SURFACE,
       platform: "claude-code",
     });
+    expect(platformChipAnalyticsData("claude-desktop", "compare-table")).toEqual(
+      {
+        surface: "compare-table",
+        platform: "claude-desktop",
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Make hub signal stats, browse trust/rollout chips, and compare category or platform pills navigable into browse filters with privacy-light CTA analytics.
- Cover every switch branch in the pure `*-cta-events-lib` helpers (including privacy/reviewed/source/package mappings) so codecov/patch stays above the 70% target.
- Prettier-format platform chip CTA tests so Trunk Check / validate-ci passes.

## Test plan
- [x] `pnpm exec prettier --check` on changed files
- [x] `pnpm exec vitest run` for the CTA event lib tests
- [ ] Confirm codecov/patch, codecov/project, validate-ci, and required-pr-gate pass

Refs #550

Made with [Cursor](https://cursor.com)