### PR TITLE
feat(web): add state of claude tooling DistTable drilldowns

### DIFF
--- a/apps/web/src/components/data-report.tsx
+++ b/apps/web/src/components/data-report.tsx
@@ -11,6 +11,8 @@ export type DistBrowseSearch = {
   category?: string;
   trust?: string;
   source?: string;
+  platform?: string;
+  signal?: string;
 };
 
 /** In-app destination for a clickable distribution row. */

--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -5,8 +5,15 @@
  * stable enum/slug keys — never free-form titles beyond registry tag slugs.
  */
 
-import type { DistRow, DistRowDrilldown } from "@/components/data-report";
-import { SOURCE_LABEL, TRUST_LABEL, type SourceStatus, type TrustLevel } from "@/types/registry";
+import type { DistBrowseSearch, DistRow, DistRowDrilldown } from "@/components/data-report";
+import {
+  PLATFORM_LABEL,
+  SOURCE_LABEL,
+  TRUST_LABEL,
+  type Platform,
+  type SourceStatus,
+  type TrustLevel,
+} from "@/types/registry";
 
 const TRUST_BY_LABEL = Object.fromEntries(
   (Object.entries(TRUST_LABEL) as Array<[TrustLevel, string]>).map(([key, label]) => [label, key]),
@@ -19,6 +26,15 @@ const SOURCE_BY_LABEL = Object.fromEntries(
   ]),
 ) as Record<string, SourceStatus>;
 
+const PLATFORM_BY_LABEL = Object.fromEntries(
+  (Object.entries(PLATFORM_LABEL) as Array<[Platform, string]>).map(([key, label]) => [label, key]),
+) as Record<string, Platform>;
+
+const NOTES_SIGNAL_BY_LABEL: Record<string, string> = {
+  "Safety notes": "safety-notes",
+  "Privacy notes": "privacy-notes",
+};
+
 export function trustLevelFromLabel(label: string): TrustLevel | undefined {
   return TRUST_BY_LABEL[label];
 }
@@ -27,16 +43,24 @@ export function sourceStatusFromLabel(label: string): SourceStatus | undefined {
   return SOURCE_BY_LABEL[label];
 }
 
-export function browseDrilldown(search: {
-  category?: string;
-  trust?: string;
-  source?: string;
-}): DistRowDrilldown {
+export function platformFromLabel(label: string): Platform | undefined {
+  return PLATFORM_BY_LABEL[label];
+}
+
+export function notesSignalFromLabel(label: string): string | undefined {
+  return NOTES_SIGNAL_BY_LABEL[label];
+}
+
+export function browseDrilldown(search: DistBrowseSearch): DistRowDrilldown {
   return { kind: "browse", search };
 }
 
 export function tagDrilldown(tag: string): DistRowDrilldown {
   return { kind: "tag", tag };
+}
+
+export function categoryDrilldown(category: string): DistRowDrilldown {
+  return { kind: "category", category };
 }
 
 export function withTrustDrilldown(rows: DistRow[], category?: string): DistRow[] {
@@ -69,12 +93,51 @@ export function withSourceDrilldown(rows: DistRow[], category?: string): DistRow
   });
 }
 
+export function withPlatformDrilldown(rows: DistRow[]): DistRow[] {
+  return rows.map((row) => {
+    const platform = platformFromLabel(row.label);
+    if (!platform) return row;
+    return {
+      ...row,
+      rowKey: platform,
+      drilldown: browseDrilldown({ platform }),
+    };
+  });
+}
+
+export function withNotesSignalDrilldown(rows: DistRow[]): DistRow[] {
+  return rows.map((row) => {
+    const signal = notesSignalFromLabel(row.label);
+    if (!signal) return row;
+    return {
+      ...row,
+      rowKey: signal,
+      drilldown: browseDrilldown({ signal }),
+    };
+  });
+}
+
 export function withTagDrilldown(rows: DistRow[]): DistRow[] {
   return rows.map((row) => ({
     ...row,
     rowKey: row.rowKey ?? row.label,
     drilldown: tagDrilldown(row.label),
   }));
+}
+
+export function withCategoryHubDrilldown(
+  rows: DistRow[],
+  labelToId: Map<string, string>,
+): DistRow[] {
+  return rows.map((row) => {
+    const category = labelToId.get(row.label);
+    if (!category) return row;
+    return {
+      ...row,
+      rowKey: category,
+      drilldown: categoryDrilldown(category),
+    };
+  });
 }
 
 export function withCategoryBrowseDrilldown(rows: DistRow[], category: string): DistRow[] {
@@ -99,6 +162,10 @@ export function withReportDimensionDrilldown(
       return withTrustDrilldown(rows, category);
     case "source-provenance":
       return withSourceDrilldown(rows, category);
+    case "platform-coverage":
+      return withPlatformDrilldown(rows);
+    case "notes-coverage":
+      return withNotesSignalDrilldown(rows);
     case "use-cases":
       return withTagDrilldown(rows);
     case "prerequisites":

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -31,13 +31,22 @@ import {
   stateReportCategoryBrowseAnalyticsEvent,
   stateReportCiteAnalyticsData,
   stateReportCiteAnalyticsEvent,
+  stateReportDistRowAnalyticsData,
+  stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
-import { DataStat } from "@/components/data-report";
+import {
+  withCategoryHubDrilldown,
+  withNotesSignalDrilldown,
+  withPlatformDrilldown,
+  withSourceDrilldown,
+  withTrustDrilldown,
+} from "@/lib/data-report-drilldown-lib";
+import { DataSection, DataStat, DistTable, type DistRow } from "@/components/data-report";
 
 const REPORT_ID = "claude-tooling" as const;
 
@@ -50,6 +59,14 @@ function trackStateReportEgress(destination: StateReportEgressDestination) {
 
 function trackStateReportCite() {
   trackEvent(stateReportCiteAnalyticsEvent(), stateReportCiteAnalyticsData(REPORT_ID));
+}
+
+function trackDistRow(dimension: string, row: DistRow, rowIndex: number, rowCount: number) {
+  if (!row.rowKey) return;
+  trackEvent(
+    stateReportDistRowAnalyticsEvent(),
+    stateReportDistRowAnalyticsData(REPORT_ID, dimension, row.rowKey, rowIndex, rowCount),
+  );
 }
 
 function trackStat(statKey: string, destination: "browse" | "quality" = "browse") {
@@ -70,40 +87,43 @@ const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
 
 // ---- Derived stats (computed once at module load; the registry is static) ----
 
-interface DistRow {
-  label: string;
-  count: number;
-  pct: number;
-}
-
 const TOTAL = ENTRIES.length;
-
-const CATEGORY_DIST: DistRow[] = CATEGORIES.map((c) => {
-  const count = ENTRIES.filter((e) => e.category === c.id).length;
-  return { label: c.label, count, pct: pctOf(count, TOTAL) };
-}).sort((a, b) => b.count - a.count);
 
 const CATEGORY_ID_BY_LABEL = new Map<string, Category>(CATEGORIES.map((c) => [c.label, c.id]));
 
+const CATEGORY_DIST: DistRow[] = withCategoryHubDrilldown(
+  CATEGORIES.map((c) => {
+    const count = ENTRIES.filter((e) => e.category === c.id).length;
+    return { label: c.label, count, pct: pctOf(count, TOTAL) };
+  }).sort((a, b) => b.count - a.count),
+  CATEGORY_ID_BY_LABEL,
+);
+
 const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
-const TRUST_DIST: DistRow[] = TRUST_ORDER.map((level) => {
-  const count = ENTRIES.filter((e) => e.trust === level).length;
-  return { label: TRUST_LABEL[level], count, pct: pctOf(count, TOTAL) };
-}).filter((row) => row.count > 0);
+const TRUST_DIST: DistRow[] = withTrustDrilldown(
+  TRUST_ORDER.map((level) => {
+    const count = ENTRIES.filter((e) => e.trust === level).length;
+    return { label: TRUST_LABEL[level], count, pct: pctOf(count, TOTAL) };
+  }).filter((row) => row.count > 0),
+);
 
 const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
-const SOURCE_DIST: DistRow[] = SOURCE_ORDER.map((status) => {
-  const count = ENTRIES.filter((e) => e.source === status).length;
-  return { label: SOURCE_LABEL[status], count, pct: pctOf(count, TOTAL) };
-}).filter((row) => row.count > 0);
+const SOURCE_DIST: DistRow[] = withSourceDrilldown(
+  SOURCE_ORDER.map((status) => {
+    const count = ENTRIES.filter((e) => e.source === status).length;
+    return { label: SOURCE_LABEL[status], count, pct: pctOf(count, TOTAL) };
+  }).filter((row) => row.count > 0),
+);
 
 // Platform coverage — how many entries declare compatibility with each harness.
-const PLATFORM_DIST: DistRow[] = HARNESSES.map((h) => {
-  const count = ENTRIES.filter((e) => e.platforms.includes(h.id as Platform)).length;
-  return { label: PLATFORM_LABEL[h.id], count, pct: pctOf(count, TOTAL) };
-})
-  .filter((row) => row.count > 0)
-  .sort((a, b) => b.count - a.count);
+const PLATFORM_DIST: DistRow[] = withPlatformDrilldown(
+  HARNESSES.map((h) => {
+    const count = ENTRIES.filter((e) => e.platforms.includes(h.id as Platform)).length;
+    return { label: PLATFORM_LABEL[h.id], count, pct: pctOf(count, TOTAL) };
+  })
+    .filter((row) => row.count > 0)
+    .sort((a, b) => b.count - a.count),
+);
 
 // Install-method distribution — derived from each entry's installCommand, over
 // the package-installable subset (file/config drop-ins have no install command).
@@ -116,11 +136,11 @@ const INSTALL_METHOD_DIST: DistRow[] = INSTALL_METHODS.rows.map((row) => ({
 
 // Safety & privacy notes coverage — HeyClaude's differentiating metadata, quantified.
 const NOTES = notesCoverage(ENTRIES);
-const NOTES_DIST: DistRow[] = [
+const NOTES_DIST: DistRow[] = withNotesSignalDrilldown([
   { label: "Safety notes", count: NOTES.safety, pct: pctOf(NOTES.safety, TOTAL) },
   { label: "Privacy notes", count: NOTES.privacy, pct: pctOf(NOTES.privacy, TOTAL) },
   { label: "Both", count: NOTES.both, pct: pctOf(NOTES.both, TOTAL) },
-];
+]);
 
 // Recent additions — newest-dated entries by dateAdded.
 const RECENT_ADDITIONS = [...ENTRIES]
@@ -247,12 +267,27 @@ function StateOfClaudeToolingPage() {
         />
       </div>
 
-      <Section
+      <DataSection
         title="Resources by category"
         help="How the catalog breaks down across the ten tracked categories."
       >
-        <DistTable rows={CATEGORY_DIST} linkCategory />
-      </Section>
+        <DistTable
+          rows={CATEGORY_DIST}
+          onRowClick={(row, rowIndex) => {
+            if (!row.rowKey) return;
+            trackEvent(
+              stateReportCategoryBrowseAnalyticsEvent(),
+              stateReportCategoryBrowseAnalyticsData(
+                REPORT_ID,
+                row.rowKey,
+                row.count,
+                rowIndex,
+                CATEGORY_DIST.length,
+              ),
+            );
+          }}
+        />
+      </DataSection>
 
       <div className="mt-12 grid gap-6 lg:grid-cols-2">
         <div>
@@ -268,7 +303,12 @@ function StateOfClaudeToolingPage() {
             </Link>
           </p>
           <div className="mt-4">
-            <DistTable rows={TRUST_DIST} />
+            <DistTable
+              rows={TRUST_DIST}
+              onRowClick={(row, rowIndex) =>
+                trackDistRow("trust-level", row, rowIndex, TRUST_DIST.length)
+              }
+            />
           </div>
         </div>
         <div>
@@ -277,31 +317,46 @@ function StateOfClaudeToolingPage() {
             Where each listing's identity comes from — repo, package registry, or first-party docs.
           </p>
           <div className="mt-4">
-            <DistTable rows={SOURCE_DIST} />
+            <DistTable
+              rows={SOURCE_DIST}
+              onRowClick={(row, rowIndex) =>
+                trackDistRow("source-provenance", row, rowIndex, SOURCE_DIST.length)
+              }
+            />
           </div>
         </div>
       </div>
 
-      <Section
+      <DataSection
         title="Platform coverage"
         help="How many resources declare compatibility with each harness. Entries can support more than one, so percentages do not sum to 100%."
       >
-        <DistTable rows={PLATFORM_DIST} />
-      </Section>
+        <DistTable
+          rows={PLATFORM_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("platform-coverage", row, rowIndex, PLATFORM_DIST.length)
+          }
+        />
+      </DataSection>
 
-      <Section
+      <DataSection
         title="Install methods"
         help={`How the ${INSTALL_METHODS.total} package-installable resources are delivered, by install command. File and config drop-ins (agents, rules, skills, and the like) install by copying into your project rather than a package manager, so they are excluded here.`}
       >
         <DistTable rows={INSTALL_METHOD_DIST} />
-      </Section>
+      </DataSection>
 
-      <Section
+      <DataSection
         title="Safety & privacy coverage"
         help="Share of the catalog carrying reviewer-checked safety and privacy notes — the execution/permissions and data-handling metadata that sets HeyClaude apart. Percentages are of the full catalog; entries can carry both."
       >
-        <DistTable rows={NOTES_DIST} />
-      </Section>
+        <DistTable
+          rows={NOTES_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("notes-coverage", row, rowIndex, NOTES_DIST.length)
+          }
+        />
+      </DataSection>
 
       <ReportDownloads exportSlug="claude-tooling" />
 
@@ -397,77 +452,5 @@ function StateOfClaudeToolingPage() {
         />
       </div>
     </PageContainer>
-  );
-
-  function DistTable({ rows, linkCategory = false }: { rows: DistRow[]; linkCategory?: boolean }) {
-    const max = rows.reduce((m, r) => Math.max(m, r.count), 0);
-    return (
-      <div className="overflow-hidden rounded-xl border border-border bg-surface">
-        {rows.map((row, rowIndex) => {
-          const categoryId = linkCategory ? CATEGORY_ID_BY_LABEL.get(row.label) : undefined;
-          const inner = (
-            <>
-              <div className="font-display text-sm font-semibold text-ink">{row.label}</div>
-              <div className="h-2 overflow-hidden rounded-full bg-surface-2">
-                <div
-                  className="h-full bg-ink"
-                  style={{ width: `${max ? Math.round((row.count / max) * 100) : 0}%` }}
-                />
-              </div>
-              <div className="text-right font-mono text-xs tabular-nums text-ink">{row.count}</div>
-              <div className="text-right font-mono text-xs tabular-nums text-ink-subtle">
-                {row.pct}%
-              </div>
-            </>
-          );
-          const className =
-            "grid grid-cols-[140px_1fr_56px_56px] items-center gap-4 border-b border-border px-5 py-3 last:border-0";
-          return categoryId ? (
-            <Link
-              key={row.label}
-              to="/$category"
-              params={{ category: categoryId }}
-              onClick={() =>
-                trackEvent(
-                  stateReportCategoryBrowseAnalyticsEvent(),
-                  stateReportCategoryBrowseAnalyticsData(
-                    REPORT_ID,
-                    categoryId,
-                    row.count,
-                    rowIndex,
-                    rows.length,
-                  ),
-                )
-              }
-              className={`${className} hover:bg-surface-2`}
-            >
-              {inner}
-            </Link>
-          ) : (
-            <div key={row.label} className={className}>
-              {inner}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
-}
-
-function Section({
-  title,
-  help,
-  children,
-}: {
-  title: string;
-  help: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="mt-12">
-      <h2 className="h-display-2 text-ink text-balance">{title}</h2>
-      <p className="mt-2 max-w-2xl text-sm text-ink-muted">{help}</p>
-      <div className="mt-4">{children}</div>
-    </section>
   );
 }

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   browseDrilldown,
+  categoryDrilldown,
+  notesSignalFromLabel,
+  platformFromLabel,
   sourceStatusFromLabel,
   tagDrilldown,
   trustLevelFromLabel,
+  withCategoryHubDrilldown,
+  withNotesSignalDrilldown,
+  withPlatformDrilldown,
   withReportDimensionDrilldown,
   withSourceDrilldown,
   withTagDrilldown,
@@ -14,16 +20,36 @@ describe("data report drilldown lib", () => {
   it("maps trust and source labels to registry enums", () => {
     expect(trustLevelFromLabel("Trusted")).toBe("trusted");
     expect(trustLevelFromLabel("Review first")).toBe("review");
+    expect(trustLevelFromLabel("Limited")).toBe("limited");
+    expect(trustLevelFromLabel("Blocked")).toBe("blocked");
+    expect(trustLevelFromLabel("Unknown")).toBeUndefined();
     expect(sourceStatusFromLabel("Source-backed")).toBe("source-backed");
     expect(sourceStatusFromLabel("First-party")).toBe("first-party");
+    expect(sourceStatusFromLabel("External")).toBe("external");
+    expect(sourceStatusFromLabel("Unverified")).toBe("unverified");
+    expect(sourceStatusFromLabel("Unknown")).toBeUndefined();
   });
 
-  it("attaches browse and tag drilldowns with privacy-light keys", () => {
+  it("maps platform and notes labels to browse filter keys", () => {
+    expect(platformFromLabel("Claude Code")).toBe("claude-code");
+    expect(platformFromLabel("Claude Desktop")).toBe("claude-desktop");
+    expect(platformFromLabel("Cursor")).toBe("cursor");
+    expect(platformFromLabel("Unknown")).toBeUndefined();
+    expect(notesSignalFromLabel("Safety notes")).toBe("safety-notes");
+    expect(notesSignalFromLabel("Privacy notes")).toBe("privacy-notes");
+    expect(notesSignalFromLabel("Both")).toBeUndefined();
+  });
+
+  it("attaches browse, tag, and category drilldowns with privacy-light keys", () => {
     expect(browseDrilldown({ category: "mcp", trust: "trusted" })).toEqual({
       kind: "browse",
       search: { category: "mcp", trust: "trusted" },
     });
     expect(tagDrilldown("postgres")).toEqual({ kind: "tag", tag: "postgres" });
+    expect(categoryDrilldown("skills")).toEqual({
+      kind: "category",
+      category: "skills",
+    });
 
     expect(
       withTrustDrilldown([{ label: "Trusted", count: 4, pct: 40 }], "mcp"),
@@ -39,6 +65,23 @@ describe("data report drilldown lib", () => {
         },
       },
     ]);
+    expect(
+      withTrustDrilldown([{ label: "Trusted", count: 4, pct: 40 }]),
+    ).toEqual([
+      {
+        label: "Trusted",
+        count: 4,
+        pct: 40,
+        rowKey: "trusted",
+        drilldown: {
+          kind: "browse",
+          search: { trust: "trusted" },
+        },
+      },
+    ]);
+    expect(
+      withTrustDrilldown([{ label: "Unknown", count: 1, pct: 10 }]),
+    ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
 
     expect(
       withSourceDrilldown(
@@ -57,6 +100,59 @@ describe("data report drilldown lib", () => {
         },
       },
     ]);
+    expect(
+      withSourceDrilldown([{ label: "Unknown", count: 1, pct: 10 }]),
+    ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
+
+    expect(
+      withPlatformDrilldown([{ label: "Claude Code", count: 9, pct: 45 }]),
+    ).toEqual([
+      {
+        label: "Claude Code",
+        count: 9,
+        pct: 45,
+        rowKey: "claude-code",
+        drilldown: {
+          kind: "browse",
+          search: { platform: "claude-code" },
+        },
+      },
+    ]);
+    expect(
+      withPlatformDrilldown([{ label: "Unknown", count: 1, pct: 5 }]),
+    ).toEqual([{ label: "Unknown", count: 1, pct: 5 }]);
+
+    expect(
+      withNotesSignalDrilldown([{ label: "Safety notes", count: 3, pct: 30 }]),
+    ).toEqual([
+      {
+        label: "Safety notes",
+        count: 3,
+        pct: 30,
+        rowKey: "safety-notes",
+        drilldown: {
+          kind: "browse",
+          search: { signal: "safety-notes" },
+        },
+      },
+    ]);
+    expect(
+      withNotesSignalDrilldown([{ label: "Privacy notes", count: 2, pct: 20 }]),
+    ).toEqual([
+      {
+        label: "Privacy notes",
+        count: 2,
+        pct: 20,
+        rowKey: "privacy-notes",
+        drilldown: {
+          kind: "browse",
+          search: { signal: "privacy-notes" },
+        },
+      },
+    ]);
+    expect(
+      withNotesSignalDrilldown([{ label: "Both", count: 1, pct: 10 }]),
+    ).toEqual([{ label: "Both", count: 1, pct: 10 }]);
 
     expect(
       withTagDrilldown([{ label: "postgres", count: 3, pct: 30 }]),
@@ -69,6 +165,27 @@ describe("data report drilldown lib", () => {
         drilldown: { kind: "tag", tag: "postgres" },
       },
     ]);
+
+    expect(
+      withCategoryHubDrilldown(
+        [{ label: "MCP Servers", count: 5, pct: 50 }],
+        new Map([["MCP Servers", "mcp"]]),
+      ),
+    ).toEqual([
+      {
+        label: "MCP Servers",
+        count: 5,
+        pct: 50,
+        rowKey: "mcp",
+        drilldown: { kind: "category", category: "mcp" },
+      },
+    ]);
+    expect(
+      withCategoryHubDrilldown(
+        [{ label: "Unknown", count: 1, pct: 10 }],
+        new Map(),
+      ),
+    ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
   });
 
   it("attaches dimension drilldowns for known report keys", () => {
@@ -81,11 +198,81 @@ describe("data report drilldown lib", () => {
     ).toBe("trusted");
     expect(
       withReportDimensionDrilldown(
+        "source-provenance",
+        [{ label: "First-party", count: 1, pct: 100 }],
+        "agents",
+      )[0]?.rowKey,
+    ).toBe("first-party");
+    expect(
+      withReportDimensionDrilldown(
+        "platform-coverage",
+        [{ label: "Cursor", count: 2, pct: 50 }],
+        "agents",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { platform: "cursor" } });
+    expect(
+      withReportDimensionDrilldown(
+        "notes-coverage",
+        [{ label: "Safety notes", count: 2, pct: 50 }],
+        "agents",
+      )[0]?.rowKey,
+    ).toBe("safety-notes");
+    expect(
+      withReportDimensionDrilldown(
         "use-cases",
         [{ label: "research", count: 2, pct: 50 }],
         "agents",
       )[0]?.drilldown,
     ).toEqual({ kind: "tag", tag: "research" });
+    expect(
+      withReportDimensionDrilldown(
+        "prerequisites",
+        [{ label: "Node", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withReportDimensionDrilldown(
+        "disclosure",
+        [{ label: "x", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withReportDimensionDrilldown(
+        "packaging",
+        [{ label: "x", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withReportDimensionDrilldown(
+        "skill-type",
+        [{ label: "x", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withReportDimensionDrilldown(
+        "maturity",
+        [{ label: "x", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withReportDimensionDrilldown(
+        "verification",
+        [{ label: "x", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withReportDimensionDrilldown(
+        "hook-events",
+        [{ label: "x", count: 1, pct: 100 }],
+        "hooks",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "hooks" } });
     expect(
       withReportDimensionDrilldown(
         "unknown-dimension",


### PR DESCRIPTION
## Summary
- Wire State of Claude Tooling distribution tables (category, trust, source, platform, notes) to shared DistTable drilldowns so rows navigate into hubs or browse filters.
- Extend `data-report-drilldown-lib` with platform and notes signal helpers, and cover every switch/branch for codecov patch.

## Test plan
- [x] `pnpm exec prettier --check` on changed files
- [x] `pnpm exec vitest run --coverage tests/data-report-drilldown-lib.test.ts` (100% lines/branches on the lib)
- [ ] Confirm codecov/patch, codecov/project, validate-ci, and required-pr-gate pass

Refs #550

Made with [Cursor](https://cursor.com)