### PR TITLE
feat(web): add sticky meta source badge browse analytics

### DIFF
--- a/apps/web/src/components/sticky-meta-bar.tsx
+++ b/apps/web/src/components/sticky-meta-bar.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { Link } from "@tanstack/react-router";
 import type { Entry, Harness } from "@/types/registry";
-import { CategoryPill, TrustBadge, InstallRiskBadge, NotesPresenceChips } from "./badges";
+import {
+  CategoryPill,
+  TrustBadge,
+  SourceBadge,
+  InstallRiskBadge,
+  NotesPresenceChips,
+} from "./badges";
 import { Star, ArrowUp, Shield, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -32,6 +38,8 @@ import {
   badgeChromeInstallRiskAnalyticsEvent,
   badgeChromeNotesAnalyticsData,
   badgeChromeNotesAnalyticsEvent,
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
   badgeChromeTrustAnalyticsData,
   badgeChromeTrustAnalyticsEvent,
 } from "@/lib/badge-chrome-cta-events";
@@ -219,6 +227,16 @@ export function StickyMetaBar({
                 trackEvent(
                   badgeChromeTrustAnalyticsEvent(),
                   badgeChromeTrustAnalyticsData(entry.trust, "detail-sticky-meta"),
+                )
+              }
+            />
+            <SourceBadge
+              status={entry.source}
+              asLink
+              onNavigate={() =>
+                trackEvent(
+                  badgeChromeSourceAnalyticsEvent(),
+                  badgeChromeSourceAnalyticsData(entry.source, "detail-sticky-meta"),
                 )
               }
             />

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -35,6 +35,12 @@ describe("badge chrome cta events lib", () => {
       source: "first-party",
     });
     expect(
+      badgeChromeSourceAnalyticsData("source-backed", "detail-sticky-meta"),
+    ).toEqual({
+      surface: "detail-sticky-meta",
+      source: "source-backed",
+    });
+    expect(
       badgeChromeSourceAnalyticsData("source-backed", "contributor-profile"),
     ).toEqual({
       surface: "contributor-profile",


### PR DESCRIPTION
## Summary
- Promote sticky meta `SourceBadge` to a browsable link (parity with trust/risk/notes chrome)
- Fire privacy-light `badge_source_browse_click` with `{ surface: detail-sticky-meta, source }` — no titles/URLs
- Cover `detail-sticky-meta` source payload in badge-chrome CTA lib tests

## Test plan
- [ ] Sticky meta SourceBadge navigates to `/browse?source=...`
- [ ] Click emits `badge_source_browse_click` with surface `detail-sticky-meta`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)