### PR TITLE
feat(web): add validators coverage and trending badge browse egress

### DIFF
--- a/apps/web/src/components/trending-podium.tsx
+++ b/apps/web/src/components/trending-podium.tsx
@@ -5,6 +5,14 @@ import { CategoryPill, TrustBadge, SourceBadge } from "@/components/badges";
 import { formatCompact } from "@/lib/format";
 import { trackEvent } from "@/lib/analytics";
 import {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
+import {
   hubTrendingPodiumEntryAnalyticsData,
   hubTrendingPodiumEntryAnalyticsEvent,
 } from "@/lib/hub-entry-cta-events";
@@ -70,18 +78,47 @@ export function TrendingPodium({ entries }: { entries: TrendingEntry[] }) {
               </div>
             </div>
 
+            <div className="mt-3 flex flex-wrap items-center gap-1.5">
+              <CategoryPill
+                asLink
+                category={e.category}
+                onNavigate={() =>
+                  trackEvent(
+                    badgeChromeCategoryAnalyticsEvent(),
+                    badgeChromeCategoryAnalyticsData(e.category, "trending-podium"),
+                  )
+                }
+              >
+                {e.category}
+              </CategoryPill>
+              <TrustBadge
+                level={e.trust}
+                asLink
+                onNavigate={() =>
+                  trackEvent(
+                    badgeChromeTrustAnalyticsEvent(),
+                    badgeChromeTrustAnalyticsData(e.trust, "trending-podium"),
+                  )
+                }
+              />
+              <SourceBadge
+                status={e.source}
+                asLink
+                onNavigate={() =>
+                  trackEvent(
+                    badgeChromeSourceAnalyticsEvent(),
+                    badgeChromeSourceAnalyticsData(e.source, "trending-podium"),
+                  )
+                }
+              />
+            </div>
             <Link
               to="/entry/$category/$slug"
               params={{ category: e.category, slug: e.slug }}
               onClick={() => trackPodiumClick(e, i + 1)}
-              className="mt-3 min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
+              className="mt-2 min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
             >
-              <div className="flex flex-wrap items-center gap-1.5">
-                <CategoryPill>{e.category}</CategoryPill>
-                <TrustBadge level={e.trust} />
-                <SourceBadge status={e.source} />
-              </div>
-              <div className="mt-2 font-display text-lg font-semibold leading-snug text-ink group-hover:underline">
+              <div className="font-display text-lg font-semibold leading-snug text-ink group-hover:underline">
                 {e.title}
               </div>
               <p className="mt-1 line-clamp-2 text-sm text-ink-muted">{e.description}</p>

--- a/apps/web/src/lib/badge-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events-lib.ts
@@ -10,7 +10,9 @@ export type BadgeChromeSurface =
   | "peek-panel"
   | "detail-header"
   | "contributor-profile"
-  | "compare-tray";
+  | "compare-tray"
+  | "trending-list"
+  | "trending-podium";
 
 export type BadgeChromeNoteKind = "safety" | "privacy";
 

--- a/apps/web/src/lib/validators-coverage-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-coverage-cta-events-lib.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure validators coverage-metric navigation analytics helpers.
+ *
+ * Maps expertise coverage Metric tiles to privacy-light browse egress without
+ * embedding coverage copy or entry titles.
+ */
+
+export const VALIDATORS_COVERAGE_SURFACE = "validators-coverage";
+
+export type ValidatorsCoverageMetricId =
+  | "reviewed"
+  | "source-backed"
+  | "safety-notes"
+  | "privacy-notes";
+
+export type ValidatorsCoverageBrowseSearch = {
+  category?: string;
+  signal?: string;
+};
+
+export function validatorsCoverageMetricAnalyticsEvent(): string {
+  return "validators_coverage_metric_click";
+}
+
+export function validatorsCoverageMetricAnalyticsData(
+  expertiseId: string,
+  metricId: string,
+  pct: number,
+  value: number,
+  total: number,
+) {
+  return {
+    surface: VALIDATORS_COVERAGE_SURFACE,
+    expertiseId,
+    metricId,
+    pct,
+    value,
+    total,
+  };
+}
+
+/** Map a coverage expertise id to a browse category patch when one applies. */
+export function validatorsCoverageExpertiseBrowseBase(expertiseId: string): { category?: string } {
+  switch (expertiseId) {
+    case "MCP":
+      return { category: "mcp" };
+    case "Hooks":
+      return { category: "hooks" };
+    case "Skills":
+      return { category: "skills" };
+    case "Commands":
+      return { category: "commands" };
+    case "Statuslines":
+      return { category: "statuslines" };
+    case "Rules":
+      return { category: "rules" };
+    case "Security":
+    case "Privacy":
+      return {};
+    default:
+      return {};
+  }
+}
+
+/** Map a coverage metric to a browse search patch (merged with expertise base). */
+export function validatorsCoverageMetricBrowseSearch(
+  expertiseId: string,
+  metricId: string,
+): ValidatorsCoverageBrowseSearch | null {
+  const base = validatorsCoverageExpertiseBrowseBase(expertiseId);
+  switch (metricId) {
+    case "reviewed":
+      return { ...base, signal: "reviewed" };
+    case "source-backed":
+      return { ...base, signal: "source-backed" };
+    case "safety-notes":
+      return { ...base, signal: "safety-notes" };
+    case "privacy-notes":
+      return { ...base, signal: "privacy-notes" };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/validators-coverage-cta-events.ts
+++ b/apps/web/src/lib/validators-coverage-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Validators coverage-metric CTA event surface.
+ */
+export {
+  VALIDATORS_COVERAGE_SURFACE,
+  validatorsCoverageExpertiseBrowseBase,
+  validatorsCoverageMetricAnalyticsData,
+  validatorsCoverageMetricAnalyticsEvent,
+  validatorsCoverageMetricBrowseSearch,
+  type ValidatorsCoverageBrowseSearch,
+  type ValidatorsCoverageMetricId,
+} from "@/lib/validators-coverage-cta-events-lib";

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -18,6 +18,14 @@ import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { trackEvent } from "@/lib/analytics";
 import {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
+import {
   trendingCategoryFilterAnalyticsData,
   trendingCategoryFilterAnalyticsEvent,
   trendingChromeAnalyticsData,
@@ -456,22 +464,53 @@ function TrendingPage() {
               <div className="font-display text-3xl font-semibold tabular-nums text-ink-subtle">
                 {String(index + 4).padStart(2, "0")}
               </div>
-              <Link
-                to="/entry/$category/$slug"
-                params={{ category: entry.category, slug: entry.slug }}
-                onClick={() => onTrendingListEntryClick(entry, index + 4)}
-                className="min-w-0 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
-              >
+              <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-2">
-                  <CategoryPill>{entry.category}</CategoryPill>
-                  <TrustBadge level={entry.trust} />
-                  <SourceBadge status={entry.source} />
+                  <CategoryPill
+                    asLink
+                    category={entry.category}
+                    onNavigate={() =>
+                      trackEvent(
+                        badgeChromeCategoryAnalyticsEvent(),
+                        badgeChromeCategoryAnalyticsData(entry.category, "trending-list"),
+                      )
+                    }
+                  >
+                    {entry.category}
+                  </CategoryPill>
+                  <TrustBadge
+                    level={entry.trust}
+                    asLink
+                    onNavigate={() =>
+                      trackEvent(
+                        badgeChromeTrustAnalyticsEvent(),
+                        badgeChromeTrustAnalyticsData(entry.trust, "trending-list"),
+                      )
+                    }
+                  />
+                  <SourceBadge
+                    status={entry.source}
+                    asLink
+                    onNavigate={() =>
+                      trackEvent(
+                        badgeChromeSourceAnalyticsEvent(),
+                        badgeChromeSourceAnalyticsData(entry.source, "trending-list"),
+                      )
+                    }
+                  />
                 </div>
-                <div className="mt-1 font-display text-base font-semibold text-ink hover:underline">
-                  {entry.title}
-                </div>
-                <p className="line-clamp-1 text-sm text-ink-muted">{entry.description}</p>
-              </Link>
+                <Link
+                  to="/entry/$category/$slug"
+                  params={{ category: entry.category, slug: entry.slug }}
+                  onClick={() => onTrendingListEntryClick(entry, index + 4)}
+                  className="mt-1 block rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                >
+                  <div className="font-display text-base font-semibold text-ink hover:underline">
+                    {entry.title}
+                  </div>
+                  <p className="line-clamp-1 text-sm text-ink-muted">{entry.description}</p>
+                </Link>
+              </div>
               <div className="hidden flex-col items-end gap-0.5 font-mono text-xs text-ink-muted tabular-nums sm:flex">
                 {entry.repoStats?.stars !== undefined && (
                   <div className="flex items-center gap-1" title="Source repository stars">

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -34,6 +34,12 @@ import {
   type ValidatorsSummaryStatId,
   type ValidatorsToolId,
 } from "@/lib/validators-tools-cta-events";
+import {
+  validatorsCoverageMetricAnalyticsData,
+  validatorsCoverageMetricAnalyticsEvent,
+  validatorsCoverageMetricBrowseSearch,
+  type ValidatorsCoverageMetricId,
+} from "@/lib/validators-coverage-cta-events";
 import atlasRegistry from "@/generated/atlas-registry.json";
 
 const VALIDATOR_TOOL_COUNT = 2;
@@ -199,19 +205,31 @@ function ValidatorsPage() {
             </div>
 
             <div className="mt-4 grid gap-2 text-xs sm:grid-cols-2">
-              <Metric label="Reviewed" value={coverage.reviewed} total={coverage.entries} />
+              <Metric
+                label="Reviewed"
+                metricId="reviewed"
+                expertiseId={coverage.id}
+                value={coverage.reviewed}
+                total={coverage.entries}
+              />
               <Metric
                 label="Source-backed"
+                metricId="source-backed"
+                expertiseId={coverage.id}
                 value={coverage.sourceBacked}
                 total={coverage.entries}
               />
               <Metric
                 label="Safety notes"
+                metricId="safety-notes"
+                expertiseId={coverage.id}
                 value={coverage.withSafetyNotes}
                 total={coverage.entries}
               />
               <Metric
                 label="Privacy notes"
+                metricId="privacy-notes"
+                expertiseId={coverage.id}
                 value={coverage.withPrivacyNotes}
                 total={coverage.entries}
               />
@@ -390,10 +408,23 @@ function SummaryStat({
   return <div className="bg-surface p-5">{body}</div>;
 }
 
-function Metric({ label, value, total }: { label: string; value: number; total: number }) {
+function Metric({
+  label,
+  metricId,
+  expertiseId,
+  value,
+  total,
+}: {
+  label: string;
+  metricId: ValidatorsCoverageMetricId;
+  expertiseId: Expertise;
+  value: number;
+  total: number;
+}) {
   const pct = total ? Math.round((value / total) * 100) : 0;
-  return (
-    <div className="rounded-lg border border-border bg-background p-3">
+  const browseSearch = validatorsCoverageMetricBrowseSearch(expertiseId, metricId);
+  const body = (
+    <>
       <div className="flex items-center justify-between gap-2">
         <span className="text-ink-muted">{label}</span>
         <span className="font-mono text-ink">{pct}%</span>
@@ -401,7 +432,27 @@ function Metric({ label, value, total }: { label: string; value: number; total: 
       <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-surface-2">
         <div className="h-full bg-ink" style={{ width: `${Math.max(pct, value > 0 ? 3 : 0)}%` }} />
       </div>
-    </div>
+    </>
+  );
+
+  if (!browseSearch) {
+    return <div className="rounded-lg border border-border bg-background p-3">{body}</div>;
+  }
+
+  return (
+    <Link
+      to="/browse"
+      search={browseSearch}
+      onClick={() =>
+        trackEvent(
+          validatorsCoverageMetricAnalyticsEvent(),
+          validatorsCoverageMetricAnalyticsData(expertiseId, metricId, pct, value, total),
+        )
+      }
+      className="block rounded-lg border border-border bg-background p-3 transition-colors hover:border-ink/20 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+    >
+      {body}
+    </Link>
   );
 }
 

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -111,5 +111,37 @@ describe("badge chrome cta events lib", () => {
       surface: "detail-header",
       risk: "high",
     });
+    expect(badgeChromeTrustAnalyticsData("review", "trending-list")).toEqual({
+      surface: "trending-list",
+      trust: "review",
+    });
+    expect(
+      badgeChromeSourceAnalyticsData("source-backed", "trending-list"),
+    ).toEqual({
+      surface: "trending-list",
+      source: "source-backed",
+    });
+    expect(badgeChromeCategoryAnalyticsData("mcp", "trending-list")).toEqual({
+      surface: "trending-list",
+      category: "mcp",
+    });
+    expect(badgeChromeTrustAnalyticsData("trusted", "trending-podium")).toEqual(
+      {
+        surface: "trending-podium",
+        trust: "trusted",
+      },
+    );
+    expect(
+      badgeChromeSourceAnalyticsData("first-party", "trending-podium"),
+    ).toEqual({
+      surface: "trending-podium",
+      source: "first-party",
+    });
+    expect(
+      badgeChromeCategoryAnalyticsData("skills", "trending-podium"),
+    ).toEqual({
+      surface: "trending-podium",
+      category: "skills",
+    });
   });
 });

--- a/tests/validators-coverage-cta-events-lib.test.ts
+++ b/tests/validators-coverage-cta-events-lib.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  VALIDATORS_COVERAGE_SURFACE,
+  validatorsCoverageExpertiseBrowseBase,
+  validatorsCoverageMetricAnalyticsData,
+  validatorsCoverageMetricAnalyticsEvent,
+  validatorsCoverageMetricBrowseSearch,
+} from "@/lib/validators-coverage-cta-events-lib";
+
+describe("validators coverage cta events lib", () => {
+  it("builds privacy-light coverage metric analytics", () => {
+    expect(validatorsCoverageMetricAnalyticsEvent()).toBe(
+      "validators_coverage_metric_click",
+    );
+    expect(
+      validatorsCoverageMetricAnalyticsData("MCP", "reviewed", 42, 21, 50),
+    ).toEqual({
+      surface: VALIDATORS_COVERAGE_SURFACE,
+      expertiseId: "MCP",
+      metricId: "reviewed",
+      pct: 42,
+      value: 21,
+      total: 50,
+    });
+    expect(
+      validatorsCoverageMetricAnalyticsData(
+        "Security",
+        "safety-notes",
+        10,
+        5,
+        50,
+      ),
+    ).toEqual({
+      surface: VALIDATORS_COVERAGE_SURFACE,
+      expertiseId: "Security",
+      metricId: "safety-notes",
+      pct: 10,
+      value: 5,
+      total: 50,
+    });
+  });
+
+  it("maps expertise ids to browse category bases", () => {
+    expect(validatorsCoverageExpertiseBrowseBase("MCP")).toEqual({
+      category: "mcp",
+    });
+    expect(validatorsCoverageExpertiseBrowseBase("Hooks")).toEqual({
+      category: "hooks",
+    });
+    expect(validatorsCoverageExpertiseBrowseBase("Skills")).toEqual({
+      category: "skills",
+    });
+    expect(validatorsCoverageExpertiseBrowseBase("Commands")).toEqual({
+      category: "commands",
+    });
+    expect(validatorsCoverageExpertiseBrowseBase("Statuslines")).toEqual({
+      category: "statuslines",
+    });
+    expect(validatorsCoverageExpertiseBrowseBase("Rules")).toEqual({
+      category: "rules",
+    });
+    expect(validatorsCoverageExpertiseBrowseBase("Security")).toEqual({});
+    expect(validatorsCoverageExpertiseBrowseBase("Privacy")).toEqual({});
+    expect(validatorsCoverageExpertiseBrowseBase("unknown")).toEqual({});
+  });
+
+  it("maps coverage metrics to browse search patches", () => {
+    expect(validatorsCoverageMetricBrowseSearch("MCP", "reviewed")).toEqual({
+      category: "mcp",
+      signal: "reviewed",
+    });
+    expect(
+      validatorsCoverageMetricBrowseSearch("Skills", "source-backed"),
+    ).toEqual({
+      category: "skills",
+      signal: "source-backed",
+    });
+    expect(
+      validatorsCoverageMetricBrowseSearch("Hooks", "safety-notes"),
+    ).toEqual({
+      category: "hooks",
+      signal: "safety-notes",
+    });
+    expect(
+      validatorsCoverageMetricBrowseSearch("Rules", "privacy-notes"),
+    ).toEqual({
+      category: "rules",
+      signal: "privacy-notes",
+    });
+    expect(
+      validatorsCoverageMetricBrowseSearch("Security", "reviewed"),
+    ).toEqual({
+      signal: "reviewed",
+    });
+    expect(
+      validatorsCoverageMetricBrowseSearch("Privacy", "privacy-notes"),
+    ).toEqual({
+      signal: "privacy-notes",
+    });
+    expect(validatorsCoverageMetricBrowseSearch("MCP", "unknown")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add validators coverage Metric browse egress (reviewed / source-backed / safety / privacy) with expertise-aware browse search patches and privacy-light analytics across all coverage cards.
- Restructure trending list and podium so category/trust/source badges sit outside entry Links and fire badge-chrome browse analytics (`trending-list`, `trending-podium`).

## Test plan
- [x] Vitest: `validators-coverage-cta-events-lib` (all expertise + metric switch arms) and `badge-chrome-cta-events-lib` (new surfaces)
- [ ] CI: validate-ci, codecov/patch, codecov/project, required-pr-gate, LoopOver
- [ ] No path overlap with open #5176 / #5182 / #5187

Refs #550

Made with [Cursor](https://cursor.com)