### PR TITLE
feat(web): add resource card and hub badge browse egress

### DIFF
--- a/apps/web/src/components/hub-highlights.tsx
+++ b/apps/web/src/components/hub-highlights.tsx
@@ -14,6 +14,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   hubHighlightEntryAnalyticsData,
   hubHighlightEntryAnalyticsEvent,
+  hubHighlightSourceBrowseAnalyticsData,
+  hubHighlightSourceBrowseAnalyticsEvent,
 } from "@/lib/hub-entry-cta-events";
 import {
   hubSignalStatAnalyticsData,
@@ -57,35 +59,46 @@ export function HubHighlights({
           const Icon = HIGHLIGHT_ICON[h.kind];
           return (
             <li key={`${h.kind}-${h.entry.category}/${h.entry.slug}`}>
-              <Link
-                to="/entry/$category/$slug"
-                params={{ category: h.entry.category, slug: h.entry.slug }}
-                onClick={() =>
-                  trackEvent(
-                    hubHighlightEntryAnalyticsEvent(),
-                    hubHighlightEntryAnalyticsData(
-                      h.entry.category,
-                      h.entry.slug,
-                      h.kind,
-                      highlights.length,
-                    ),
-                  )
-                }
-                className="group flex h-full flex-col rounded-xl border border-border bg-surface p-4 transition-colors hover:border-ink/20 hover:bg-surface-2"
-              >
-                <div className="flex items-center gap-1.5 eyebrow">
-                  <Icon className="h-3.5 w-3.5 text-accent" aria-hidden />
-                  {h.label}
-                </div>
-                <div className="mt-2 font-display text-sm font-semibold text-ink group-hover:underline">
-                  {h.entry.title}
-                </div>
-                <p className="mt-1 flex-1 text-xs text-ink-muted">{h.reason}</p>
+              <div className="group flex h-full flex-col rounded-xl border border-border bg-surface p-4 transition-colors hover:border-ink/20 hover:bg-surface-2">
+                <Link
+                  to="/entry/$category/$slug"
+                  params={{ category: h.entry.category, slug: h.entry.slug }}
+                  onClick={() =>
+                    trackEvent(
+                      hubHighlightEntryAnalyticsEvent(),
+                      hubHighlightEntryAnalyticsData(
+                        h.entry.category,
+                        h.entry.slug,
+                        h.kind,
+                        highlights.length,
+                      ),
+                    )
+                  }
+                  className="flex flex-1 flex-col focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
+                >
+                  <div className="flex items-center gap-1.5 eyebrow">
+                    <Icon className="h-3.5 w-3.5 text-accent" aria-hidden />
+                    {h.label}
+                  </div>
+                  <div className="mt-2 font-display text-sm font-semibold text-ink group-hover:underline">
+                    {h.entry.title}
+                  </div>
+                  <p className="mt-1 flex-1 text-xs text-ink-muted">{h.reason}</p>
+                </Link>
                 <div className="mt-3 flex flex-wrap items-center gap-1.5">
                   <TrustBadge level={h.entry.trust} />
-                  <SourceBadge status={h.entry.source} />
+                  <SourceBadge
+                    status={h.entry.source}
+                    asLink
+                    onNavigate={() =>
+                      trackEvent(
+                        hubHighlightSourceBrowseAnalyticsEvent(),
+                        hubHighlightSourceBrowseAnalyticsData(h.entry.source, h.kind),
+                      )
+                    }
+                  />
                 </div>
-              </Link>
+              </div>
             </li>
           );
         })}

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -212,7 +212,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
               )
             }
           />
-          <InstallRiskBadge entry={entry} size="xs" />
+          <InstallRiskBadge entry={entry} size="xs" asLink surface="peek-panel" />
         </div>
         <div className="flex min-w-0 items-start gap-3">
           <EntryBrandMark entry={entry} size="md" priority className="mt-0.5" />

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -20,6 +20,8 @@ import { LazyEntryAuthorAttribution } from "./lazy-linked-attribution";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { recordIntentEvent } from "@/lib/intent-event-client";
 import {
+  resourceCardCategoryBrowseAnalyticsData,
+  resourceCardCategoryBrowseAnalyticsEvent,
   resourceCardCompareAnalyticsData,
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
@@ -201,7 +203,6 @@ function ResourceCardInner({
             </span>
           )}
           <EntryBrandMark entry={entry} size="xs" />
-          <CategoryPill>{entry.category}</CategoryPill>
           <span className="min-w-0 flex-1 truncate font-medium text-ink group-hover:underline">
             {entry.title}
           </span>
@@ -211,8 +212,21 @@ function ResourceCardInner({
           <span className="hidden sm:inline-flex">
             <SourceRepoStars entry={entry} compact />
           </span>
-          <TrustBadge level={entry.trust} />
         </Link>
+        <CategoryPill
+          asLink
+          category={entry.category}
+          onNavigate={() =>
+            trackEvent(
+              resourceCardCategoryBrowseAnalyticsEvent(),
+              resourceCardCategoryBrowseAnalyticsData(entry.category, analyticsSurface),
+            )
+          }
+        >
+          {entry.category}
+        </CategoryPill>
+        <SourceBadge status={entry.source} asLink surface={analyticsSurface} />
+        <TrustBadge level={entry.trust} />
         <span className="hidden min-w-0 shrink md:inline-flex">
           <LazyEntryAuthorAttribution entry={entry} className="truncate text-xs text-ink-subtle" />
         </span>
@@ -244,7 +258,6 @@ function ResourceCardInner({
             <div className="flex items-start justify-between gap-2">
               <div className="flex min-w-0 items-center gap-2">
                 <EntryBrandMark entry={entry} size="xs" />
-                <CategoryPill>{entry.category}</CategoryPill>
               </div>
               <div className="flex min-h-4 items-center text-xs text-ink-muted tabular-nums">
                 <SourceRepoStars entry={entry} compact />
@@ -259,18 +272,32 @@ function ResourceCardInner({
               </p>
             </div>
             <EntryFacets entry={entry} density="card" />
-            <div className="mt-auto flex flex-wrap items-center gap-1.5">
-              <TrustBadge level={entry.trust} />
-              <SourceBadge status={entry.source} />
-              <InstallRiskBadge entry={entry} size="xs" />
-              {entry.dateAdded && (
-                <span className="ml-auto font-mono text-[10px] text-ink-subtle">
+            {entry.dateAdded && (
+              <div className="mt-auto">
+                <span className="font-mono text-[10px] text-ink-subtle">
                   Added {timeAgo(entry.dateAdded)}
                 </span>
-              )}
-            </div>
-            <NotesPresenceChips entry={entry} />
+              </div>
+            )}
           </Link>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <CategoryPill
+              asLink
+              category={entry.category}
+              onNavigate={() =>
+                trackEvent(
+                  resourceCardCategoryBrowseAnalyticsEvent(),
+                  resourceCardCategoryBrowseAnalyticsData(entry.category, analyticsSurface),
+                )
+              }
+            >
+              {entry.category}
+            </CategoryPill>
+            <TrustBadge level={entry.trust} />
+            <SourceBadge status={entry.source} asLink surface={analyticsSurface} />
+            <InstallRiskBadge entry={entry} size="xs" asLink surface={analyticsSurface} />
+          </div>
+          <NotesPresenceChips entry={entry} asLink surface={analyticsSurface} />
           {trustDecision ? (
             <ResourceCardTrustHint
               state={trustDecision}
@@ -335,12 +362,23 @@ function ResourceCardInner({
         <EntryBrandMark entry={entry} size="sm" className="mt-0.5" />
         <div className="flex min-w-0 flex-1 flex-col gap-1.5">
           <div className="flex flex-wrap items-center gap-1.5">
-            <CategoryPill>{entry.category}</CategoryPill>
+            <CategoryPill
+              asLink
+              category={entry.category}
+              onNavigate={() =>
+                trackEvent(
+                  resourceCardCategoryBrowseAnalyticsEvent(),
+                  resourceCardCategoryBrowseAnalyticsData(entry.category, analyticsSurface),
+                )
+              }
+            >
+              {entry.category}
+            </CategoryPill>
             <TrustBadge level={entry.trust} />
-            <SourceBadge status={entry.source} />
-            <InstallRiskBadge entry={entry} size="xs" />
+            <SourceBadge status={entry.source} asLink surface={analyticsSurface} />
+            <InstallRiskBadge entry={entry} size="xs" asLink surface={analyticsSurface} />
             {entry.platforms.slice(0, 2).map((p) => (
-              <PlatformChip key={p} id={p} />
+              <PlatformChip key={p} id={p} asLink surface={analyticsSurface} />
             ))}
           </div>
 
@@ -365,7 +403,7 @@ function ResourceCardInner({
           ) : null}
           <div className="flex flex-wrap items-center gap-2 pt-0.5">
             <EntryFacets entry={entry} density="card" />
-            <NotesPresenceChips entry={entry} />
+            <NotesPresenceChips entry={entry} asLink surface={analyticsSurface} />
           </div>
         </div>
       </div>

--- a/apps/web/src/lib/hub-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/hub-entry-cta-events-lib.ts
@@ -68,3 +68,34 @@ export function hubCategoryRankingEntryAnalyticsData(
     rowCount,
   };
 }
+
+export function hubHighlightSourceBrowseAnalyticsEvent(): string {
+  return "hub_highlight_source_browse_click";
+}
+
+export function hubHighlightSourceBrowseAnalyticsData(source: string, kind: string) {
+  return {
+    surface: HUB_HIGHLIGHTS_SURFACE,
+    source,
+    kind,
+  };
+}
+
+/** Map highlight kind to a privacy-light browse signal hint for analytics context. */
+export function hubHighlightBrowseSignal(kind: string): string | null {
+  switch (kind) {
+    case "trusted":
+      return "trusted";
+    case "sourced":
+      return "source-backed";
+    case "documented":
+      return "safety-notes";
+    case "reviewed":
+      return "reviewed";
+    case "newest":
+    case "popular":
+      return null;
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/hub-entry-cta-events.ts
+++ b/apps/web/src/lib/hub-entry-cta-events.ts
@@ -8,8 +8,11 @@ export {
   hubCategoryRankingEntryAnalyticsData,
   hubCategoryRankingEntryAnalyticsEvent,
   hubEntryKey,
+  hubHighlightBrowseSignal,
   hubHighlightEntryAnalyticsData,
   hubHighlightEntryAnalyticsEvent,
+  hubHighlightSourceBrowseAnalyticsData,
+  hubHighlightSourceBrowseAnalyticsEvent,
   hubTrendingPodiumEntryAnalyticsData,
   hubTrendingPodiumEntryAnalyticsEvent,
 } from "@/lib/hub-entry-cta-events-lib";

--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -11,7 +11,24 @@ export type InstallRiskBadgeSurface =
   | typeof INSTALL_RISK_BADGE_SURFACE
   | "compare-table"
   | "compare-drawer"
-  | "category-ranking";
+  | "category-ranking"
+  | "peek-panel"
+  | "browse-card"
+  | "browse-grid"
+  | "browse-row"
+  | "browse-compact"
+  | "home-recent"
+  | "home-popular"
+  | "home-newest"
+  | "home-compare-rail"
+  | "category-hub"
+  | "tag-hub"
+  | "best-index"
+  | "best-collection"
+  | "platform-hub"
+  | "platform-category"
+  | "detail-related"
+  | "detail-guides";
 
 export function installRiskBadgeAnalyticsEvent(): string {
   return "install_risk_badge_click";

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -12,7 +12,23 @@ export type NotesPresenceSurface =
   | "compare-table"
   | "compare-drawer"
   | "category-ranking"
-  | "peek-panel";
+  | "peek-panel"
+  | "browse-card"
+  | "browse-grid"
+  | "browse-row"
+  | "browse-compact"
+  | "home-recent"
+  | "home-popular"
+  | "home-newest"
+  | "home-compare-rail"
+  | "category-hub"
+  | "tag-hub"
+  | "best-index"
+  | "best-collection"
+  | "platform-hub"
+  | "platform-category"
+  | "detail-related"
+  | "detail-guides";
 
 export type NotesPresenceKind = "safety" | "privacy";
 

--- a/apps/web/src/lib/resource-card-cta-events-lib.ts
+++ b/apps/web/src/lib/resource-card-cta-events-lib.ts
@@ -125,6 +125,36 @@ export function resourceCardEntryAnalyticsData(
   };
 }
 
+export function resourceCardCategoryBrowseAnalyticsEvent(): string {
+  return "browse_card_category_click";
+}
+
+export function resourceCardCategoryBrowseAnalyticsData(
+  category: string,
+  surface: ResourceCardSurface = RESOURCE_CARD_SURFACE,
+) {
+  return {
+    surface,
+    category,
+  };
+}
+
+export type ResourceCardBadgeKind = "source" | "install-risk" | "notes" | "platform" | "category";
+
+/** Resolve which secondary badge kinds a card variant can expose as browse egress. */
+export function resourceCardBadgeKinds(variant: string): ResourceCardBadgeKind[] {
+  switch (variant) {
+    case "grid":
+      return ["category", "source", "install-risk", "notes"];
+    case "row":
+      return ["category", "source", "install-risk", "platform", "notes"];
+    case "compact":
+      return ["category", "source"];
+    default:
+      return [];
+  }
+}
+
 export function resourceCardTrustHintAnalyticsEvent(): string {
   return "browse_card_trust_hint_click";
 }

--- a/apps/web/src/lib/resource-card-cta-events.ts
+++ b/apps/web/src/lib/resource-card-cta-events.ts
@@ -3,6 +3,9 @@
  */
 export {
   RESOURCE_CARD_SURFACE,
+  resourceCardBadgeKinds,
+  resourceCardCategoryBrowseAnalyticsData,
+  resourceCardCategoryBrowseAnalyticsEvent,
   resourceCardCompareAnalyticsData,
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
@@ -17,6 +20,7 @@ export {
   resourceCardInstallIntentType,
   resourceCardTrustHintAnalyticsData,
   resourceCardTrustHintAnalyticsEvent,
+  type ResourceCardBadgeKind,
   type ResourceCardSurface,
   type ResourceCardVariant,
 } from "@/lib/resource-card-cta-events-lib";

--- a/apps/web/src/lib/source-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/source-badge-cta-events-lib.ts
@@ -11,7 +11,24 @@ export type SourceBadgeSurface =
   | typeof SOURCE_BADGE_SURFACE
   | "compare-table"
   | "compare-drawer"
-  | "category-ranking";
+  | "category-ranking"
+  | "hub-highlights"
+  | "browse-card"
+  | "browse-grid"
+  | "browse-row"
+  | "browse-compact"
+  | "home-recent"
+  | "home-popular"
+  | "home-newest"
+  | "home-compare-rail"
+  | "category-hub"
+  | "tag-hub"
+  | "best-index"
+  | "best-collection"
+  | "platform-hub"
+  | "platform-category"
+  | "detail-related"
+  | "detail-guides";
 
 export function sourceBadgeAnalyticsEvent(): string {
   return "source_badge_click";

--- a/tests/hub-entry-cta-events-lib.test.ts
+++ b/tests/hub-entry-cta-events-lib.test.ts
@@ -5,8 +5,11 @@ import {
   HUB_TRENDING_PODIUM_SURFACE,
   hubCategoryRankingEntryAnalyticsData,
   hubCategoryRankingEntryAnalyticsEvent,
+  hubHighlightBrowseSignal,
   hubHighlightEntryAnalyticsData,
   hubHighlightEntryAnalyticsEvent,
+  hubHighlightSourceBrowseAnalyticsData,
+  hubHighlightSourceBrowseAnalyticsEvent,
   hubTrendingPodiumEntryAnalyticsData,
   hubTrendingPodiumEntryAnalyticsEvent,
 } from "@/lib/hub-entry-cta-events-lib";
@@ -44,5 +47,25 @@ describe("hub entry cta events lib", () => {
       rowIndex: 2,
       rowCount: 12,
     });
+  });
+
+  it("builds hub highlight source browse analytics and signal maps", () => {
+    expect(hubHighlightSourceBrowseAnalyticsEvent()).toBe(
+      "hub_highlight_source_browse_click",
+    );
+    expect(
+      hubHighlightSourceBrowseAnalyticsData("source-backed", "sourced"),
+    ).toEqual({
+      surface: HUB_HIGHLIGHTS_SURFACE,
+      source: "source-backed",
+      kind: "sourced",
+    });
+    expect(hubHighlightBrowseSignal("trusted")).toBe("trusted");
+    expect(hubHighlightBrowseSignal("sourced")).toBe("source-backed");
+    expect(hubHighlightBrowseSignal("documented")).toBe("safety-notes");
+    expect(hubHighlightBrowseSignal("reviewed")).toBe("reviewed");
+    expect(hubHighlightBrowseSignal("newest")).toBeNull();
+    expect(hubHighlightBrowseSignal("popular")).toBeNull();
+    expect(hubHighlightBrowseSignal("unknown")).toBeNull();
   });
 });

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -25,6 +25,18 @@ describe("install risk badge cta events lib", () => {
       surface: "category-ranking",
       risk: "low",
     });
+    expect(installRiskBadgeAnalyticsData("review", "peek-panel")).toEqual({
+      surface: "peek-panel",
+      risk: "review",
+    });
+    expect(installRiskBadgeAnalyticsData("high", "browse-grid")).toEqual({
+      surface: "browse-grid",
+      risk: "high",
+    });
+    expect(installRiskBadgeAnalyticsData("low", "browse-row")).toEqual({
+      surface: "browse-row",
+      risk: "low",
+    });
   });
 
   it("maps install risk levels to browse trust search patches", () => {

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -40,6 +40,16 @@ describe("notes presence cta events lib", () => {
       noteKind: "safety",
       present: true,
     });
+    expect(notesPresenceAnalyticsData("privacy", true, "browse-grid")).toEqual({
+      surface: "browse-grid",
+      noteKind: "privacy",
+      present: true,
+    });
+    expect(notesPresenceAnalyticsData("safety", false, "browse-row")).toEqual({
+      surface: "browse-row",
+      noteKind: "safety",
+      present: false,
+    });
   });
 
   it("maps present notes chips to browse signal search patches", () => {

--- a/tests/resource-card-cta-events-lib.test.ts
+++ b/tests/resource-card-cta-events-lib.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  resourceCardBadgeKinds,
+  resourceCardCategoryBrowseAnalyticsData,
+  resourceCardCategoryBrowseAnalyticsEvent,
   resourceCardCompareAnalyticsData,
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
@@ -106,5 +109,42 @@ describe("resource card cta events lib", () => {
       inCompareTray: false,
       compareCount: 1,
     });
+  });
+
+  it("builds category browse analytics and badge kind maps", () => {
+    expect(resourceCardCategoryBrowseAnalyticsEvent()).toBe(
+      "browse_card_category_click",
+    );
+    expect(resourceCardCategoryBrowseAnalyticsData("mcp")).toEqual({
+      surface: "browse-card",
+      category: "mcp",
+    });
+    expect(
+      resourceCardCategoryBrowseAnalyticsData("skills", "browse-grid"),
+    ).toEqual({
+      surface: "browse-grid",
+      category: "skills",
+    });
+    expect(
+      resourceCardCategoryBrowseAnalyticsData("hooks", "home-recent"),
+    ).toEqual({
+      surface: "home-recent",
+      category: "hooks",
+    });
+    expect(resourceCardBadgeKinds("grid")).toEqual([
+      "category",
+      "source",
+      "install-risk",
+      "notes",
+    ]);
+    expect(resourceCardBadgeKinds("row")).toEqual([
+      "category",
+      "source",
+      "install-risk",
+      "platform",
+      "notes",
+    ]);
+    expect(resourceCardBadgeKinds("compact")).toEqual(["category", "source"]);
+    expect(resourceCardBadgeKinds("unknown")).toEqual([]);
   });
 });

--- a/tests/source-badge-cta-events-lib.test.ts
+++ b/tests/source-badge-cta-events-lib.test.ts
@@ -24,5 +24,23 @@ describe("source badge cta events lib", () => {
       surface: "category-ranking",
       source: "unverified",
     });
+    expect(sourceBadgeAnalyticsData("source-backed", "hub-highlights")).toEqual(
+      {
+        surface: "hub-highlights",
+        source: "source-backed",
+      },
+    );
+    expect(sourceBadgeAnalyticsData("first-party", "browse-grid")).toEqual({
+      surface: "browse-grid",
+      source: "first-party",
+    });
+    expect(sourceBadgeAnalyticsData("external", "browse-row")).toEqual({
+      surface: "browse-row",
+      source: "external",
+    });
+    expect(sourceBadgeAnalyticsData("unverified", "home-recent")).toEqual({
+      surface: "home-recent",
+      source: "unverified",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Enable browse egress from resource-card secondary badges (source, install risk, notes, platforms, category) across grid/row/compact variants, using each card’s `analyticsSurface` and keeping badges outside nested entry links.
- Add hub-highlight source badge browse egress (kind-aware analytics) and peek-panel install-risk browse links.
- Extend badge CTA surface unions and add `resourceCardBadgeKinds` / hub highlight browse helpers with full Vitest branch coverage.

## Test plan
- [x] `pnpm exec vitest run` on resource-card, hub-entry, source/install-risk/notes badge lib tests
- [ ] CI: validate-ci, codecov/patch, codecov/project, required-pr-gate, LoopOver
- [ ] No path overlap with open #5176 (trust badge ranking/tray)

Refs #550

Made with [Cursor](https://cursor.com)