### PR TITLE
feat(web): add MCP DistTable transport, hosting, and signal drilldowns

### DIFF
--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -35,6 +35,24 @@ const NOTES_SIGNAL_BY_LABEL: Record<string, string> = {
   "Privacy notes": "privacy-notes",
 };
 
+const SUPPLY_SIGNAL_BY_LABEL: Record<string, string> = {
+  "Verified package": "trusted-package",
+  "Checksummed download": "checksums",
+};
+
+const TRANSPORT_KEY_BY_LABEL: Record<string, string> = {
+  "stdio (local)": "stdio",
+  HTTP: "http",
+  SSE: "sse",
+  Unspecified: "unspecified",
+};
+
+const HOSTING_KEY_BY_LABEL: Record<string, string> = {
+  "Local (stdio)": "local",
+  "Remote (hosted)": "remote",
+  Unspecified: "unspecified",
+};
+
 export function trustLevelFromLabel(label: string): TrustLevel | undefined {
   return TRUST_BY_LABEL[label];
 }
@@ -49,6 +67,25 @@ export function platformFromLabel(label: string): Platform | undefined {
 
 export function notesSignalFromLabel(label: string): string | undefined {
   return NOTES_SIGNAL_BY_LABEL[label];
+}
+
+export function supplyChainSignalFromLabel(label: string): string | undefined {
+  return SUPPLY_SIGNAL_BY_LABEL[label];
+}
+
+export function transportKeyFromLabel(label: string): string | undefined {
+  return TRANSPORT_KEY_BY_LABEL[label];
+}
+
+export function hostingKeyFromLabel(label: string): string | undefined {
+  return HOSTING_KEY_BY_LABEL[label];
+}
+
+export function installMethodKeyFromLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 export function browseDrilldown(search: DistBrowseSearch): DistRowDrilldown {
@@ -105,16 +142,91 @@ export function withPlatformDrilldown(rows: DistRow[]): DistRow[] {
   });
 }
 
-export function withNotesSignalDrilldown(rows: DistRow[]): DistRow[] {
+export function withNotesSignalDrilldown(rows: DistRow[], category?: string): DistRow[] {
   return rows.map((row) => {
     const signal = notesSignalFromLabel(row.label);
+    if (!signal) {
+      if (!category) return row;
+      return {
+        ...row,
+        rowKey: row.rowKey ?? row.label,
+        drilldown: browseDrilldown({ category }),
+      };
+    }
+    return {
+      ...row,
+      rowKey: signal,
+      drilldown: browseDrilldown({
+        ...(category ? { category } : {}),
+        signal,
+      }),
+    };
+  });
+}
+
+export function withSupplyChainSignalDrilldown(rows: DistRow[], category?: string): DistRow[] {
+  return rows.map((row) => {
+    const signal = supplyChainSignalFromLabel(row.label);
     if (!signal) return row;
     return {
       ...row,
       rowKey: signal,
-      drilldown: browseDrilldown({ signal }),
+      drilldown: browseDrilldown({
+        ...(category ? { category } : {}),
+        signal,
+      }),
     };
   });
+}
+
+export function withDocsCoverageDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => {
+    const signal = notesSignalFromLabel(row.label);
+    if (signal) {
+      return {
+        ...row,
+        rowKey: signal,
+        drilldown: browseDrilldown({ category, signal }),
+      };
+    }
+    return {
+      ...row,
+      rowKey: row.rowKey ?? installMethodKeyFromLabel(row.label),
+      drilldown: browseDrilldown({ category }),
+    };
+  });
+}
+
+export function withTransportDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => {
+    const key = transportKeyFromLabel(row.label);
+    if (!key) return row;
+    return {
+      ...row,
+      rowKey: key,
+      drilldown: browseDrilldown({ category }),
+    };
+  });
+}
+
+export function withHostingDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => {
+    const key = hostingKeyFromLabel(row.label);
+    if (!key) return row;
+    return {
+      ...row,
+      rowKey: key,
+      drilldown: browseDrilldown({ category }),
+    };
+  });
+}
+
+export function withInstallMethodDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => ({
+    ...row,
+    rowKey: installMethodKeyFromLabel(row.label),
+    drilldown: browseDrilldown({ category }),
+  }));
 }
 
 export function withTagDrilldown(rows: DistRow[]): DistRow[] {
@@ -165,7 +277,17 @@ export function withReportDimensionDrilldown(
     case "platform-coverage":
       return withPlatformDrilldown(rows);
     case "notes-coverage":
-      return withNotesSignalDrilldown(rows);
+      return withNotesSignalDrilldown(rows, category);
+    case "supply-chain":
+      return withSupplyChainSignalDrilldown(rows, category);
+    case "docs-coverage":
+      return withDocsCoverageDrilldown(rows, category);
+    case "transport":
+      return withTransportDrilldown(rows, category);
+    case "hosting":
+      return withHostingDrilldown(rows, category);
+    case "install-methods":
+      return withInstallMethodDrilldown(rows, category);
     case "use-cases":
       return withTagDrilldown(rows);
     case "prerequisites":

--- a/apps/web/src/routes/mcp-security-report.tsx
+++ b/apps/web/src/routes/mcp-security-report.tsx
@@ -11,7 +11,13 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
-import { withCategoryBrowseDrilldown } from "@/lib/data-report-drilldown-lib";
+import {
+  withCategoryBrowseDrilldown,
+  withDocsCoverageDrilldown,
+  withHostingDrilldown,
+  withNotesSignalDrilldown,
+  withSupplyChainSignalDrilldown,
+} from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   mcpSecurityReportCategoryBrowseAnalyticsData,
@@ -61,19 +67,17 @@ const MCP = ENTRIES.filter((e) => e.category === "mcp");
 const TOTAL = MCP.length;
 
 const NOTES = notesCoverage(MCP);
-const NOTES_DIST: DistRow[] = withCategoryBrowseDrilldown(
+const NOTES_DIST: DistRow[] = withNotesSignalDrilldown(
   [
     {
       label: "Safety notes",
       count: NOTES.safety,
       pct: pctOf(NOTES.safety, TOTAL),
-      rowKey: "safety-notes",
     },
     {
       label: "Privacy notes",
       count: NOTES.privacy,
       pct: pctOf(NOTES.privacy, TOTAL),
-      rowKey: "privacy-notes",
     },
     { label: "Both", count: NOTES.both, pct: pctOf(NOTES.both, TOTAL), rowKey: "both" },
   ],
@@ -92,35 +96,27 @@ const AUTH_DIST: DistRow[] = withCategoryBrowseDrilldown(
 );
 
 const HOSTING = hostingDistribution(MCP);
-const HOSTING_DIST: DistRow[] = withCategoryBrowseDrilldown(
+const HOSTING_DIST: DistRow[] = withHostingDrilldown(
   HOSTING.rows.map((r) => ({
     label: r.label,
     count: r.count,
     pct: pctOf(r.count, HOSTING.total),
-    rowKey:
-      r.label === "Local (stdio)"
-        ? "local"
-        : r.label === "Remote (hosted)"
-          ? "remote"
-          : "unspecified",
   })),
   "mcp",
 );
 
 const SUPPLY = supplyChainCoverage(MCP);
-const SUPPLY_DIST: DistRow[] = withCategoryBrowseDrilldown(
+const SUPPLY_DIST: DistRow[] = withSupplyChainSignalDrilldown(
   [
     {
       label: "Verified package",
       count: SUPPLY.packageVerified,
       pct: pctOf(SUPPLY.packageVerified, TOTAL),
-      rowKey: "verified-package",
     },
     {
       label: "Checksummed download",
       count: SUPPLY.checksummedDownload,
       pct: pctOf(SUPPLY.checksummedDownload, TOTAL),
-      rowKey: "checksummed-download",
     },
   ],
   "mcp",
@@ -129,7 +125,7 @@ const SUPPLY_DIST: DistRow[] = withCategoryBrowseDrilldown(
 // Documentation & disclosure coverage — how well servers are documented for safe rollout.
 const WITH_PREREQS = MCP.filter((e) => (e.prerequisites?.length ?? 0) > 0).length;
 const WITH_TROUBLESHOOTING = MCP.filter((e) => e.hasTroubleshooting).length;
-const DOCS_DIST: DistRow[] = withCategoryBrowseDrilldown(
+const DOCS_DIST: DistRow[] = withDocsCoverageDrilldown(
   [
     {
       label: "Prerequisites listed",
@@ -141,13 +137,11 @@ const DOCS_DIST: DistRow[] = withCategoryBrowseDrilldown(
       label: "Safety notes",
       count: NOTES.safety,
       pct: pctOf(NOTES.safety, TOTAL),
-      rowKey: "safety-notes",
     },
     {
       label: "Privacy notes",
       count: NOTES.privacy,
       pct: pctOf(NOTES.privacy, TOTAL),
-      rowKey: "privacy-notes",
     },
     {
       label: "Troubleshooting",

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -22,6 +22,9 @@ import {
   withSourceDrilldown,
   withTagDrilldown,
   withTrustDrilldown,
+  withTransportDrilldown,
+  withHostingDrilldown,
+  withInstallMethodDrilldown,
 } from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -83,18 +86,24 @@ const MCP = ENTRIES.filter((e) => e.category === "mcp");
 const TOTAL = MCP.length;
 
 const TRANSPORT = transportDistribution(MCP);
-const TRANSPORT_DIST: DistRow[] = TRANSPORT.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, TRANSPORT.total),
-}));
+const TRANSPORT_DIST: DistRow[] = withTransportDrilldown(
+  TRANSPORT.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, TRANSPORT.total),
+  })),
+  "mcp",
+);
 
 const HOSTING = hostingDistribution(MCP);
-const HOSTING_DIST: DistRow[] = HOSTING.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, HOSTING.total),
-}));
+const HOSTING_DIST: DistRow[] = withHostingDrilldown(
+  HOSTING.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, HOSTING.total),
+  })),
+  "mcp",
+);
 const REMOTE = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Remote (hosted)").length;
 const LOCAL = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Local (stdio)").length;
 
@@ -120,11 +129,14 @@ const SOURCE_DIST: DistRow[] = withSourceDrilldown(
 );
 
 const INSTALL = installMethodDistribution(MCP);
-const INSTALL_DIST: DistRow[] = INSTALL.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, INSTALL.total),
-}));
+const INSTALL_DIST: DistRow[] = withInstallMethodDrilldown(
+  INSTALL.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, INSTALL.total),
+  })),
+  "mcp",
+);
 
 // Most common integration tags — what these servers actually connect Claude to.
 const GENERIC_TAGS = new Set(["mcp", "mcp-server", "mcp-servers", "claude", "ai", "integration"]);
@@ -279,14 +291,24 @@ function StateOfMcpServersPage() {
         title="Transport distribution"
         help="How MCP servers connect to Claude. Local servers speak stdio; hosted servers expose an HTTP (streamable) or SSE endpoint. Classified from each entry's declared config and install command."
       >
-        <DistTable rows={TRANSPORT_DIST} />
+        <DistTable
+          rows={TRANSPORT_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("transport", row, rowIndex, TRANSPORT_DIST.length)
+          }
+        />
       </DataSection>
 
       <DataSection
         title="Local vs hosted"
         help="Whether a server runs as a local process you launch (stdio) or a remote endpoint you connect to (HTTP/SSE)."
       >
-        <DistTable rows={HOSTING_DIST} />
+        <DistTable
+          rows={HOSTING_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("hosting", row, rowIndex, HOSTING_DIST.length)
+          }
+        />
       </DataSection>
 
       <div className="mt-12 grid gap-6 lg:grid-cols-2">
@@ -332,7 +354,12 @@ function StateOfMcpServersPage() {
         title="Install methods"
         help={`How the ${INSTALL.total} MCP servers with an install command are delivered. Servers configured purely by editing a config file (no install command) are excluded here.`}
       >
-        <DistTable rows={INSTALL_DIST} />
+        <DistTable
+          rows={INSTALL_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("install-methods", row, rowIndex, INSTALL_DIST.length)
+          }
+        />
       </DataSection>
 
       <DataSection

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -2,17 +2,26 @@ import { describe, expect, it } from "vitest";
 import {
   browseDrilldown,
   categoryDrilldown,
+  hostingKeyFromLabel,
+  installMethodKeyFromLabel,
   notesSignalFromLabel,
   platformFromLabel,
   sourceStatusFromLabel,
+  supplyChainSignalFromLabel,
   tagDrilldown,
+  transportKeyFromLabel,
   trustLevelFromLabel,
   withCategoryHubDrilldown,
+  withDocsCoverageDrilldown,
+  withHostingDrilldown,
+  withInstallMethodDrilldown,
   withNotesSignalDrilldown,
   withPlatformDrilldown,
   withReportDimensionDrilldown,
   withSourceDrilldown,
+  withSupplyChainSignalDrilldown,
   withTagDrilldown,
+  withTransportDrilldown,
   withTrustDrilldown,
 } from "@/lib/data-report-drilldown-lib";
 
@@ -101,6 +110,20 @@ describe("data report drilldown lib", () => {
       },
     ]);
     expect(
+      withSourceDrilldown([{ label: "First-party", count: 3, pct: 30 }]),
+    ).toEqual([
+      {
+        label: "First-party",
+        count: 3,
+        pct: 30,
+        rowKey: "first-party",
+        drilldown: {
+          kind: "browse",
+          search: { source: "first-party" },
+        },
+      },
+    ]);
+    expect(
       withSourceDrilldown([{ label: "Unknown", count: 1, pct: 10 }]),
     ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
 
@@ -153,6 +176,48 @@ describe("data report drilldown lib", () => {
     expect(
       withNotesSignalDrilldown([{ label: "Both", count: 1, pct: 10 }]),
     ).toEqual([{ label: "Both", count: 1, pct: 10 }]);
+    expect(
+      withNotesSignalDrilldown(
+        [{ label: "Both", count: 1, pct: 10, rowKey: "both" }],
+        "mcp",
+      ),
+    ).toEqual([
+      {
+        label: "Both",
+        count: 1,
+        pct: 10,
+        rowKey: "both",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+    ]);
+    expect(
+      withNotesSignalDrilldown([{ label: "Both", count: 1, pct: 10 }], "mcp"),
+    ).toEqual([
+      {
+        label: "Both",
+        count: 1,
+        pct: 10,
+        rowKey: "Both",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+    ]);
+    expect(
+      withNotesSignalDrilldown(
+        [{ label: "Safety notes", count: 3, pct: 30 }],
+        "mcp",
+      ),
+    ).toEqual([
+      {
+        label: "Safety notes",
+        count: 3,
+        pct: 30,
+        rowKey: "safety-notes",
+        drilldown: {
+          kind: "browse",
+          search: { category: "mcp", signal: "safety-notes" },
+        },
+      },
+    ]);
 
     expect(
       withTagDrilldown([{ label: "postgres", count: 3, pct: 30 }]),
@@ -188,6 +253,155 @@ describe("data report drilldown lib", () => {
     ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
   });
 
+  it("maps MCP transport, hosting, supply-chain, and install labels", () => {
+    expect(transportKeyFromLabel("stdio (local)")).toBe("stdio");
+    expect(transportKeyFromLabel("HTTP")).toBe("http");
+    expect(transportKeyFromLabel("SSE")).toBe("sse");
+    expect(transportKeyFromLabel("Unspecified")).toBe("unspecified");
+    expect(transportKeyFromLabel("Unknown")).toBeUndefined();
+    expect(hostingKeyFromLabel("Local (stdio)")).toBe("local");
+    expect(hostingKeyFromLabel("Remote (hosted)")).toBe("remote");
+    expect(hostingKeyFromLabel("Unspecified")).toBe("unspecified");
+    expect(hostingKeyFromLabel("Unknown")).toBeUndefined();
+    expect(supplyChainSignalFromLabel("Verified package")).toBe(
+      "trusted-package",
+    );
+    expect(supplyChainSignalFromLabel("Checksummed download")).toBe(
+      "checksums",
+    );
+    expect(supplyChainSignalFromLabel("Unknown")).toBeUndefined();
+    expect(installMethodKeyFromLabel("npm / npx")).toBe("npm-npx");
+    expect(installMethodKeyFromLabel("Python (pip / uv)")).toBe(
+      "python-pip-uv",
+    );
+
+    expect(
+      withTransportDrilldown([{ label: "HTTP", count: 4, pct: 40 }], "mcp"),
+    ).toEqual([
+      {
+        label: "HTTP",
+        count: 4,
+        pct: 40,
+        rowKey: "http",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+    ]);
+    expect(
+      withTransportDrilldown([{ label: "Unknown", count: 1, pct: 10 }], "mcp"),
+    ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
+
+    expect(
+      withHostingDrilldown(
+        [{ label: "Local (stdio)", count: 5, pct: 50 }],
+        "mcp",
+      ),
+    ).toEqual([
+      {
+        label: "Local (stdio)",
+        count: 5,
+        pct: 50,
+        rowKey: "local",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+    ]);
+    expect(
+      withHostingDrilldown([{ label: "Unknown", count: 1, pct: 10 }], "mcp"),
+    ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
+
+    expect(
+      withSupplyChainSignalDrilldown(
+        [{ label: "Verified package", count: 2, pct: 20 }],
+        "mcp",
+      ),
+    ).toEqual([
+      {
+        label: "Verified package",
+        count: 2,
+        pct: 20,
+        rowKey: "trusted-package",
+        drilldown: {
+          kind: "browse",
+          search: { category: "mcp", signal: "trusted-package" },
+        },
+      },
+    ]);
+    expect(
+      withSupplyChainSignalDrilldown([
+        { label: "Checksummed download", count: 1, pct: 10 },
+      ]),
+    ).toEqual([
+      {
+        label: "Checksummed download",
+        count: 1,
+        pct: 10,
+        rowKey: "checksums",
+        drilldown: { kind: "browse", search: { signal: "checksums" } },
+      },
+    ]);
+    expect(
+      withSupplyChainSignalDrilldown(
+        [{ label: "Unknown", count: 1, pct: 10 }],
+        "mcp",
+      ),
+    ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
+
+    expect(
+      withInstallMethodDrilldown(
+        [{ label: "npm / npx", count: 3, pct: 30 }],
+        "mcp",
+      ),
+    ).toEqual([
+      {
+        label: "npm / npx",
+        count: 3,
+        pct: 30,
+        rowKey: "npm-npx",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+    ]);
+
+    expect(
+      withDocsCoverageDrilldown(
+        [
+          { label: "Safety notes", count: 2, pct: 20 },
+          {
+            label: "Prerequisites listed",
+            count: 3,
+            pct: 30,
+            rowKey: "prerequisites",
+          },
+          { label: "Troubleshooting", count: 1, pct: 10 },
+        ],
+        "mcp",
+      ),
+    ).toEqual([
+      {
+        label: "Safety notes",
+        count: 2,
+        pct: 20,
+        rowKey: "safety-notes",
+        drilldown: {
+          kind: "browse",
+          search: { category: "mcp", signal: "safety-notes" },
+        },
+      },
+      {
+        label: "Prerequisites listed",
+        count: 3,
+        pct: 30,
+        rowKey: "prerequisites",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+      {
+        label: "Troubleshooting",
+        count: 1,
+        pct: 10,
+        rowKey: "troubleshooting",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+    ]);
+  });
+
   it("attaches dimension drilldowns for known report keys", () => {
     expect(
       withReportDimensionDrilldown(
@@ -217,6 +431,41 @@ describe("data report drilldown lib", () => {
         "agents",
       )[0]?.rowKey,
     ).toBe("safety-notes");
+    expect(
+      withReportDimensionDrilldown(
+        "supply-chain",
+        [{ label: "Verified package", count: 1, pct: 100 }],
+        "mcp",
+      )[0]?.rowKey,
+    ).toBe("trusted-package");
+    expect(
+      withReportDimensionDrilldown(
+        "docs-coverage",
+        [{ label: "Privacy notes", count: 1, pct: 100 }],
+        "mcp",
+      )[0]?.rowKey,
+    ).toBe("privacy-notes");
+    expect(
+      withReportDimensionDrilldown(
+        "transport",
+        [{ label: "SSE", count: 1, pct: 100 }],
+        "mcp",
+      )[0]?.rowKey,
+    ).toBe("sse");
+    expect(
+      withReportDimensionDrilldown(
+        "hosting",
+        [{ label: "Remote (hosted)", count: 1, pct: 100 }],
+        "mcp",
+      )[0]?.rowKey,
+    ).toBe("remote");
+    expect(
+      withReportDimensionDrilldown(
+        "install-methods",
+        [{ label: "pnpm", count: 1, pct: 100 }],
+        "mcp",
+      )[0]?.rowKey,
+    ).toBe("pnpm");
     expect(
       withReportDimensionDrilldown(
         "use-cases",


### PR DESCRIPTION
## Summary
- Make State of MCP Servers transport, hosting, and install DistTables navigable into browse with privacy-light analytics.
- Upgrade MCP Security notes, supply-chain, docs, and hosting rows from category-only stubs to signal-aware or keyed drilldowns.
- Extend `data-report-drilldown-lib` with full branch coverage for codecov patch.

## Test plan
- [x] `pnpm exec prettier --write` on changed files
- [x] `pnpm exec vitest run --coverage tests/data-report-drilldown-lib.test.ts` (100% lines/branches)
- [ ] Confirm codecov/patch, codecov/project, validate-ci, and required-pr-gate pass

Refs #550

Made with [Cursor](https://cursor.com)