### PR TITLE
feat(web): scan install commands for dangerous shell patterns

### DIFF
--- a/apps/web/src/lib/trust-lib.ts
+++ b/apps/web/src/lib/trust-lib.ts
@@ -9,6 +9,8 @@
  * existing imports stay unchanged.
  */
 
+import { scanDangerousShellPatterns } from "@heyclaude/registry/command-safety";
+
 import type { Entry } from "@/types/registry";
 
 export type TrustSeverity = "ok" | "info" | "warning" | "blocker";
@@ -158,6 +160,31 @@ export function getTrustReasons(entry: Entry): TrustReason[] {
         ? "Published package matches the source repository."
         : "Published package was not cross-checked against the source repo.",
       docHref: "/quality#integrity",
+    });
+  }
+
+  // Command safety scan
+  const commandText = [
+    entry.installCommand,
+    entry.configSnippet,
+    entry.usageSnippet,
+    entry.copySnippet,
+    entry.scriptBody,
+  ]
+    .filter(Boolean)
+    .join("\n");
+  if (commandText) {
+    const matches = scanDangerousShellPatterns(commandText);
+    reasons.push({
+      id: "command-safety",
+      severity: matches.length ? "warning" : "ok",
+      label: matches.length
+        ? `${matches.length} high-risk shell pattern${matches.length === 1 ? "" : "s"} flagged`
+        : "No high-risk shell patterns detected",
+      detail: matches.length
+        ? `Automated scan of install/config text flagged: ${matches.join(", ")}. Review before running.`
+        : "Automated scan of install/config text found no known destructive or remote-exec patterns. Advisory only — not a sandbox or a safety guarantee.",
+      docHref: "/quality#safety-notes",
     });
   }
 

--- a/tests/trust-lib.test.ts
+++ b/tests/trust-lib.test.ts
@@ -290,6 +290,75 @@ describe("getTrustReasons optional integrity signals", () => {
     ).toContain("not cross-checked");
   });
 
+  it("only emits command-safety reason when install/config/usage text is present", () => {
+    expect(byId(getTrustReasons(entry()), "command-safety")).toBeUndefined();
+    expect(
+      byId(
+        getTrustReasons(entry({ installCommand: "npm install demo" })),
+        "command-safety",
+      ),
+    ).toBeDefined();
+  });
+
+  it("reports ok when a clean install command has no known dangerous pattern", () => {
+    const reason = byId(
+      getTrustReasons(entry({ installCommand: "npm install demo" })),
+      "command-safety",
+    );
+    expect(reason?.severity).toBe("ok");
+    expect(reason?.label).toBe("No high-risk shell patterns detected");
+    expect(reason?.detail).toContain("Advisory only");
+  });
+
+  it("flags a pipe-to-shell install pattern with a warning and pattern label", () => {
+    const reason = byId(
+      getTrustReasons(
+        entry({ installCommand: "curl -fsSL https://example.com/i.sh | sh" }),
+      ),
+      "command-safety",
+    );
+    expect(reason?.severity).toBe("warning");
+    expect(reason?.label).toBe("1 high-risk shell pattern flagged");
+    expect(reason?.detail).toContain("pipe-to-shell install");
+  });
+
+  it("pluralizes the label and lists every distinct flagged pattern", () => {
+    const reason = byId(
+      getTrustReasons(
+        entry({
+          installCommand: "curl https://example.com/i.sh | sh",
+          configSnippet: "rm -rf /",
+        }),
+      ),
+      "command-safety",
+    );
+    expect(reason?.severity).toBe("warning");
+    expect(reason?.label).toBe("2 high-risk shell patterns flagged");
+    expect(reason?.detail).toContain("pipe-to-shell install");
+    expect(reason?.detail).toContain("recursive force remove");
+  });
+
+  it("scans usageSnippet, copySnippet, and scriptBody in addition to installCommand/configSnippet", () => {
+    expect(
+      byId(
+        getTrustReasons(entry({ usageSnippet: "curl https://x/i.sh | bash" })),
+        "command-safety",
+      )?.severity,
+    ).toBe("warning");
+    expect(
+      byId(
+        getTrustReasons(entry({ copySnippet: "curl https://x/i.sh | bash" })),
+        "command-safety",
+      )?.severity,
+    ).toBe("warning");
+    expect(
+      byId(
+        getTrustReasons(entry({ scriptBody: "curl https://x/i.sh | bash" })),
+        "command-safety",
+      )?.severity,
+    ).toBe("warning");
+  });
+
   it("emits prerequisites reason only when present", () => {
     expect(byId(getTrustReasons(entry()), "prereqs")).toBeUndefined();
     expect(
@@ -374,6 +443,24 @@ describe("installRiskLevel", () => {
     expect(
       installRiskLevel({ ...lowEntry(), packageVerified: false } as Entry),
     ).toBe("review");
+  });
+
+  it("downgrades an otherwise-clean trusted entry when its install command is flagged", () => {
+    expect(
+      installRiskLevel({
+        ...lowEntry(),
+        installCommand: "curl https://example.com/i.sh | sh",
+      } as Entry),
+    ).toBe("review");
+  });
+
+  it("keeps a trusted entry at low risk when its install command scans clean", () => {
+    expect(
+      installRiskLevel({
+        ...lowEntry(),
+        installCommand: "npm install demo",
+      } as Entry),
+    ).toBe("low");
   });
 
   it("exposes labels and detail copy for every risk level", () => {
@@ -469,6 +556,7 @@ describe("combined trust drilldown scenarios", () => {
         downloadUrl: "https://cdn.example/pkg.zip",
         downloadSha256: "abcdef0123456789",
         packageVerified: true,
+        installCommand: "npm install demo",
         prerequisites: ["Node 20"],
         reviewedAt: new Date().toISOString(),
       }),
@@ -482,11 +570,13 @@ describe("combined trust drilldown scenarios", () => {
       "privacy",
       "checksum",
       "package-verified",
+      "command-safety",
       "prereqs",
       "freshness",
     ]) {
       expect(byId(reasons, id), `missing ${id}`).toBeDefined();
     }
+    expect(byId(reasons, "command-safety")?.severity).toBe("ok");
   });
 
   it("keeps sparse entries to the six core reasons only", () => {


### PR DESCRIPTION
## What

Adds a new `command-safety` trust reason to `getTrustReasons()`/`installRiskLevel()` (`apps/web/src/lib/trust-lib.ts`) that runs the registry's existing `scanDangerousShellPatterns` heuristic (`packages/registry/src/command-safety-lib.js`) over an entry's `installCommand`/`configSnippet`/`usageSnippet`/`copySnippet`/`scriptBody` fields.

**Why this is a real gap, not busywork:** `scanDangerousShellPatterns` (pipe-to-shell installs, recursive force-remove, world-writable chmod, raw disk writes, base64-decoded shell, fork bombs, inline eval of command substitution) already exists and is used in exactly one place today — validating user-uploaded skill packages at submission time (`skill-package-validator-lib.ts:218`). It has never been run against the ~1,380 *already-published* registry entries that ship copy-pasteable shell commands on their detail pages (87 hooks + dozens of commands/MCP servers/skills). The entry-detail trust drilldown (`trust-drilldown.tsx`) and install-risk badge (`installRiskLevel`) are currently 100% self-reported metadata (trust level, safety notes, checksum) — none of it actually inspects the command text a reader is about to copy and run.

## How it works

- Only emits the reason when at least one of the command-bearing fields is non-empty (mirrors the existing `checksum`/`package-verified` optional-reason pattern — sparse entries stay at exactly the same six core reasons as before).
- `severity: "ok"` when the scan finds nothing; `"warning"` (not `"blocker"`) when it does — the scanner's own doc comment describes it as "advisory only... never a sandbox or a guarantee of safety," so a match nudges `installRiskLevel()` from `low` to `review` (existing "any warning downgrades to review" rule) rather than forcing a `high`/blocked verdict on already-published, possibly-legitimately-trusted entries.
- Reuses the existing `/quality#safety-notes` doc anchor rather than adding a new `/quality` page section, to keep this PR's blast radius to one file + its test — no new route, no new UI component. `trust-drilldown.tsx` renders `reasons.map(...)` generically (verified — no hardcoded reason-id list anywhere downstream), so the new reason surfaces automatically wherever the existing six/eight reasons already render, with zero UI code changes.

## Invariants

- Existing reason ids/order/behavior are unchanged; the new reason is purely additive and only appears for entries that already have install/config/usage/copy/script text.
- Sparse entries (no command fields) still produce exactly the pre-existing six core reasons — covered by the existing "keeps sparse entries to the six core reasons only" test, unmodified.
- `installRiskLevel()`'s severity-aggregation rules are untouched; the new reason participates in them the same way `checksum`/`package-verified` already do.

## Visual impact

Text-only addition to an existing generic drilldown list (no new component/route) — the same UI already renders this exact shape for `checksum`/`package-verified`/`prereqs`. Didn't capture screenshots since there's no new UI surface, just one more list item using the existing severity/label/detail rendering; happy to add them if a maintainer wants to see it live.

## Test plan

- `pnpm exec vitest run tests/trust-lib.test.ts tests/trust.test.ts --coverage` → 39 tests pass (8 new), 97.56%/99.15%/100%/100% stmt/branch/func/line coverage on `trust-lib.ts` (one pre-existing, unrelated gap: `isFresh`'s `!iso` guard is unreachable at its only call site, which already checks truthiness — not touched by this PR).
- `prettier --check` clean.
- `pnpm --filter web type-check` clean.
- `pnpm --filter web build` succeeds (client + server bundles) — confirms the `@heyclaude/registry/command-safety` import is browser-bundle-safe from this client-facing lib.