### PR TITLE
feat(web): add tooling categories DataStat browse analytics

### DIFF
--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -250,6 +250,8 @@ function StateOfClaudeToolingPage() {
           label="Categories tracked"
           value={CATEGORIES.length}
           hint="agents to statuslines"
+          to="/browse"
+          onNavigate={() => trackStat("categories")}
         />
         <DataStat
           icon={GitBranch}


### PR DESCRIPTION
## Summary
- Promote State of Claude Tooling `Categories tracked` DataStat to `/browse` with click analytics
- Fire privacy-light `state_report_stat_click` with `{ reportId: claude-tooling, statKey: categories, destination: browse }` — no titles/URLs

## Test plan
- [ ] Categories tracked tile navigates to browse
- [ ] Click emits `state_report_stat_click` with `statKey: categories`
- [ ] type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)