### PR TITLE
feat(web): add compare tray chip badge browse analytics

### DIFF
--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -31,6 +31,12 @@ import {
   comparisonTrayViewSelectionAnalyticsData,
   comparisonTrayViewSelectionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
+import {
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { TrustBadge, SourceBadge, ReadinessDot } from "./badges";
 import { compareSignalToneClass } from "@/lib/compare-entry-signals";
@@ -54,8 +60,27 @@ function TrayChip({
       <span className="max-w-[9rem] truncate font-medium text-ink sm:max-w-[12rem]">
         {entry.title}
       </span>
-      <TrustBadge level={entry.trust} />
-      <SourceBadge status={entry.source} className="hidden sm:inline-flex" />
+      <TrustBadge
+        level={entry.trust}
+        asLink
+        onNavigate={() =>
+          trackEvent(
+            badgeChromeTrustAnalyticsEvent(),
+            badgeChromeTrustAnalyticsData(entry.trust, "compare-tray"),
+          )
+        }
+      />
+      <SourceBadge
+        status={entry.source}
+        className="hidden sm:inline-flex"
+        asLink
+        onNavigate={() =>
+          trackEvent(
+            badgeChromeSourceAnalyticsEvent(),
+            badgeChromeSourceAnalyticsData(entry.source, "compare-tray"),
+          )
+        }
+      />
       <span className="inline-flex items-center gap-0.5 text-ink-subtle" aria-hidden>
         <Shield
           className={cn("h-3 w-3", signals.hasSafetyNotes ? "text-trust-trusted" : "opacity-40")}

--- a/apps/web/src/lib/badge-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events-lib.ts
@@ -9,7 +9,8 @@ export type BadgeChromeSurface =
   | "detail-sticky-meta"
   | "peek-panel"
   | "detail-header"
-  | "contributor-profile";
+  | "contributor-profile"
+  | "compare-tray";
 
 export type BadgeChromeNoteKind = "safety" | "privacy";
 

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -46,6 +46,16 @@ describe("badge chrome cta events lib", () => {
       surface: "contributor-profile",
       trust: "verified",
     });
+    expect(badgeChromeTrustAnalyticsData("trusted", "compare-tray")).toEqual({
+      surface: "compare-tray",
+      trust: "trusted",
+    });
+    expect(
+      badgeChromeSourceAnalyticsData("unverified", "compare-tray"),
+    ).toEqual({
+      surface: "compare-tray",
+      source: "unverified",
+    });
     expect(badgeChromeCategoryAnalyticsEvent()).toBe(
       "badge_category_browse_click",
     );


### PR DESCRIPTION
## Summary
- Make the compare tray chip `TrustBadge` and `SourceBadge` navigable (`asLink`) with privacy-light analytics
- Events: `badge_trust_browse_click`, `badge_source_browse_click`
- Payload: `{ surface: "compare-tray", trust | source }` (no titles or URLs)
- Adds `compare-tray` to `BadgeChromeSurface`; the tray chip badges sit outside the row link, so opting them into browse links does not nest anchors

## Test plan
- [ ] Vitest covers the `compare-tray` surface payloads
- [ ] Click the Trust / Source badge on a compare tray chip
- [ ] CI: validate-web, coverage, codecov/patch
