### PR TITLE
feat(web): add entry header harness badge browse analytics

### DIFF
--- a/apps/web/src/lib/harness-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/harness-badge-cta-events-lib.ts
@@ -11,7 +11,8 @@ export type HarnessBadgeSurface =
   | typeof HARNESS_BADGE_SURFACE
   | "compare-table"
   | "compare-drawer"
-  | "category-ranking";
+  | "category-ranking"
+  | "detail-header";
 
 export function harnessBadgeAnalyticsEvent(): string {
   return "harness_badge_click";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -743,7 +743,7 @@ function Dossier() {
             <div className="mt-3 flex flex-wrap items-center gap-1.5">
               <span className="eyebrow mr-1">Harness</span>
               {entry.harness.map((h) => (
-                <HarnessBadge key={h} id={h} />
+                <HarnessBadge key={h} id={h} asLink surface="detail-header" />
               ))}
             </div>
           )}

--- a/tests/harness-badge-cta-events-lib.test.ts
+++ b/tests/harness-badge-cta-events-lib.test.ts
@@ -26,5 +26,9 @@ describe("harness badge cta events lib", () => {
       surface: "category-ranking",
       harness: "vscode",
     });
+    expect(harnessBadgeAnalyticsData("claude-code", "detail-header")).toEqual({
+      surface: "detail-header",
+      harness: "claude-code",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Promote entry detail header `HarnessBadge` to platform-hub links
- Fire privacy-light `harness_badge_click` with `{ surface: detail-header, harness }` — no titles/URLs
- Extend `HarnessBadgeSurface` + cover `detail-header` in harness-badge CTA lib tests

## Test plan
- [ ] Header harness badge navigates to `/for/\`
- [ ] Click emits `harness_badge_click` with surface `detail-header`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)