### PR TITLE
feat(web): tag peek panel platform chip analytics surface

### DIFF
--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -243,7 +243,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
         <div className="mt-4 flex flex-wrap items-center gap-1">
           <span className="eyebrow mr-1">Platforms</span>
           {entry.platforms.map((p) => (
-            <PlatformChip key={p} id={p} asLink />
+            <PlatformChip key={p} id={p} asLink surface="peek-panel" />
           ))}
         </div>
       )}

--- a/tests/platform-chip-cta-events-lib.test.ts
+++ b/tests/platform-chip-cta-events-lib.test.ts
@@ -18,5 +18,9 @@ describe("platform chip cta events lib", () => {
       surface: "compare-table",
       platform: "claude-desktop",
     });
+    expect(platformChipAnalyticsData("raycast", "peek-panel")).toEqual({
+      surface: "peek-panel",
+      platform: "raycast",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Tag peek-panel `PlatformChip` clicks with `surface: peek-panel` (was generic `platform-chip` default)
- Keep privacy-light payload `{ surface, platform }` — no titles/URLs
- Cover `peek-panel` surface in platform-chip CTA lib tests

## Test plan
- [ ] Peek panel platform chip click emits `platform_chip_click` with surface `peek-panel`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)