### PR TITLE
test(web): cover attribute-parsing edge cases in content-section-lib

### DIFF
--- a/tests/content-section-lib.test.ts
+++ b/tests/content-section-lib.test.ts
@@ -131,6 +131,14 @@ describe("getEmbeddedSectionType", () => {
     expect(getEmbeddedSectionType("<p>section type: fake</p>")).toBeNull();
   });
 
+  it("returns null when the marker sits between two separate comments", () => {
+    expect(
+      getEmbeddedSectionType(
+        "<!-- unrelated -->plain section type: css<!-- trailer -->",
+      ),
+    ).toBeNull();
+  });
+
   it("reads the inner marker when comments are nested", () => {
     expect(
       getEmbeddedSectionType(
@@ -742,4 +750,37 @@ describe("isEssentialVariant and getSectionEyebrow", () => {
   it.each(labels)("maps variant %j to eyebrow %j", (variant, label) => {
     expect(getSectionEyebrow(variant)).toBe(label);
   });
+});
+
+describe("extractSectionSubitems id attribute parsing", () => {
+  it("ignores an id-like attribute name that is only a substring, such as data-id", () => {
+    const html = '<h3 data-id="not-the-id">Heading</h3><p>Body</p>';
+    expect(extractSectionSubitems(html, "sec")).toEqual([
+      { id: "sec-1", title: "Heading", html: "<p>Body</p>" },
+    ]);
+  });
+
+  it("falls back to a generated id when the id attribute's quote is never closed", () => {
+    const html = '<h3 id="unterminated>Heading</h3><p>Body</p>';
+    expect(extractSectionSubitems(html, "sec")).toEqual([
+      { id: "sec-1", title: "Heading", html: "<p>Body</p>" },
+    ]);
+  });
+
+  it("falls back to the body-derived title when the heading tag never gets its own closing >", () => {
+    const html = '<h3 id="broken</h3>afterward';
+    expect(extractSectionSubitems(html, "sec")).toEqual([
+      { id: "sec-1", title: "afterward", html: "afterward" },
+    ]);
+  });
+
+  it.each(["\n", "\r", "\t"])(
+    "treats %j before the id attribute as a valid boundary",
+    (whitespace) => {
+      const html = `<h3${whitespace}id="ws-id">Heading</h3><p>Body</p>`;
+      expect(extractSectionSubitems(html, "sec")).toEqual([
+        { id: "ws-id", title: "Heading", html: "<p>Body</p>" },
+      ]);
+    },
+  );
 });


### PR DESCRIPTION
## What

Raises `apps/web/src/lib/content-section-lib.ts` branch coverage from **88.31% to 97.4% (75/77)** and statements from 96.4% to 99.09% (110/111), covering 7 previously-untested edge cases in the hand-rolled HTML comment/heading/attribute parsing:

- `getEmbeddedSectionType`: a marker that sits between two *separate* comments (`<!-- a -->text section type: x<!-- b -->`) is correctly rejected — only the earlier existing tests for "no opener", "no closer", and "nested comment" were covered, not this "looks bracketed but isn't actually inside one comment" case.
- `readQuotedAttribute` (via `extractSectionSubitems`'s id lookup): an attribute name that's only a *substring* match (`data-id="..."` when searching for `id`) is correctly skipped rather than misread, because the character before the match isn't a valid attribute boundary.
- Same function: an unterminated attribute value (`id="never-closed>...`) is correctly treated as "not found" rather than reading garbage, falling back to a generated id.
- `isAttributeBoundary`'s `\n`/`\r`/`\t` boundary characters (only space/`<`/empty-string were exercised before) — parameterized with `it.each`.
- `extractHeadingInnerHtml`'s degenerate fallback path, exercised indirectly through a heading whose opening `<h3` tag never gets its own closing `>` before the literal `</h3>` — confirmed empirically (ran the exact inputs through a throwaway probe test before writing the real assertions, since the resulting title/html values for this edge case were non-obvious by inspection alone).

Two branches remain uncovered (source lines 102 and 115) and are left untouched: both are defensive `< 0` checks for "no `>` found in this string," but the only real caller always builds its input by slicing up to and including a literal `</h3>` — which itself always contains a `>` — so both checks are unreachable through the public API. Confirmed this holds for every crafted input in this PR, including the deliberately malformed ones.

## Notes

- **Test-only change** — no source behaviour is modified.
- Verified locally: `vitest run tests/content-section-lib.test.ts --coverage` → 209 tests pass; `prettier --check` and `pnpm --filter web type-check` clean.