### PR TITLE
feat(web): add peek panel notes chips browse analytics

### DIFF
--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -235,7 +235,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
               {entry.repoStats.stars.toLocaleString()} repo
             </span>
           )}
-          <NotesPresenceChips entry={entry} className="ml-auto" />
+          <NotesPresenceChips entry={entry} className="ml-auto" asLink surface="peek-panel" />
         </div>
       </SheetHeader>
 

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -11,7 +11,8 @@ export type NotesPresenceSurface =
   | typeof NOTES_PRESENCE_SURFACE
   | "compare-table"
   | "compare-drawer"
-  | "category-ranking";
+  | "category-ranking"
+  | "peek-panel";
 
 export type NotesPresenceKind = "safety" | "privacy";
 

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -35,6 +35,11 @@ describe("notes presence cta events lib", () => {
       noteKind: "privacy",
       present: true,
     });
+    expect(notesPresenceAnalyticsData("safety", true, "peek-panel")).toEqual({
+      surface: "peek-panel",
+      noteKind: "safety",
+      present: true,
+    });
   });
 
   it("maps present notes chips to browse signal search patches", () => {


### PR DESCRIPTION
## Summary
- Promote peek-panel `NotesPresenceChips` to browse links (`asLink surface=peek-panel`)
- Fire privacy-light `notes_presence_chip_click` with `{ surface, noteKind, present }` — no titles/URLs
- Extend `NotesPresenceSurface` + cover `peek-panel` in notes-presence CTA lib tests

## Test plan
- [ ] Peek Safety/Privacy chips navigate to browse signal filters when present
- [ ] Click emits `notes_presence_chip_click` with surface `peek-panel`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)