### PR TITLE
feat(web): add MCP state report dist-row browse analytics

### DIFF
--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -19,6 +19,7 @@ import { NewsletterInline } from "@/components/newsletter-inline";
 import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
 import {
+  withCategoryBrowseDrilldown,
   withSourceDrilldown,
   withTagDrilldown,
   withTrustDrilldown,
@@ -83,18 +84,38 @@ const MCP = ENTRIES.filter((e) => e.category === "mcp");
 const TOTAL = MCP.length;
 
 const TRANSPORT = transportDistribution(MCP);
-const TRANSPORT_DIST: DistRow[] = TRANSPORT.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, TRANSPORT.total),
-}));
+const TRANSPORT_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  TRANSPORT.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, TRANSPORT.total),
+    rowKey:
+      r.label === "stdio (local)"
+        ? "stdio"
+        : r.label === "HTTP"
+          ? "http"
+          : r.label === "SSE"
+            ? "sse"
+            : "unspecified",
+  })),
+  "mcp",
+);
 
 const HOSTING = hostingDistribution(MCP);
-const HOSTING_DIST: DistRow[] = HOSTING.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, HOSTING.total),
-}));
+const HOSTING_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  HOSTING.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, HOSTING.total),
+    rowKey:
+      r.label === "Local (stdio)"
+        ? "local"
+        : r.label === "Remote (hosted)"
+          ? "remote"
+          : "unspecified",
+  })),
+  "mcp",
+);
 const REMOTE = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Remote (hosted)").length;
 const LOCAL = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Local (stdio)").length;
 
@@ -120,11 +141,18 @@ const SOURCE_DIST: DistRow[] = withSourceDrilldown(
 );
 
 const INSTALL = installMethodDistribution(MCP);
-const INSTALL_DIST: DistRow[] = INSTALL.rows.map((r) => ({
-  label: r.label,
-  count: r.count,
-  pct: pctOf(r.count, INSTALL.total),
-}));
+const INSTALL_DIST: DistRow[] = withCategoryBrowseDrilldown(
+  INSTALL.rows.map((r) => ({
+    label: r.label,
+    count: r.count,
+    pct: pctOf(r.count, INSTALL.total),
+    rowKey: r.label
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, ""),
+  })),
+  "mcp",
+);
 
 // Most common integration tags — what these servers actually connect Claude to.
 const GENERIC_TAGS = new Set(["mcp", "mcp-server", "mcp-servers", "claude", "ai", "integration"]);
@@ -279,14 +307,24 @@ function StateOfMcpServersPage() {
         title="Transport distribution"
         help="How MCP servers connect to Claude. Local servers speak stdio; hosted servers expose an HTTP (streamable) or SSE endpoint. Classified from each entry's declared config and install command."
       >
-        <DistTable rows={TRANSPORT_DIST} />
+        <DistTable
+          rows={TRANSPORT_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("transport", row, rowIndex, TRANSPORT_DIST.length)
+          }
+        />
       </DataSection>
 
       <DataSection
         title="Local vs hosted"
         help="Whether a server runs as a local process you launch (stdio) or a remote endpoint you connect to (HTTP/SSE)."
       >
-        <DistTable rows={HOSTING_DIST} />
+        <DistTable
+          rows={HOSTING_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("hosting", row, rowIndex, HOSTING_DIST.length)
+          }
+        />
       </DataSection>
 
       <div className="mt-12 grid gap-6 lg:grid-cols-2">
@@ -332,7 +370,12 @@ function StateOfMcpServersPage() {
         title="Install methods"
         help={`How the ${INSTALL.total} MCP servers with an install command are delivered. Servers configured purely by editing a config file (no install command) are excluded here.`}
       >
-        <DistTable rows={INSTALL_DIST} />
+        <DistTable
+          rows={INSTALL_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("install-methods", row, rowIndex, INSTALL_DIST.length)
+          }
+        />
       </DataSection>
 
       <DataSection


### PR DESCRIPTION
## Summary
- Promote State of MCP transport / hosting / install DistTables to category browse drilldowns
- Fire privacy-light `state_report_dist_row_click` with `{ reportId: mcp-servers, dimension, rowKey, rowIndex, rowCount }` — no labels/URLs
- Mirror mcp-security-report hosting rowKey pattern (`local` / `remote` / transport slugs)

## Test plan
- [ ] Transport / hosting / install rows navigate to `/browse?category=mcp`
- [ ] Click emits `state_report_dist_row_click` with stable `rowKey` + dimension
- [ ] type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)