### PR TITLE
feat(web): add peek panel harness badge browse analytics

### DIFF
--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -22,6 +22,7 @@ import {
 } from "./badges";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
+import { HarnessBadge } from "./harness-badge";
 import { HarnessVariantPicker } from "./harness-variant-picker";
 import { useHarnessPref, useCopyPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { entryDomId } from "@/lib/entry-identity";
@@ -244,6 +245,15 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
           <span className="eyebrow mr-1">Platforms</span>
           {entry.platforms.map((p) => (
             <PlatformChip key={p} id={p} asLink surface="peek-panel" />
+          ))}
+        </div>
+      )}
+
+      {entry.harness && entry.harness.length > 0 && (
+        <div className="mt-4 flex flex-wrap items-center gap-1.5">
+          <span className="eyebrow mr-1">Harness</span>
+          {entry.harness.map((h) => (
+            <HarnessBadge key={h} id={h} asLink surface="peek-panel" />
           ))}
         </div>
       )}

--- a/apps/web/src/lib/harness-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/harness-badge-cta-events-lib.ts
@@ -12,7 +12,8 @@ export type HarnessBadgeSurface =
   | "compare-table"
   | "compare-drawer"
   | "category-ranking"
-  | "detail-header";
+  | "detail-header"
+  | "peek-panel";
 
 export function harnessBadgeAnalyticsEvent(): string {
   return "harness_badge_click";

--- a/tests/harness-badge-cta-events-lib.test.ts
+++ b/tests/harness-badge-cta-events-lib.test.ts
@@ -30,5 +30,9 @@ describe("harness badge cta events lib", () => {
       surface: "detail-header",
       harness: "claude-code",
     });
+    expect(harnessBadgeAnalyticsData("cursor", "peek-panel")).toEqual({
+      surface: "peek-panel",
+      harness: "cursor",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Render peek-panel `HarnessBadge` row (parity with detail-header) linking to platform hubs
- Fire privacy-light `harness_badge_click` with `{ surface: peek-panel, harness }` — no titles/URLs
- Extend `HarnessBadgeSurface` + cover `peek-panel` in harness-badge CTA lib tests

Replaces closed #5173 (LoopOver correctly flagged a missing render; this PR includes the JSX).

## Test plan
- [ ] Peek harness badges render next to platforms and navigate to `/for/\`
- [ ] Click emits `harness_badge_click` with surface `peek-panel`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)