### PR TITLE
feat(web): add contributor profile category badge analytics

### DIFF
--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -25,6 +25,8 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
   badgeChromeSourceAnalyticsData,
   badgeChromeSourceAnalyticsEvent,
   badgeChromeTrustAnalyticsData,
@@ -362,7 +364,18 @@ function ContributionRow({
           <RoleIcon className="h-3 w-3" aria-hidden />
           {roleLabel[role]}
         </span>
-        <CategoryPill>{entry.category}</CategoryPill>
+        <CategoryPill
+          asLink
+          category={entry.category}
+          onNavigate={() =>
+            trackEvent(
+              badgeChromeCategoryAnalyticsEvent(),
+              badgeChromeCategoryAnalyticsData(entry.category, "contributor-profile"),
+            )
+          }
+        >
+          {entry.category}
+        </CategoryPill>
         <TrustBadge
           level={entry.trust}
           asLink

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -69,6 +69,12 @@ describe("badge chrome cta events lib", () => {
         category: "skills",
       },
     );
+    expect(
+      badgeChromeCategoryAnalyticsData("hooks", "contributor-profile"),
+    ).toEqual({
+      surface: "contributor-profile",
+      category: "hooks",
+    });
     expect(badgeChromeNotesAnalyticsEvent()).toBe("badge_notes_scroll_click");
     expect(
       badgeChromeNotesAnalyticsData("safety", true, "detail-sticky-meta"),


### PR DESCRIPTION
﻿## Summary
- Make contributor contribution-row `CategoryPill` navigable (`asLink`) with privacy-light analytics
- Event: `badge_category_browse_click`
- Payload: `{ surface: "contributor-profile", category }` (no titles)

## Test plan
- [ ] Vitest covers `contributor-profile` category surface
- [ ] Click CategoryPill on a contribution row
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550
