### PR TITLE
feat(web): add install-risk browse and tooling install DistTable drilldowns

### DIFF
--- a/apps/web/src/components/badges.tsx
+++ b/apps/web/src/components/badges.tsx
@@ -45,6 +45,11 @@ import {
   INSTALL_RISK_DETAIL,
   type InstallRisk,
 } from "@/lib/trust";
+import {
+  installRiskBadgeAnalyticsData,
+  installRiskBadgeAnalyticsEvent,
+  installRiskBrowseSearch,
+} from "@/lib/install-risk-badge-cta-events";
 
 const trustStyles: Record<TrustLevel, { dot: string; text: string; ring: string }> = {
   trusted: { dot: "bg-trust-trusted", text: "text-trust-trusted", ring: "ring-trust-trusted/30" },
@@ -261,6 +266,8 @@ export function InstallRiskBadge({
   className,
   size = "sm",
   asButton = false,
+  asLink = false,
+  surface,
   onActivate,
 }: {
   entry: Entry;
@@ -268,6 +275,10 @@ export function InstallRiskBadge({
   size?: "sm" | "xs";
   /** Opt-in scroll control — never use inside card `<Link>`s. */
   asButton?: boolean;
+  /** Opt-in browse link — never use inside card `<Link>`s. */
+  asLink?: boolean;
+  /** Optional analytics surface when asLink is set. */
+  surface?: string;
   onActivate?: (risk: InstallRisk) => void;
 }) {
   const level = React.useMemo(() => installRiskLevel(entry), [entry]);
@@ -304,6 +315,28 @@ export function InstallRiskBadge({
       >
         {content}
       </button>
+    );
+  }
+  const browseSearch = asLink ? installRiskBrowseSearch(level) : null;
+  if (browseSearch) {
+    return (
+      <Link
+        to="/browse"
+        search={browseSearch}
+        title={`${INSTALL_RISK_LABEL[level]} — browse by trust`}
+        onClick={() => {
+          onActivate?.(level);
+          if (surface) {
+            trackEvent(
+              installRiskBadgeAnalyticsEvent(),
+              installRiskBadgeAnalyticsData(level, surface),
+            );
+          }
+        }}
+        className={cn(classes, "transition-colors hover:border-ink/20")}
+      >
+        {content}
+      </Link>
     );
   }
   return (

--- a/apps/web/src/components/category-ranking-table.tsx
+++ b/apps/web/src/components/category-ranking-table.tsx
@@ -72,7 +72,7 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                   <SourceBadge status={e.source} asLink surface="category-ranking" />
                 </td>
                 <td className="px-3 py-2.5 align-top">
-                  <InstallRiskBadge entry={e} />
+                  <InstallRiskBadge entry={e} asLink surface="category-ranking" />
                 </td>
                 <td className="px-3 py-2.5 align-top">
                   {e.installCommand ? (

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -10,7 +10,12 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { useCompare } from "@/lib/compare";
-import { CategoryPill, PlatformChip, NotesPresenceChips } from "@/components/badges";
+import {
+  CategoryPill,
+  PlatformChip,
+  NotesPresenceChips,
+  InstallRiskBadge,
+} from "@/components/badges";
 import { HarnessBadgeRow } from "@/components/harness-badge";
 import { HarnessVariantPicker } from "@/components/harness-variant-picker";
 import { TrustDrilldown } from "./trust-drilldown";
@@ -223,6 +228,10 @@ const ROWS: RowDef[] = [
   {
     label: "Notes",
     render: (e) => <NotesPresenceChips entry={e} asLink surface="compare-drawer" />,
+  },
+  {
+    label: "Install risk",
+    render: (e) => <InstallRiskBadge entry={e} asLink surface="compare-drawer" />,
   },
   {
     label: "Source repo",

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -166,7 +166,10 @@ const DECISION_COMPARISON_ROWS: RowDef[] = comparisonDecisionRows().map((row) =>
 export const COMPARISON_ROWS: RowDef[] = [
   { label: "Trust", render: (e) => <TrustDrilldown entry={e} /> },
   ...DECISION_COMPARISON_ROWS,
-  { label: "Install risk", render: (e) => <InstallRiskBadge entry={e} /> },
+  {
+    label: "Install risk",
+    render: (e) => <InstallRiskBadge entry={e} asLink surface="compare-table" />,
+  },
   {
     label: "Notes",
     render: (e) => <NotesPresenceChips entry={e} asLink surface="compare-table" />,

--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -221,11 +221,13 @@ export function withHostingDrilldown(rows: DistRow[], category: string): DistRow
   });
 }
 
-export function withInstallMethodDrilldown(rows: DistRow[], category: string): DistRow[] {
+export function withInstallMethodDrilldown(rows: DistRow[], category?: string): DistRow[] {
   return rows.map((row) => ({
     ...row,
     rowKey: installMethodKeyFromLabel(row.label),
-    drilldown: browseDrilldown({ category }),
+    drilldown: browseDrilldown({
+      ...(category ? { category } : {}),
+    }),
   }));
 }
 

--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure install-risk badge navigation analytics helpers.
+ *
+ * Maps opt-in install-risk badge browse egress to privacy-light event names
+ * without embedding display labels.
+ */
+
+export const INSTALL_RISK_BADGE_SURFACE = "install-risk-badge";
+
+export type InstallRiskBadgeSurface =
+  | typeof INSTALL_RISK_BADGE_SURFACE
+  | "compare-table"
+  | "compare-drawer"
+  | "category-ranking";
+
+export function installRiskBadgeAnalyticsEvent(): string {
+  return "install_risk_badge_click";
+}
+
+export function installRiskBadgeAnalyticsData(
+  risk: string,
+  surface: string = INSTALL_RISK_BADGE_SURFACE,
+) {
+  return {
+    surface,
+    risk,
+  };
+}
+
+/** Map an install-risk level to a browse `trust` search patch. */
+export function installRiskBrowseSearch(risk: string): { trust: string } | null {
+  switch (risk) {
+    case "low":
+      return { trust: "trusted" };
+    case "review":
+      return { trust: "review" };
+    case "high":
+      return { trust: "blocked" };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/install-risk-badge-cta-events.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Install-risk badge navigation CTA event surface.
+ */
+export {
+  INSTALL_RISK_BADGE_SURFACE,
+  installRiskBadgeAnalyticsData,
+  installRiskBadgeAnalyticsEvent,
+  installRiskBrowseSearch,
+  type InstallRiskBadgeSurface,
+} from "@/lib/install-risk-badge-cta-events-lib";

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/lib/state-report-page-cta-events";
 import {
   withCategoryHubDrilldown,
+  withInstallMethodDrilldown,
   withNotesSignalDrilldown,
   withPlatformDrilldown,
   withSourceDrilldown,
@@ -128,11 +129,13 @@ const PLATFORM_DIST: DistRow[] = withPlatformDrilldown(
 // Install-method distribution — derived from each entry's installCommand, over
 // the package-installable subset (file/config drop-ins have no install command).
 const INSTALL_METHODS = installMethodDistribution(ENTRIES);
-const INSTALL_METHOD_DIST: DistRow[] = INSTALL_METHODS.rows.map((row) => ({
-  label: row.label,
-  count: row.count,
-  pct: pctOf(row.count, INSTALL_METHODS.total),
-}));
+const INSTALL_METHOD_DIST: DistRow[] = withInstallMethodDrilldown(
+  INSTALL_METHODS.rows.map((row) => ({
+    label: row.label,
+    count: row.count,
+    pct: pctOf(row.count, INSTALL_METHODS.total),
+  })),
+);
 
 // Safety & privacy notes coverage — HeyClaude's differentiating metadata, quantified.
 const NOTES = notesCoverage(ENTRIES);
@@ -343,7 +346,12 @@ function StateOfClaudeToolingPage() {
         title="Install methods"
         help={`How the ${INSTALL_METHODS.total} package-installable resources are delivered, by install command. File and config drop-ins (agents, rules, skills, and the like) install by copying into your project rather than a package manager, so they are excluded here.`}
       >
-        <DistTable rows={INSTALL_METHOD_DIST} />
+        <DistTable
+          rows={INSTALL_METHOD_DIST}
+          onRowClick={(row, rowIndex) =>
+            trackDistRow("install-methods", row, rowIndex, INSTALL_METHOD_DIST.length)
+          }
+        />
       </DataSection>
 
       <DataSection

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -359,6 +359,17 @@ describe("data report drilldown lib", () => {
         drilldown: { kind: "browse", search: { category: "mcp" } },
       },
     ]);
+    expect(
+      withInstallMethodDrilldown([{ label: "pnpm", count: 2, pct: 20 }]),
+    ).toEqual([
+      {
+        label: "pnpm",
+        count: 2,
+        pct: 20,
+        rowKey: "pnpm",
+        drilldown: { kind: "browse", search: {} },
+      },
+    ]);
 
     expect(
       withDocsCoverageDrilldown(

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  INSTALL_RISK_BADGE_SURFACE,
+  installRiskBadgeAnalyticsData,
+  installRiskBadgeAnalyticsEvent,
+  installRiskBrowseSearch,
+} from "@/lib/install-risk-badge-cta-events-lib";
+
+describe("install risk badge cta events lib", () => {
+  it("builds privacy-light install risk analytics for each surface", () => {
+    expect(installRiskBadgeAnalyticsEvent()).toBe("install_risk_badge_click");
+    expect(installRiskBadgeAnalyticsData("low")).toEqual({
+      surface: INSTALL_RISK_BADGE_SURFACE,
+      risk: "low",
+    });
+    expect(installRiskBadgeAnalyticsData("review", "compare-table")).toEqual({
+      surface: "compare-table",
+      risk: "review",
+    });
+    expect(installRiskBadgeAnalyticsData("high", "compare-drawer")).toEqual({
+      surface: "compare-drawer",
+      risk: "high",
+    });
+    expect(installRiskBadgeAnalyticsData("low", "category-ranking")).toEqual({
+      surface: "category-ranking",
+      risk: "low",
+    });
+  });
+
+  it("maps install risk levels to browse trust search patches", () => {
+    expect(installRiskBrowseSearch("low")).toEqual({ trust: "trusted" });
+    expect(installRiskBrowseSearch("review")).toEqual({ trust: "review" });
+    expect(installRiskBrowseSearch("high")).toEqual({ trust: "blocked" });
+    expect(installRiskBrowseSearch("unknown")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Make InstallRiskBadge navigable on category ranking and compare table/drawer surfaces with privacy-light CTA analytics mapped to browse trust filters.
- Wire State of Claude Tooling install-method DistTable rows into shared drilldowns with onRowClick analytics.
- Cover every switch/branch in the new install-risk CTA lib and the optional-category install-method helper for codecov patch.

## Test plan
- [x] `pnpm exec prettier --write` on changed files
- [x] `pnpm exec vitest run --coverage` for install-risk and data-report-drilldown lib tests (100% lines/branches)
- [ ] Confirm codecov/patch, codecov/project, validate-ci, and required-pr-gate pass

Refs #550

Made with [Cursor](https://cursor.com)