### PR TITLE
feat(web): add entry header category badge browse analytics

### DIFF
--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -82,6 +82,8 @@ import { useCompare, useIsCompared } from "@/lib/compare";
 import { serializeCompareItems } from "@/lib/compare-selection";
 import { trackEvent, outboundHost } from "@/lib/analytics";
 import {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
   badgeChromeInstallRiskAnalyticsData,
   badgeChromeInstallRiskAnalyticsEvent,
   badgeChromeSourceAnalyticsData,
@@ -640,7 +642,18 @@ function Dossier() {
       <header className="mt-6 grid grid-cols-[minmax(0,1fr)] gap-6 border-b border-border pb-8 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <CategoryPill>{entry.category}</CategoryPill>
+            <CategoryPill
+              asLink
+              category={entry.category}
+              onNavigate={() =>
+                trackEvent(
+                  badgeChromeCategoryAnalyticsEvent(),
+                  badgeChromeCategoryAnalyticsData(entry.category, "detail-header"),
+                )
+              }
+            >
+              {entry.category}
+            </CategoryPill>
             <TrustDrilldown entry={entry} />
             <SourceBadge
               status={entry.source}

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -63,6 +63,12 @@ describe("badge chrome cta events lib", () => {
       surface: "peek-panel",
       category: "mcp",
     });
+    expect(badgeChromeCategoryAnalyticsData("skills", "detail-header")).toEqual(
+      {
+        surface: "detail-header",
+        category: "skills",
+      },
+    );
     expect(badgeChromeNotesAnalyticsEvent()).toBe("badge_notes_scroll_click");
     expect(
       badgeChromeNotesAnalyticsData("safety", true, "detail-sticky-meta"),


### PR DESCRIPTION
﻿## Summary
- Make entry header `CategoryPill` navigable (`asLink`) with privacy-light analytics
- Event: `badge_category_browse_click`
- Payload: `{ surface: "detail-header", category }` (no titles)

## Test plan
- [ ] Vitest covers `detail-header` category surface
- [ ] Click CategoryPill on an entry detail header
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
