### PR TITLE
feat(web): add entry header install-risk badge analytics

### DIFF
--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -82,6 +82,8 @@ import { useCompare, useIsCompared } from "@/lib/compare";
 import { serializeCompareItems } from "@/lib/compare-selection";
 import { trackEvent, outboundHost } from "@/lib/analytics";
 import {
+  badgeChromeInstallRiskAnalyticsData,
+  badgeChromeInstallRiskAnalyticsEvent,
   badgeChromeSourceAnalyticsData,
   badgeChromeSourceAnalyticsEvent,
 } from "@/lib/badge-chrome-cta-events";
@@ -650,7 +652,16 @@ function Dossier() {
                 )
               }
             />
-            <InstallRiskBadge entry={entry} />
+            <InstallRiskBadge
+              entry={entry}
+              asButton
+              onActivate={(risk) =>
+                trackEvent(
+                  badgeChromeInstallRiskAnalyticsEvent(),
+                  badgeChromeInstallRiskAnalyticsData(risk, "detail-header"),
+                )
+              }
+            />
             <NotesPresenceChips entry={entry} className="ml-1" />
             {entry.claimed && (
               <span className="inline-flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-0.5 text-[11px] text-ink-muted">

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -58,5 +58,11 @@ describe("badge chrome cta events lib", () => {
         risk: "review",
       },
     );
+    expect(
+      badgeChromeInstallRiskAnalyticsData("high", "detail-header"),
+    ).toEqual({
+      surface: "detail-header",
+      risk: "high",
+    });
   });
 });


### PR DESCRIPTION
﻿## Summary
- Make entry header `InstallRiskBadge` actionable (`asButton`) with privacy-light analytics
- Event: `badge_install_risk_scroll_click`
- Payload: `{ surface: "detail-header", risk }` (no titles/URLs)

## Test plan
- [ ] Vitest covers `detail-header` install-risk surface
- [ ] Click InstallRiskBadge on an entry detail header; scrolls to risk callout
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
