### PR TITLE
feat(web): add entry header notes chips scroll analytics

### DIFF
--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -86,6 +86,8 @@ import {
   badgeChromeCategoryAnalyticsEvent,
   badgeChromeInstallRiskAnalyticsData,
   badgeChromeInstallRiskAnalyticsEvent,
+  badgeChromeNotesAnalyticsData,
+  badgeChromeNotesAnalyticsEvent,
   badgeChromeSourceAnalyticsData,
   badgeChromeSourceAnalyticsEvent,
 } from "@/lib/badge-chrome-cta-events";
@@ -675,7 +677,17 @@ function Dossier() {
                 )
               }
             />
-            <NotesPresenceChips entry={entry} className="ml-1" />
+            <NotesPresenceChips
+              entry={entry}
+              className="ml-1"
+              interactive
+              onNoteClick={(noteKind, present) =>
+                trackEvent(
+                  badgeChromeNotesAnalyticsEvent(),
+                  badgeChromeNotesAnalyticsData(noteKind, present, "detail-header"),
+                )
+              }
+            />
             {entry.claimed && (
               <span className="inline-flex items-center gap-1 rounded-md bg-surface-2 px-1.5 py-0.5 text-[11px] text-ink-muted">
                 <Sparkles className="h-3 w-3" />

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -89,6 +89,13 @@ describe("badge chrome cta events lib", () => {
       noteKind: "safety",
       present: true,
     });
+    expect(
+      badgeChromeNotesAnalyticsData("privacy", false, "detail-header"),
+    ).toEqual({
+      surface: "detail-header",
+      noteKind: "privacy",
+      present: false,
+    });
     expect(badgeChromeInstallRiskAnalyticsEvent()).toBe(
       "badge_install_risk_scroll_click",
     );


### PR DESCRIPTION
## Summary
- Promote entry detail header `NotesPresenceChips` to interactive scroll buttons (parity with sticky meta)
- Fire privacy-light `badge_notes_scroll_click` with `{ surface: detail-header, noteKind, present }` — no titles/URLs
- Cover `detail-header` notes payload in badge-chrome CTA lib tests

## Test plan
- [ ] Header Safety/Privacy chips scroll to matching sections
- [ ] Click emits `badge_notes_scroll_click` with surface `detail-header`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)