### PR TITLE
feat(web): add peek panel install-risk badge browse analytics

### DIFF
--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -212,7 +212,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
               )
             }
           />
-          <InstallRiskBadge entry={entry} size="xs" />
+          <InstallRiskBadge entry={entry} size="xs" asLink surface="peek-panel" />
         </div>
         <div className="flex min-w-0 items-start gap-3">
           <EntryBrandMark entry={entry} size="md" priority className="mt-0.5" />

--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -11,7 +11,8 @@ export type InstallRiskBadgeSurface =
   | typeof INSTALL_RISK_BADGE_SURFACE
   | "compare-table"
   | "compare-drawer"
-  | "category-ranking";
+  | "category-ranking"
+  | "peek-panel";
 
 export function installRiskBadgeAnalyticsEvent(): string {
   return "install_risk_badge_click";

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -25,6 +25,10 @@ describe("install risk badge cta events lib", () => {
       surface: "category-ranking",
       risk: "low",
     });
+    expect(installRiskBadgeAnalyticsData("review", "peek-panel")).toEqual({
+      surface: "peek-panel",
+      risk: "review",
+    });
   });
 
   it("maps install risk levels to browse trust search patches", () => {


### PR DESCRIPTION
## Summary
- Promote peek-panel `InstallRiskBadge` to browse link (`asLink surface=peek-panel`)
- Fire privacy-light `install_risk_badge_click` with `{ surface: peek-panel, risk }` — no titles/URLs
- Extend `InstallRiskBadgeSurface` + cover `peek-panel` in install-risk CTA lib tests

## Test plan
- [ ] Peek install-risk badge navigates to browse trust filter
- [ ] Click emits `install_risk_badge_click` with surface `peek-panel`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)