### PR TITLE
feat(web): add trust badge browse analytics on ranking and tray

### DIFF
--- a/apps/web/src/components/badges.tsx
+++ b/apps/web/src/components/badges.tsx
@@ -50,6 +50,11 @@ import {
   installRiskBadgeAnalyticsEvent,
   installRiskBrowseSearch,
 } from "@/lib/install-risk-badge-cta-events";
+import {
+  trustBadgeAnalyticsData,
+  trustBadgeAnalyticsEvent,
+  trustBrowseSearch,
+} from "@/lib/trust-badge-cta-events";
 
 const trustStyles: Record<TrustLevel, { dot: string; text: string; ring: string }> = {
   trusted: { dot: "bg-trust-trusted", text: "text-trust-trusted", ring: "ring-trust-trusted/30" },
@@ -69,12 +74,15 @@ export function TrustBadge({
   level,
   className,
   asLink = false,
+  surface,
   onNavigate,
 }: {
   level: TrustLevel;
   className?: string;
   /** Opt-in browse link — never use inside card `<Link>`s. */
   asLink?: boolean;
+  /** Optional analytics surface when asLink is set. */
+  surface?: string;
   onNavigate?: () => void;
 }) {
   const s = trustStyles[level];
@@ -90,12 +98,18 @@ export function TrustBadge({
     s.text,
     className,
   );
-  if (asLink) {
+  const browseSearch = asLink ? trustBrowseSearch(level) : null;
+  if (asLink && browseSearch) {
     return (
       <Link
         to="/browse"
-        search={{ trust: level }}
-        onClick={onNavigate}
+        search={browseSearch}
+        onClick={() => {
+          onNavigate?.();
+          if (surface) {
+            trackEvent(trustBadgeAnalyticsEvent(), trustBadgeAnalyticsData(level, surface));
+          }
+        }}
         className={cn(classes, "transition-colors hover:border-ink/20")}
         title={`${TRUST_LABEL[level]} — browse by trust`}
       >

--- a/apps/web/src/components/category-ranking-table.tsx
+++ b/apps/web/src/components/category-ranking-table.tsx
@@ -4,6 +4,7 @@ import {
   InstallRiskBadge,
   NotesPresenceChips,
   SourceBadge,
+  TrustBadge,
 } from "@/components/badges";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -31,22 +32,24 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
         HeyClaude&apos;s metadata review, not by repo popularity.
       </p>
       <div className="mt-5 overflow-x-auto rounded-xl border border-border">
-        <table className="w-full min-w-[44rem] border-collapse text-left">
+        <table className="w-full min-w-[52rem] border-collapse text-left">
           <caption className="sr-only">
-            Top Claude {label} compared by source, install risk, setup, platform support, and
+            Top Claude {label} compared by trust, source, install risk, setup, platform support, and
             disclosed notes.
           </caption>
           <thead className="bg-surface">
             <tr>
-              {["Resource", "Source", "Install risk", "Setup", "Platforms", "Notes"].map((head) => (
-                <th
-                  key={head}
-                  scope="col"
-                  className="border-b border-border px-3 py-2.5 text-xs font-semibold text-ink-muted"
-                >
-                  {head}
-                </th>
-              ))}
+              {["Resource", "Trust", "Source", "Install risk", "Setup", "Platforms", "Notes"].map(
+                (head) => (
+                  <th
+                    key={head}
+                    scope="col"
+                    className="border-b border-border px-3 py-2.5 text-xs font-semibold text-ink-muted"
+                  >
+                    {head}
+                  </th>
+                ),
+              )}
             </tr>
           </thead>
           <tbody>
@@ -68,6 +71,9 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                   </Link>
                   <div className="mt-0.5 text-xs text-ink-subtle">{e.author}</div>
                 </th>
+                <td className="px-3 py-2.5 align-top">
+                  <TrustBadge level={e.trust} asLink surface="category-ranking" />
+                </td>
                 <td className="px-3 py-2.5 align-top">
                   <SourceBadge status={e.source} asLink surface="category-ranking" />
                 </td>

--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -31,12 +31,6 @@ import {
   comparisonTrayViewSelectionAnalyticsData,
   comparisonTrayViewSelectionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
-import {
-  badgeChromeSourceAnalyticsData,
-  badgeChromeSourceAnalyticsEvent,
-  badgeChromeTrustAnalyticsData,
-  badgeChromeTrustAnalyticsEvent,
-} from "@/lib/badge-chrome-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { TrustBadge, SourceBadge, ReadinessDot } from "./badges";
 import { compareSignalToneClass } from "@/lib/compare-entry-signals";
@@ -60,26 +54,12 @@ function TrayChip({
       <span className="max-w-[9rem] truncate font-medium text-ink sm:max-w-[12rem]">
         {entry.title}
       </span>
-      <TrustBadge
-        level={entry.trust}
-        asLink
-        onNavigate={() =>
-          trackEvent(
-            badgeChromeTrustAnalyticsEvent(),
-            badgeChromeTrustAnalyticsData(entry.trust, "compare-tray"),
-          )
-        }
-      />
+      <TrustBadge level={entry.trust} asLink surface="compare-tray" />
       <SourceBadge
         status={entry.source}
         className="hidden sm:inline-flex"
         asLink
-        onNavigate={() =>
-          trackEvent(
-            badgeChromeSourceAnalyticsEvent(),
-            badgeChromeSourceAnalyticsData(entry.source, "compare-tray"),
-          )
-        }
+        surface="compare-tray"
       />
       <span className="inline-flex items-center gap-0.5 text-ink-subtle" aria-hidden>
         <Shield

--- a/apps/web/src/lib/trust-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/trust-badge-cta-events-lib.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure trust badge navigation analytics helpers.
+ *
+ * Maps opt-in trust badge browse egress to privacy-light event names without
+ * embedding display labels.
+ */
+
+export const TRUST_BADGE_SURFACE = "trust-badge";
+
+export type TrustBadgeSurface =
+  | typeof TRUST_BADGE_SURFACE
+  | "category-ranking"
+  | "compare-tray"
+  | "compare-table"
+  | "compare-drawer";
+
+export function trustBadgeAnalyticsEvent(): string {
+  return "trust_badge_click";
+}
+
+export function trustBadgeAnalyticsData(trust: string, surface: string = TRUST_BADGE_SURFACE) {
+  return {
+    surface,
+    trust,
+  };
+}
+
+/** Map a trust level to a browse `trust` search patch. */
+export function trustBrowseSearch(trust: string): { trust: string } | null {
+  switch (trust) {
+    case "trusted":
+      return { trust: "trusted" };
+    case "review":
+      return { trust: "review" };
+    case "limited":
+      return { trust: "limited" };
+    case "blocked":
+      return { trust: "blocked" };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/trust-badge-cta-events.ts
+++ b/apps/web/src/lib/trust-badge-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Trust badge navigation CTA event surface.
+ */
+export {
+  TRUST_BADGE_SURFACE,
+  trustBadgeAnalyticsData,
+  trustBadgeAnalyticsEvent,
+  trustBrowseSearch,
+  type TrustBadgeSurface,
+} from "@/lib/trust-badge-cta-events-lib";

--- a/tests/trust-badge-cta-events-lib.test.ts
+++ b/tests/trust-badge-cta-events-lib.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  TRUST_BADGE_SURFACE,
+  trustBadgeAnalyticsData,
+  trustBadgeAnalyticsEvent,
+  trustBrowseSearch,
+} from "@/lib/trust-badge-cta-events-lib";
+
+describe("trust badge cta events lib", () => {
+  it("builds privacy-light trust badge analytics for each surface", () => {
+    expect(trustBadgeAnalyticsEvent()).toBe("trust_badge_click");
+    expect(trustBadgeAnalyticsData("trusted")).toEqual({
+      surface: TRUST_BADGE_SURFACE,
+      trust: "trusted",
+    });
+    expect(trustBadgeAnalyticsData("review", "category-ranking")).toEqual({
+      surface: "category-ranking",
+      trust: "review",
+    });
+    expect(trustBadgeAnalyticsData("limited", "compare-tray")).toEqual({
+      surface: "compare-tray",
+      trust: "limited",
+    });
+    expect(trustBadgeAnalyticsData("blocked", "compare-table")).toEqual({
+      surface: "compare-table",
+      trust: "blocked",
+    });
+    expect(trustBadgeAnalyticsData("trusted", "compare-drawer")).toEqual({
+      surface: "compare-drawer",
+      trust: "trusted",
+    });
+  });
+
+  it("maps trust levels to browse trust search patches", () => {
+    expect(trustBrowseSearch("trusted")).toEqual({ trust: "trusted" });
+    expect(trustBrowseSearch("review")).toEqual({ trust: "review" });
+    expect(trustBrowseSearch("limited")).toEqual({ trust: "limited" });
+    expect(trustBrowseSearch("blocked")).toEqual({ trust: "blocked" });
+    expect(trustBrowseSearch("unknown")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add pure `trust-badge-cta-events-lib` helpers with full switch-branch coverage for browse trust filters.
- Add a Trust column with navigable TrustBadge chips on category ranking tables.
- Standardize compare-tray trust and source chips on the dedicated CTA surfaces instead of badge-chrome callbacks.

## Test plan
- [x] `pnpm exec prettier --write` on changed files
- [x] `pnpm exec vitest run --coverage tests/trust-badge-cta-events-lib.test.ts` (100% lines/branches)
- [ ] Confirm codecov/patch, codecov/project, validate-ci, and required-pr-gate pass

Refs #550

Made with [Cursor](https://cursor.com)