### PR TITLE
feat(web): add compare tray notes chips browse analytics

### DIFF
--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -1,15 +1,5 @@
 import * as React from "react";
-import {
-  BadgeCheck,
-  GitCompare,
-  X,
-  ArrowRight,
-  Shield,
-  Lock,
-  Link2,
-  Package,
-  Trash2,
-} from "lucide-react";
+import { BadgeCheck, GitCompare, X, ArrowRight, Link2, Package, Trash2 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useCompare } from "@/lib/compare";
 import {
@@ -38,7 +28,7 @@ import {
   badgeChromeTrustAnalyticsEvent,
 } from "@/lib/badge-chrome-cta-events";
 import { trackEvent } from "@/lib/analytics";
-import { TrustBadge, SourceBadge, ReadinessDot } from "./badges";
+import { TrustBadge, SourceBadge, NotesPresenceChips, ReadinessDot } from "./badges";
 import { compareSignalToneClass } from "@/lib/compare-entry-signals";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
@@ -81,13 +71,13 @@ function TrayChip({
           )
         }
       />
+      <NotesPresenceChips
+        entry={entry}
+        asLink
+        surface="compare-tray"
+        className="hidden sm:inline-flex"
+      />
       <span className="inline-flex items-center gap-0.5 text-ink-subtle" aria-hidden>
-        <Shield
-          className={cn("h-3 w-3", signals.hasSafetyNotes ? "text-trust-trusted" : "opacity-40")}
-        />
-        <Lock
-          className={cn("h-3 w-3", signals.hasPrivacyNotes ? "text-trust-trusted" : "opacity-40")}
-        />
         <BadgeCheck
           className={cn(
             "h-3 w-3",

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -12,7 +12,8 @@ export type NotesPresenceSurface =
   | "compare-table"
   | "compare-drawer"
   | "category-ranking"
-  | "peek-panel";
+  | "peek-panel"
+  | "compare-tray";
 
 export type NotesPresenceKind = "safety" | "privacy";
 

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -40,6 +40,13 @@ describe("notes presence cta events lib", () => {
       noteKind: "safety",
       present: true,
     });
+    expect(notesPresenceAnalyticsData("privacy", true, "compare-tray")).toEqual(
+      {
+        surface: "compare-tray",
+        noteKind: "privacy",
+        present: true,
+      },
+    );
   });
 
   it("maps present notes chips to browse signal search patches", () => {


### PR DESCRIPTION
## Summary
- Replace decorative compare-tray safety/privacy icons with `NotesPresenceChips asLink surface=compare-tray`
- Fire privacy-light `notes_presence_chip_click` with `{ surface: compare-tray, noteKind, present }` — no titles/URLs
- Keep chips out of `aria-hidden` and extend `NotesPresenceSurface` + tests

## Test plan
- [ ] Compare tray Safety/Privacy chips navigate to browse signal filters when present
- [ ] Click emits `notes_presence_chip_click` with surface `compare-tray`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)