### PR TITLE
feat(web): add compare and ranking source, notes, and harness drilldowns

### DIFF
--- a/apps/web/src/components/badges.tsx
+++ b/apps/web/src/components/badges.tsx
@@ -33,6 +33,12 @@ import {
   categoryPillAnalyticsData,
   categoryPillAnalyticsEvent,
 } from "@/lib/category-pill-cta-events";
+import { sourceBadgeAnalyticsData, sourceBadgeAnalyticsEvent } from "@/lib/source-badge-cta-events";
+import {
+  notesPresenceAnalyticsData,
+  notesPresenceAnalyticsEvent,
+  notesPresenceBrowseSearch,
+} from "@/lib/notes-presence-cta-events";
 import {
   installRiskLevel,
   INSTALL_RISK_LABEL,
@@ -110,12 +116,15 @@ export function SourceBadge({
   status,
   className,
   asLink = false,
+  surface,
   onNavigate,
 }: {
   status: SourceStatus;
   className?: string;
   /** Opt-in browse link — never use inside card `<Link>`s. */
   asLink?: boolean;
+  /** Optional analytics surface when asLink is set. */
+  surface?: string;
   onNavigate?: () => void;
 }) {
   const Icon = sourceIcon[status];
@@ -134,7 +143,12 @@ export function SourceBadge({
       <Link
         to="/browse"
         search={{ source: status }}
-        onClick={onNavigate}
+        onClick={() => {
+          onNavigate?.();
+          if (surface) {
+            trackEvent(sourceBadgeAnalyticsEvent(), sourceBadgeAnalyticsData(status, surface));
+          }
+        }}
         className={cn(classes, "transition-colors hover:text-ink")}
         title={`${SOURCE_LABEL[status]} — browse by source`}
       >
@@ -307,12 +321,18 @@ export function NotesPresenceChips({
   entry,
   className,
   interactive = false,
+  asLink = false,
+  surface,
   onNoteClick,
 }: {
   entry: Entry;
   className?: string;
   /** Opt-in scroll buttons — never use inside card `<Link>`s. */
   interactive?: boolean;
+  /** Opt-in browse links for present notes — never use inside card `<Link>`s. */
+  asLink?: boolean;
+  /** Optional analytics surface when asLink is set. */
+  surface?: string;
   onNoteClick?: (noteKind: "safety" | "privacy", present: boolean) => void;
 }) {
   const hasSafety = !!(entry.safetyNotes || entry.safetyNotesList?.length);
@@ -327,6 +347,16 @@ export function NotesPresenceChips({
   const activate = (noteKind: "safety" | "privacy", present: boolean, targetId: string) => {
     onNoteClick?.(noteKind, present);
     document.getElementById(targetId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const trackNote = (noteKind: "safety" | "privacy", present: boolean) => {
+    onNoteClick?.(noteKind, present);
+    if (surface) {
+      trackEvent(
+        notesPresenceAnalyticsEvent(),
+        notesPresenceAnalyticsData(noteKind, present, surface),
+      );
+    }
   };
 
   if (interactive) {
@@ -359,6 +389,45 @@ export function NotesPresenceChips({
           )}{" "}
           Privacy {hasPrivacy ? "✓" : "·"}
         </button>
+      </span>
+    );
+  }
+
+  if (asLink) {
+    const safetySearch = notesPresenceBrowseSearch("safety", hasSafety);
+    const privacySearch = notesPresenceBrowseSearch("privacy", hasPrivacy);
+    return (
+      <span className={cn("inline-flex items-center gap-1", className)}>
+        {safetySearch ? (
+          <Link
+            to="/browse"
+            search={safetySearch}
+            onClick={() => trackNote("safety", true)}
+            title="Safety notes present — browse by signal"
+            className={cn(chipClass(true), "transition-colors hover:border-ink/20")}
+          >
+            <Lock className="h-2.5 w-2.5" aria-hidden /> Safety ✓
+          </Link>
+        ) : (
+          <span title="Safety notes missing" className={chipClass(false)}>
+            <Lock className="h-2.5 w-2.5" aria-hidden /> Safety ·
+          </span>
+        )}
+        {privacySearch ? (
+          <Link
+            to="/browse"
+            search={privacySearch}
+            onClick={() => trackNote("privacy", true)}
+            title="Privacy notes present — browse by signal"
+            className={cn(chipClass(true), "transition-colors hover:border-ink/20")}
+          >
+            <Eye className="h-2.5 w-2.5" aria-hidden /> Privacy ✓
+          </Link>
+        ) : (
+          <span title="Privacy notes missing" className={chipClass(false)}>
+            <EyeOff className="h-2.5 w-2.5" aria-hidden /> Privacy ·
+          </span>
+        )}
       </span>
     );
   }

--- a/apps/web/src/components/category-ranking-table.tsx
+++ b/apps/web/src/components/category-ranking-table.tsx
@@ -1,5 +1,10 @@
 import { Link } from "@tanstack/react-router";
-import { PlatformChip, InstallRiskBadge, NotesPresenceChips } from "@/components/badges";
+import {
+  PlatformChip,
+  InstallRiskBadge,
+  NotesPresenceChips,
+  SourceBadge,
+} from "@/components/badges";
 import { trackEvent } from "@/lib/analytics";
 import {
   hubCategoryRankingEntryAnalyticsData,
@@ -63,7 +68,9 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                   </Link>
                   <div className="mt-0.5 text-xs text-ink-subtle">{e.author}</div>
                 </th>
-                <td className="px-3 py-2.5 align-top text-sm capitalize text-ink">{e.source}</td>
+                <td className="px-3 py-2.5 align-top">
+                  <SourceBadge status={e.source} asLink surface="category-ranking" />
+                </td>
                 <td className="px-3 py-2.5 align-top">
                   <InstallRiskBadge entry={e} />
                 </td>
@@ -88,7 +95,7 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                   </div>
                 </td>
                 <td className="px-3 py-2.5 align-top">
-                  <NotesPresenceChips entry={e} />
+                  <NotesPresenceChips entry={e} asLink surface="category-ranking" />
                 </td>
               </tr>
             ))}

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -215,14 +215,14 @@ const ROWS: RowDef[] = [
     label: "Harness",
     render: (e) =>
       e.harness && e.harness.length > 0 ? (
-        <HarnessBadgeRow ids={e.harness} />
+        <HarnessBadgeRow ids={e.harness} asLink surface="compare-drawer" />
       ) : (
         <span className="text-xs text-ink-subtle">—</span>
       ),
   },
   {
     label: "Notes",
-    render: (e) => <NotesPresenceChips entry={e} />,
+    render: (e) => <NotesPresenceChips entry={e} asLink surface="compare-drawer" />,
   },
   {
     label: "Source repo",

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -6,6 +6,7 @@ import {
   PlatformChip,
   InstallRiskBadge,
   NotesPresenceChips,
+  SourceBadge,
 } from "@/components/badges";
 import { TrustDrilldown } from "@/components/trust-drilldown";
 import { CopyButton } from "@/components/copy-button";
@@ -166,7 +167,10 @@ export const COMPARISON_ROWS: RowDef[] = [
   { label: "Trust", render: (e) => <TrustDrilldown entry={e} /> },
   ...DECISION_COMPARISON_ROWS,
   { label: "Install risk", render: (e) => <InstallRiskBadge entry={e} /> },
-  { label: "Notes", render: (e) => <NotesPresenceChips entry={e} /> },
+  {
+    label: "Notes",
+    render: (e) => <NotesPresenceChips entry={e} asLink surface="compare-table" />,
+  },
   {
     label: "Brand",
     render: (e) => {
@@ -191,7 +195,7 @@ export const COMPARISON_ROWS: RowDef[] = [
   },
   {
     label: "Source",
-    render: (e) => <span className="text-sm capitalize text-ink">{e.source}</span>,
+    render: (e) => <SourceBadge status={e.source} asLink surface="compare-table" />,
   },
   { label: "Author", render: (e) => <span className="text-sm text-ink">{e.author}</span> },
   {

--- a/apps/web/src/components/harness-badge.tsx
+++ b/apps/web/src/components/harness-badge.tsx
@@ -1,41 +1,81 @@
+import { Link } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
 import { IntegrationMark, platformMark } from "./integration-marks";
 import { PLATFORM_LABEL, type Harness } from "@/types/registry";
+import { trackEvent } from "@/lib/analytics";
+import {
+  harnessBadgeAnalyticsData,
+  harnessBadgeAnalyticsEvent,
+} from "@/lib/harness-badge-cta-events";
 
 export function HarnessBadge({
   id,
   size = "sm",
   className,
+  asLink = false,
+  surface,
 }: {
   id: Harness;
   size?: "xs" | "sm";
   className?: string;
+  /** Opt-in platform hub link — never use inside card `<Link>`s. */
+  asLink?: boolean;
+  /** Optional analytics surface when asLink is set. */
+  surface?: string;
 }) {
   const mark = platformMark(id);
   const px = size === "xs" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-[11px]";
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-md border border-border bg-surface text-ink-muted",
-        px,
-        className,
-      )}
-      title={`Works with ${PLATFORM_LABEL[id]}`}
-    >
+  const classes = cn(
+    "inline-flex items-center gap-1 rounded-md border border-border bg-surface text-ink-muted",
+    px,
+    className,
+  );
+  const content = (
+    <>
       {mark && (
         <IntegrationMark name={mark} size={size === "xs" ? 10 : 11} className="opacity-80" />
       )}
       {PLATFORM_LABEL[id]}
+    </>
+  );
+  if (asLink) {
+    return (
+      <Link
+        to="/for/$platform"
+        params={{ platform: id }}
+        title={`Works with ${PLATFORM_LABEL[id]} — open platform hub`}
+        onClick={() =>
+          trackEvent(harnessBadgeAnalyticsEvent(), harnessBadgeAnalyticsData(id, surface))
+        }
+        className={cn(classes, "transition-colors hover:border-ink/20 hover:text-ink")}
+      >
+        {content}
+      </Link>
+    );
+  }
+  return (
+    <span className={classes} title={`Works with ${PLATFORM_LABEL[id]}`}>
+      {content}
     </span>
   );
 }
 
-export function HarnessBadgeRow({ ids, className }: { ids: Harness[]; className?: string }) {
+export function HarnessBadgeRow({
+  ids,
+  className,
+  asLink = false,
+  surface,
+}: {
+  ids: Harness[];
+  className?: string;
+  asLink?: boolean;
+  surface?: string;
+}) {
   if (!ids?.length) return null;
   return (
     <div className={cn("flex flex-wrap gap-1", className)}>
       {ids.map((id) => (
-        <HarnessBadge key={id} id={id} />
+        <HarnessBadge key={id} id={id} asLink={asLink} surface={surface} />
       ))}
     </div>
   );

--- a/apps/web/src/lib/harness-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/harness-badge-cta-events-lib.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure harness badge navigation analytics helpers.
+ *
+ * Maps harness badge platform egress to privacy-light event names without
+ * embedding display labels.
+ */
+
+export const HARNESS_BADGE_SURFACE = "harness-badge";
+
+export type HarnessBadgeSurface =
+  | typeof HARNESS_BADGE_SURFACE
+  | "compare-table"
+  | "compare-drawer"
+  | "category-ranking";
+
+export function harnessBadgeAnalyticsEvent(): string {
+  return "harness_badge_click";
+}
+
+export function harnessBadgeAnalyticsData(
+  harness: string,
+  surface: string = HARNESS_BADGE_SURFACE,
+) {
+  return {
+    surface,
+    harness,
+  };
+}

--- a/apps/web/src/lib/harness-badge-cta-events.ts
+++ b/apps/web/src/lib/harness-badge-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Harness badge navigation CTA event surface.
+ */
+export {
+  HARNESS_BADGE_SURFACE,
+  harnessBadgeAnalyticsData,
+  harnessBadgeAnalyticsEvent,
+  type HarnessBadgeSurface,
+} from "@/lib/harness-badge-cta-events-lib";

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure notes-presence chip navigation analytics helpers.
+ *
+ * Maps safety/privacy presence chips to privacy-light browse egress without
+ * embedding note copy.
+ */
+
+export const NOTES_PRESENCE_SURFACE = "notes-presence";
+
+export type NotesPresenceSurface =
+  | typeof NOTES_PRESENCE_SURFACE
+  | "compare-table"
+  | "compare-drawer"
+  | "category-ranking";
+
+export type NotesPresenceKind = "safety" | "privacy";
+
+export function notesPresenceAnalyticsEvent(): string {
+  return "notes_presence_chip_click";
+}
+
+export function notesPresenceAnalyticsData(
+  noteKind: NotesPresenceKind,
+  present: boolean,
+  surface: string = NOTES_PRESENCE_SURFACE,
+) {
+  return {
+    surface,
+    noteKind,
+    present,
+  };
+}
+
+/** Map a present notes chip to a browse `signal` search patch. */
+export function notesPresenceBrowseSearch(
+  noteKind: string,
+  present: boolean,
+): { signal: string } | null {
+  if (!present) return null;
+  switch (noteKind) {
+    case "safety":
+      return { signal: "safety-notes" };
+    case "privacy":
+      return { signal: "privacy-notes" };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/notes-presence-cta-events.ts
+++ b/apps/web/src/lib/notes-presence-cta-events.ts
@@ -1,0 +1,11 @@
+/**
+ * Notes presence chip navigation CTA event surface.
+ */
+export {
+  NOTES_PRESENCE_SURFACE,
+  notesPresenceAnalyticsData,
+  notesPresenceAnalyticsEvent,
+  notesPresenceBrowseSearch,
+  type NotesPresenceKind,
+  type NotesPresenceSurface,
+} from "@/lib/notes-presence-cta-events-lib";

--- a/apps/web/src/lib/source-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/source-badge-cta-events-lib.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure source badge navigation analytics helpers.
+ *
+ * Maps opt-in source badge browse egress to privacy-light event names without
+ * embedding display labels.
+ */
+
+export const SOURCE_BADGE_SURFACE = "source-badge";
+
+export type SourceBadgeSurface =
+  | typeof SOURCE_BADGE_SURFACE
+  | "compare-table"
+  | "compare-drawer"
+  | "category-ranking";
+
+export function sourceBadgeAnalyticsEvent(): string {
+  return "source_badge_click";
+}
+
+export function sourceBadgeAnalyticsData(source: string, surface: string = SOURCE_BADGE_SURFACE) {
+  return {
+    surface,
+    source,
+  };
+}

--- a/apps/web/src/lib/source-badge-cta-events.ts
+++ b/apps/web/src/lib/source-badge-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Source badge navigation CTA event surface.
+ */
+export {
+  SOURCE_BADGE_SURFACE,
+  sourceBadgeAnalyticsData,
+  sourceBadgeAnalyticsEvent,
+  type SourceBadgeSurface,
+} from "@/lib/source-badge-cta-events-lib";

--- a/tests/harness-badge-cta-events-lib.test.ts
+++ b/tests/harness-badge-cta-events-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  HARNESS_BADGE_SURFACE,
+  harnessBadgeAnalyticsData,
+  harnessBadgeAnalyticsEvent,
+} from "@/lib/harness-badge-cta-events-lib";
+
+describe("harness badge cta events lib", () => {
+  it("builds privacy-light harness badge analytics for each surface", () => {
+    expect(harnessBadgeAnalyticsEvent()).toBe("harness_badge_click");
+    expect(harnessBadgeAnalyticsData("claude-code")).toEqual({
+      surface: HARNESS_BADGE_SURFACE,
+      harness: "claude-code",
+    });
+    expect(harnessBadgeAnalyticsData("cursor", "compare-table")).toEqual({
+      surface: "compare-table",
+      harness: "cursor",
+    });
+    expect(
+      harnessBadgeAnalyticsData("claude-desktop", "compare-drawer"),
+    ).toEqual({
+      surface: "compare-drawer",
+      harness: "claude-desktop",
+    });
+    expect(harnessBadgeAnalyticsData("vscode", "category-ranking")).toEqual({
+      surface: "category-ranking",
+      harness: "vscode",
+    });
+  });
+});

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  NOTES_PRESENCE_SURFACE,
+  notesPresenceAnalyticsData,
+  notesPresenceAnalyticsEvent,
+  notesPresenceBrowseSearch,
+} from "@/lib/notes-presence-cta-events-lib";
+
+describe("notes presence cta events lib", () => {
+  it("builds privacy-light notes chip analytics payloads", () => {
+    expect(notesPresenceAnalyticsEvent()).toBe("notes_presence_chip_click");
+    expect(notesPresenceAnalyticsData("safety", true)).toEqual({
+      surface: NOTES_PRESENCE_SURFACE,
+      noteKind: "safety",
+      present: true,
+    });
+    expect(
+      notesPresenceAnalyticsData("privacy", false, "compare-table"),
+    ).toEqual({
+      surface: "compare-table",
+      noteKind: "privacy",
+      present: false,
+    });
+    expect(
+      notesPresenceAnalyticsData("safety", true, "compare-drawer"),
+    ).toEqual({
+      surface: "compare-drawer",
+      noteKind: "safety",
+      present: true,
+    });
+    expect(
+      notesPresenceAnalyticsData("privacy", true, "category-ranking"),
+    ).toEqual({
+      surface: "category-ranking",
+      noteKind: "privacy",
+      present: true,
+    });
+  });
+
+  it("maps present notes chips to browse signal search patches", () => {
+    expect(notesPresenceBrowseSearch("safety", true)).toEqual({
+      signal: "safety-notes",
+    });
+    expect(notesPresenceBrowseSearch("privacy", true)).toEqual({
+      signal: "privacy-notes",
+    });
+    expect(notesPresenceBrowseSearch("safety", false)).toBeNull();
+    expect(notesPresenceBrowseSearch("privacy", false)).toBeNull();
+    expect(notesPresenceBrowseSearch("unknown", true)).toBeNull();
+  });
+});

--- a/tests/source-badge-cta-events-lib.test.ts
+++ b/tests/source-badge-cta-events-lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  SOURCE_BADGE_SURFACE,
+  sourceBadgeAnalyticsData,
+  sourceBadgeAnalyticsEvent,
+} from "@/lib/source-badge-cta-events-lib";
+
+describe("source badge cta events lib", () => {
+  it("builds privacy-light source badge analytics for each surface", () => {
+    expect(sourceBadgeAnalyticsEvent()).toBe("source_badge_click");
+    expect(sourceBadgeAnalyticsData("source-backed")).toEqual({
+      surface: SOURCE_BADGE_SURFACE,
+      source: "source-backed",
+    });
+    expect(sourceBadgeAnalyticsData("first-party", "compare-table")).toEqual({
+      surface: "compare-table",
+      source: "first-party",
+    });
+    expect(sourceBadgeAnalyticsData("external", "compare-drawer")).toEqual({
+      surface: "compare-drawer",
+      source: "external",
+    });
+    expect(sourceBadgeAnalyticsData("unverified", "category-ranking")).toEqual({
+      surface: "category-ranking",
+      source: "unverified",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Make SourceBadge, NotesPresenceChips, and HarnessBadge navigable on category ranking and compare table/drawer surfaces.
- Add pure `source-badge`, `notes-presence`, and `harness-badge` CTA event libs with full branch coverage for codecov patch.

## Test plan
- [x] `pnpm exec prettier --write` on changed files
- [x] `pnpm exec vitest run --coverage` for the three new CTA lib tests (100% lines/branches)
- [ ] Confirm codecov/patch, codecov/project, validate-ci, and required-pr-gate pass

Refs #550

Made with [Cursor](https://cursor.com)