### PR TITLE
feat(web): add trust drilldown surface analytics and browse egress

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -15,6 +15,7 @@ import {
   PlatformChip,
   NotesPresenceChips,
   InstallRiskBadge,
+  SourceBadge,
 } from "@/components/badges";
 import { HarnessBadgeRow } from "@/components/harness-badge";
 import { HarnessVariantPicker } from "@/components/harness-variant-picker";
@@ -144,7 +145,7 @@ function CompareDrawerSourceCell({ entry }: { entry: Entry }) {
 const ROWS: RowDef[] = [
   {
     label: "Trust",
-    render: (e) => <TrustDrilldown entry={e} />,
+    render: (e) => <TrustDrilldown entry={e} surface="compare-drawer" />,
   },
   ...compareDrawerDecisionRows().map((row) => ({
     label: row.label,
@@ -246,6 +247,10 @@ const ROWS: RowDef[] = [
   {
     label: "Snippet",
     render: (e) => <SnippetCell entry={e} />,
+  },
+  {
+    label: "Source status",
+    render: (e) => <SourceBadge status={e.source} asLink surface="compare-drawer" />,
   },
   {
     label: "Source",

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -164,7 +164,7 @@ const DECISION_COMPARISON_ROWS: RowDef[] = comparisonDecisionRows().map((row) =>
 
 /** Shared comparison field definitions — used by the interactive /compare page and curated pages. */
 export const COMPARISON_ROWS: RowDef[] = [
-  { label: "Trust", render: (e) => <TrustDrilldown entry={e} /> },
+  { label: "Trust", render: (e) => <TrustDrilldown entry={e} surface="compare-table" /> },
   ...DECISION_COMPARISON_ROWS,
   {
     label: "Install risk",

--- a/apps/web/src/components/trust-drilldown.tsx
+++ b/apps/web/src/components/trust-drilldown.tsx
@@ -16,6 +16,9 @@ import { Link } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
 import { trackEvent } from "@/lib/analytics";
 import {
+  trustDrilldownBrowseAnalyticsData,
+  trustDrilldownBrowseAnalyticsEvent,
+  trustDrilldownBrowseSearch,
   trustDrilldownDocAnalyticsData,
   trustDrilldownDocAnalyticsEvent,
   trustDrilldownMethodologyAnalyticsData,
@@ -24,6 +27,8 @@ import {
   trustDrilldownOpenAnalyticsEvent,
   trustDrilldownSourceAnalyticsData,
   trustDrilldownSourceAnalyticsEvent,
+  TRUST_DRILLDOWN_SURFACE,
+  type TrustDrilldownSurface,
 } from "@/lib/trust-drilldown-cta-events";
 
 const SEV_META = {
@@ -36,13 +41,17 @@ const SEV_META = {
 export function TrustDrilldown({
   entry,
   align = "start",
+  surface = TRUST_DRILLDOWN_SURFACE,
 }: {
   entry: Entry;
   align?: "start" | "center" | "end";
+  /** Analytics surface for drilldown opens and egress. */
+  surface?: TrustDrilldownSurface;
 }) {
   const reasons = React.useMemo(() => getTrustReasons(entry), [entry]);
   const counts = summarizeTrust(reasons);
   const summary = trustSummaryLine(counts);
+  const browseSearch = trustDrilldownBrowseSearch(entry.trust);
 
   return (
     <Popover>
@@ -59,6 +68,7 @@ export function TrustDrilldown({
                 entry.slug,
                 entry.trust,
                 reasons.length,
+                surface,
               ),
             )
           }
@@ -72,24 +82,53 @@ export function TrustDrilldown({
             <div className="eyebrow">Trust drilldown</div>
             <div className="mt-0.5 font-display text-sm font-semibold text-ink">{entry.title}</div>
           </div>
-          <Link
-            to="/quality"
-            hash="methodology"
-            className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] font-medium text-ink hover:bg-surface-2"
-            onClick={() =>
-              trackEvent(
-                trustDrilldownMethodologyAnalyticsEvent(),
-                trustDrilldownMethodologyAnalyticsData(entry.category, entry.slug),
-              )
-            }
-          >
-            Methodology
-            <ArrowUpRight className="h-3 w-3" />
-          </Link>
+          <div className="flex flex-col items-end gap-1">
+            <Link
+              to="/quality"
+              hash="methodology"
+              className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] font-medium text-ink hover:bg-surface-2"
+              onClick={() =>
+                trackEvent(
+                  trustDrilldownMethodologyAnalyticsEvent(),
+                  trustDrilldownMethodologyAnalyticsData(entry.category, entry.slug, surface),
+                )
+              }
+            >
+              Methodology
+              <ArrowUpRight className="h-3 w-3" />
+            </Link>
+            {browseSearch && (
+              <Link
+                to="/browse"
+                search={browseSearch}
+                className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] font-medium text-ink-muted hover:bg-surface-2 hover:text-ink"
+                onClick={() =>
+                  trackEvent(
+                    trustDrilldownBrowseAnalyticsEvent(),
+                    trustDrilldownBrowseAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      entry.trust,
+                      surface,
+                    ),
+                  )
+                }
+              >
+                Browse similar
+                <ArrowUpRight className="h-3 w-3" />
+              </Link>
+            )}
+          </div>
         </header>
         <ul className="max-h-[60vh] divide-y divide-border overflow-y-auto">
           {reasons.map((r) => (
-            <TrustReasonRow key={r.id} reason={r} category={entry.category} slug={entry.slug} />
+            <TrustReasonRow
+              key={r.id}
+              reason={r}
+              category={entry.category}
+              slug={entry.slug}
+              surface={surface}
+            />
           ))}
         </ul>
       </PopoverContent>
@@ -101,10 +140,12 @@ function TrustReasonRow({
   reason,
   category,
   slug,
+  surface,
 }: {
   reason: TrustReason;
   category: string;
   slug: string;
+  surface: TrustDrilldownSurface;
 }) {
   const meta = SEV_META[reason.severity];
   const { Icon } = meta;
@@ -133,7 +174,13 @@ function TrustReasonRow({
               onClick={() =>
                 trackEvent(
                   trustDrilldownDocAnalyticsEvent(),
-                  trustDrilldownDocAnalyticsData(category, slug, reason.id, reason.severity),
+                  trustDrilldownDocAnalyticsData(
+                    category,
+                    slug,
+                    reason.id,
+                    reason.severity,
+                    surface,
+                  ),
                 )
               }
             >
@@ -149,7 +196,13 @@ function TrustReasonRow({
               onClick={() =>
                 trackEvent(
                   trustDrilldownSourceAnalyticsEvent(),
-                  trustDrilldownSourceAnalyticsData(category, slug, reason.id, reason.severity),
+                  trustDrilldownSourceAnalyticsData(
+                    category,
+                    slug,
+                    reason.id,
+                    reason.severity,
+                    surface,
+                  ),
                 )
               }
             >

--- a/apps/web/src/lib/trust-drilldown-cta-events-lib.ts
+++ b/apps/web/src/lib/trust-drilldown-cta-events-lib.ts
@@ -1,11 +1,18 @@
 /**
  * Pure trust drilldown navigation analytics helpers.
  *
- * Maps methodology egress, reason doc links, and external source opens to
- * privacy-light event names without embedding titles, URLs, or free text.
+ * Maps methodology egress, reason doc links, external source opens, and trust
+ * browse egress to privacy-light event names without embedding titles, URLs, or
+ * free text.
  */
 
 export const TRUST_DRILLDOWN_SURFACE = "trust-drilldown";
+
+export type TrustDrilldownSurface =
+  | typeof TRUST_DRILLDOWN_SURFACE
+  | "compare-table"
+  | "compare-drawer"
+  | "detail-header";
 
 export function trustDrilldownEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;
@@ -20,9 +27,10 @@ export function trustDrilldownOpenAnalyticsData(
   slug: string,
   trust: string,
   reasonCount: number,
+  surface: string = TRUST_DRILLDOWN_SURFACE,
 ) {
   return {
-    surface: TRUST_DRILLDOWN_SURFACE,
+    surface,
     entry: trustDrilldownEntryKey(category, slug),
     trust,
     reasonCount,
@@ -33,9 +41,13 @@ export function trustDrilldownMethodologyAnalyticsEvent(): string {
   return "trust_drilldown_methodology_click";
 }
 
-export function trustDrilldownMethodologyAnalyticsData(category: string, slug: string) {
+export function trustDrilldownMethodologyAnalyticsData(
+  category: string,
+  slug: string,
+  surface: string = TRUST_DRILLDOWN_SURFACE,
+) {
   return {
-    surface: TRUST_DRILLDOWN_SURFACE,
+    surface,
     entry: trustDrilldownEntryKey(category, slug),
   };
 }
@@ -49,9 +61,10 @@ export function trustDrilldownDocAnalyticsData(
   slug: string,
   reasonId: string,
   severity: string,
+  surface: string = TRUST_DRILLDOWN_SURFACE,
 ) {
   return {
-    surface: TRUST_DRILLDOWN_SURFACE,
+    surface,
     entry: trustDrilldownEntryKey(category, slug),
     reasonId,
     severity,
@@ -67,11 +80,45 @@ export function trustDrilldownSourceAnalyticsData(
   slug: string,
   reasonId: string,
   severity: string,
+  surface: string = TRUST_DRILLDOWN_SURFACE,
 ) {
   return {
-    surface: TRUST_DRILLDOWN_SURFACE,
+    surface,
     entry: trustDrilldownEntryKey(category, slug),
     reasonId,
     severity,
   };
+}
+
+export function trustDrilldownBrowseAnalyticsEvent(): string {
+  return "trust_drilldown_browse_click";
+}
+
+export function trustDrilldownBrowseAnalyticsData(
+  category: string,
+  slug: string,
+  trust: string,
+  surface: string = TRUST_DRILLDOWN_SURFACE,
+) {
+  return {
+    surface,
+    entry: trustDrilldownEntryKey(category, slug),
+    trust,
+  };
+}
+
+/** Map a trust level to a browse `trust` search patch. */
+export function trustDrilldownBrowseSearch(trust: string): { trust: string } | null {
+  switch (trust) {
+    case "trusted":
+      return { trust: "trusted" };
+    case "review":
+      return { trust: "review" };
+    case "limited":
+      return { trust: "limited" };
+    case "blocked":
+      return { trust: "blocked" };
+    default:
+      return null;
+  }
 }

--- a/apps/web/src/lib/trust-drilldown-cta-events.ts
+++ b/apps/web/src/lib/trust-drilldown-cta-events.ts
@@ -3,6 +3,9 @@
  */
 export {
   TRUST_DRILLDOWN_SURFACE,
+  trustDrilldownBrowseAnalyticsData,
+  trustDrilldownBrowseAnalyticsEvent,
+  trustDrilldownBrowseSearch,
   trustDrilldownDocAnalyticsData,
   trustDrilldownDocAnalyticsEvent,
   trustDrilldownEntryKey,
@@ -12,4 +15,5 @@ export {
   trustDrilldownOpenAnalyticsEvent,
   trustDrilldownSourceAnalyticsData,
   trustDrilldownSourceAnalyticsEvent,
+  type TrustDrilldownSurface,
 } from "@/lib/trust-drilldown-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -656,7 +656,7 @@ function Dossier() {
             >
               {entry.category}
             </CategoryPill>
-            <TrustDrilldown entry={entry} />
+            <TrustDrilldown entry={entry} surface="detail-header" />
             <SourceBadge
               status={entry.source}
               asLink

--- a/tests/trust-drilldown-cta-events-lib.test.ts
+++ b/tests/trust-drilldown-cta-events-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   TRUST_DRILLDOWN_SURFACE,
+  trustDrilldownBrowseAnalyticsData,
+  trustDrilldownBrowseAnalyticsEvent,
+  trustDrilldownBrowseSearch,
   trustDrilldownDocAnalyticsData,
   trustDrilldownDocAnalyticsEvent,
   trustDrilldownEntryKey,
@@ -13,7 +16,7 @@ import {
 } from "@/lib/trust-drilldown-cta-events-lib";
 
 describe("trust drilldown cta events lib", () => {
-  it("builds trust drilldown navigation analytics", () => {
+  it("builds trust drilldown navigation analytics for each surface", () => {
     expect(trustDrilldownEntryKey("mcp", "browser")).toBe("mcp/browser");
     expect(trustDrilldownOpenAnalyticsEvent()).toBe(
       "trust_drilldown_open_click",
@@ -26,6 +29,48 @@ describe("trust drilldown cta events lib", () => {
       trust: "trusted",
       reasonCount: 4,
     });
+    expect(
+      trustDrilldownOpenAnalyticsData(
+        "mcp",
+        "browser",
+        "trusted",
+        4,
+        "compare-table",
+      ),
+    ).toEqual({
+      surface: "compare-table",
+      entry: "mcp/browser",
+      trust: "trusted",
+      reasonCount: 4,
+    });
+    expect(
+      trustDrilldownOpenAnalyticsData(
+        "skills",
+        "lint",
+        "review",
+        2,
+        "compare-drawer",
+      ),
+    ).toEqual({
+      surface: "compare-drawer",
+      entry: "skills/lint",
+      trust: "review",
+      reasonCount: 2,
+    });
+    expect(
+      trustDrilldownOpenAnalyticsData(
+        "tooling",
+        "fmt",
+        "limited",
+        1,
+        "detail-header",
+      ),
+    ).toEqual({
+      surface: "detail-header",
+      entry: "tooling/fmt",
+      trust: "limited",
+      reasonCount: 1,
+    });
     expect(trustDrilldownMethodologyAnalyticsEvent()).toBe(
       "trust_drilldown_methodology_click",
     );
@@ -33,11 +78,31 @@ describe("trust drilldown cta events lib", () => {
       surface: TRUST_DRILLDOWN_SURFACE,
       entry: "mcp/browser",
     });
+    expect(
+      trustDrilldownMethodologyAnalyticsData("mcp", "browser", "compare-table"),
+    ).toEqual({
+      surface: "compare-table",
+      entry: "mcp/browser",
+    });
     expect(trustDrilldownDocAnalyticsEvent()).toBe("trust_drilldown_doc_click");
     expect(
       trustDrilldownDocAnalyticsData("mcp", "browser", "source-ok", "ok"),
     ).toEqual({
       surface: TRUST_DRILLDOWN_SURFACE,
+      entry: "mcp/browser",
+      reasonId: "source-ok",
+      severity: "ok",
+    });
+    expect(
+      trustDrilldownDocAnalyticsData(
+        "mcp",
+        "browser",
+        "source-ok",
+        "ok",
+        "detail-header",
+      ),
+    ).toEqual({
+      surface: "detail-header",
       entry: "mcp/browser",
       reasonId: "source-ok",
       severity: "ok",
@@ -53,5 +118,52 @@ describe("trust drilldown cta events lib", () => {
       reasonId: "repo-stars",
       severity: "info",
     });
+    expect(
+      trustDrilldownSourceAnalyticsData(
+        "mcp",
+        "browser",
+        "repo-stars",
+        "info",
+        "compare-drawer",
+      ),
+    ).toEqual({
+      surface: "compare-drawer",
+      entry: "mcp/browser",
+      reasonId: "repo-stars",
+      severity: "info",
+    });
+  });
+
+  it("maps trust drilldown browse egress to privacy-light analytics", () => {
+    expect(trustDrilldownBrowseAnalyticsEvent()).toBe(
+      "trust_drilldown_browse_click",
+    );
+    expect(
+      trustDrilldownBrowseAnalyticsData("mcp", "browser", "trusted"),
+    ).toEqual({
+      surface: TRUST_DRILLDOWN_SURFACE,
+      entry: "mcp/browser",
+      trust: "trusted",
+    });
+    expect(
+      trustDrilldownBrowseAnalyticsData(
+        "mcp",
+        "browser",
+        "review",
+        "compare-table",
+      ),
+    ).toEqual({
+      surface: "compare-table",
+      entry: "mcp/browser",
+      trust: "review",
+    });
+  });
+
+  it("maps trust levels to browse search patches", () => {
+    expect(trustDrilldownBrowseSearch("trusted")).toEqual({ trust: "trusted" });
+    expect(trustDrilldownBrowseSearch("review")).toEqual({ trust: "review" });
+    expect(trustDrilldownBrowseSearch("limited")).toEqual({ trust: "limited" });
+    expect(trustDrilldownBrowseSearch("blocked")).toEqual({ trust: "blocked" });
+    expect(trustDrilldownBrowseSearch("unknown")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Tag trust drilldown open, methodology, doc, source, and browse events with surface context (`compare-table`, `compare-drawer`, `detail-header`) so analytics can distinguish where users opened the popover.
- Add **Browse similar** egress from the trust drilldown header that maps trust levels to browse search patches.
- Wire compare-table, compare-drawer, and entry detail headers; add compare-drawer **Source status** row with browseable `SourceBadge` to mirror the comparison table.

## Test plan
- [x] `pnpm exec vitest run tests/trust-drilldown-cta-events-lib.test.ts` — all surfaces + browse search switch arms covered
- [ ] CI: validate-ci, codecov/patch, codecov/project, required-pr-gate, LoopOver

Refs #550

Made with [Cursor](https://cursor.com)