### PR TITLE
test(submissions): cover submitted source url extraction from frontmatter

### DIFF
--- a/tests/submission-gate-source-url-extraction.test.ts
+++ b/tests/submission-gate-source-url-extraction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { extractSubmittedSourceUrls } from "../apps/submission-gate/src/source-evidence";
+
+function frontmatter(lines: string[]) {
+  return ["---", ...lines, "---", "", "body text", ""].join("\n");
+}
+
+describe("submission-gate extractSubmittedSourceUrls", () => {
+  it("returns nothing without frontmatter", () => {
+    expect(extractSubmittedSourceUrls("no frontmatter here")).toEqual([]);
+  });
+
+  it("reads an inline array with mixed quoting", () => {
+    expect(
+      extractSubmittedSourceUrls(
+        frontmatter([
+          `sourceUrls: ["https://a.example/x", 'https://b.example/y']`,
+          "title: T",
+        ]),
+      ),
+    ).toEqual([
+      { field: "sourceUrls", url: "https://a.example/x" },
+      { field: "sourceUrls", url: "https://b.example/y" },
+    ]);
+  });
+
+  it("reads a block list and skips blank items", () => {
+    expect(
+      extractSubmittedSourceUrls(
+        frontmatter([
+          "sourceUrls:",
+          '  - "https://c.example/z"',
+          "  - https://d.example/w",
+          "  -",
+          "title: T",
+        ]),
+      ),
+    ).toEqual([
+      { field: "sourceUrls", url: "https://c.example/z" },
+      { field: "sourceUrls", url: "https://d.example/w" },
+    ]);
+  });
+
+  it("reads a scalar source url field", () => {
+    expect(
+      extractSubmittedSourceUrls(
+        frontmatter(["sourceUrl: https://e.example/s"]),
+      ),
+    ).toEqual([{ field: "sourceUrl", url: "https://e.example/s" }]);
+  });
+
+  it("reads list items under a block scalar marker", () => {
+    expect(
+      extractSubmittedSourceUrls(
+        frontmatter(["sourceUrls: |", "  - https://f.example/p"]),
+      ),
+    ).toEqual([{ field: "sourceUrls", url: "https://f.example/p" }]);
+  });
+
+  it("ignores list items that belong to a non-source field", () => {
+    expect(
+      extractSubmittedSourceUrls(
+        frontmatter(["tags:", "  - https://not-a-source.example/x"]),
+      ),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Source-evidence checks start from the URLs parsed out of submitted frontmatter, but most of that extractor was untested. This adds a new test file covering `extractSubmittedSourceUrls`: returning nothing without frontmatter; reading an inline array with mixed single/double quoting; reading a block list while skipping blank items; reading a scalar source url field; reading list items that follow a block scalar marker; and ignoring list items belonging to a non-source field. Lib branch coverage 82.5% -> 87.5% (140/160). Test-only change; kept in its own file.