### PR TITLE
feat(web): add contributor profile entry badge browse analytics

### DIFF
--- a/apps/web/src/lib/badge-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events-lib.ts
@@ -5,7 +5,11 @@
  * names without embedding titles or free-form note copy.
  */
 
-export type BadgeChromeSurface = "detail-sticky-meta" | "peek-panel" | "detail-header";
+export type BadgeChromeSurface =
+  | "detail-sticky-meta"
+  | "peek-panel"
+  | "detail-header"
+  | "contributor-profile";
 
 export type BadgeChromeNoteKind = "safety" | "privacy";
 

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -25,6 +25,12 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
+import {
   contributorProfileEntryAnalyticsData,
   contributorProfileEntryAnalyticsEvent,
 } from "@/lib/insights-page-entry-cta-events";
@@ -357,8 +363,26 @@ function ContributionRow({
           {roleLabel[role]}
         </span>
         <CategoryPill>{entry.category}</CategoryPill>
-        <TrustBadge level={entry.trust} />
-        <SourceBadge status={entry.source} />
+        <TrustBadge
+          level={entry.trust}
+          asLink
+          onNavigate={() =>
+            trackEvent(
+              badgeChromeTrustAnalyticsEvent(),
+              badgeChromeTrustAnalyticsData(entry.trust, "contributor-profile"),
+            )
+          }
+        />
+        <SourceBadge
+          status={entry.source}
+          asLink
+          onNavigate={() =>
+            trackEvent(
+              badgeChromeSourceAnalyticsEvent(),
+              badgeChromeSourceAnalyticsData(entry.source, "contributor-profile"),
+            )
+          }
+        />
       </div>
 
       <div className="mt-3">

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -34,6 +34,18 @@ describe("badge chrome cta events lib", () => {
       surface: "detail-header",
       source: "first-party",
     });
+    expect(
+      badgeChromeSourceAnalyticsData("source-backed", "contributor-profile"),
+    ).toEqual({
+      surface: "contributor-profile",
+      source: "source-backed",
+    });
+    expect(
+      badgeChromeTrustAnalyticsData("verified", "contributor-profile"),
+    ).toEqual({
+      surface: "contributor-profile",
+      trust: "verified",
+    });
     expect(badgeChromeCategoryAnalyticsEvent()).toBe(
       "badge_category_browse_click",
     );


### PR DESCRIPTION
## Summary
- Make the contributor profile contribution-row `TrustBadge` and `SourceBadge` navigable (`asLink`) with privacy-light analytics
- Events: `badge_trust_browse_click`, `badge_source_browse_click`
- Payload: `{ surface: "contributor-profile", trust | source }` (no names, titles, or URLs)
- Adds `contributor-profile` to `BadgeChromeSurface`; these badges sit outside the row `<Link>`, so opting them into browse links does not nest anchors

## Test plan
- [ ] Vitest covers the `contributor-profile` surface payloads
- [ ] Click the Trust / Source badge on a contributor profile contribution row
- [ ] CI: validate-web, coverage, codecov/patch
