### PR TITLE
feat(web): tag detail header platform chip analytics surface

### DIFF
--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -735,7 +735,7 @@ function Dossier() {
             <span>·</span>
             <div className="flex flex-wrap gap-1">
               {entry.platforms.map((p) => (
-                <PlatformChip key={p} id={p} asLink />
+                <PlatformChip key={p} id={p} asLink surface="detail-header" />
               ))}
             </div>
           </div>

--- a/tests/platform-chip-cta-events-lib.test.ts
+++ b/tests/platform-chip-cta-events-lib.test.ts
@@ -22,5 +22,9 @@ describe("platform chip cta events lib", () => {
       surface: "peek-panel",
       platform: "raycast",
     });
+    expect(platformChipAnalyticsData("claude-code", "detail-header")).toEqual({
+      surface: "detail-header",
+      platform: "claude-code",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Tag entry detail header `PlatformChip` clicks with `surface: detail-header` (was generic `platform-chip` default)
- Keep privacy-light payload `{ surface, platform }` — no titles/URLs
- Cover `detail-header` surface in platform-chip CTA lib tests

## Test plan
- [ ] Detail header platform chip click emits `platform_chip_click` with surface `detail-header`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)