### PR TITLE
test(web): cover url/title/sections fallback branches in brief-email-lib

### DIFF
--- a/tests/brief-email-lib.test.ts
+++ b/tests/brief-email-lib.test.ts
@@ -169,6 +169,17 @@ describe("cardHtml", () => {
     expect(html).not.toContain("text-transform:uppercase");
     expect(html).not.toContain("line-height:1.5");
   });
+
+  it("falls back to the site URL and an empty title when both are absent", () => {
+    const html = cardHtml(
+      item({ url: undefined, title: undefined as unknown as string }),
+      siteUrl,
+    );
+    expect(html).toContain(`href="${siteUrl}"`);
+    expect(html).toContain(
+      'style="display:inline-block;margin:3px 0 0;font-size:15px;font-weight:600;color:#171614;text-decoration:none;line-height:1.3;"></a>',
+    );
+  });
 });
 
 describe("overflowRowHtml", () => {
@@ -183,6 +194,17 @@ describe("overflowRowHtml", () => {
       siteUrl,
     );
     expect(bare).not.toContain("text-transform:uppercase");
+  });
+
+  it("falls back to the site URL and an empty title when both are absent", () => {
+    const html = overflowRowHtml(
+      item({ url: undefined, title: undefined as unknown as string }),
+      siteUrl,
+    );
+    expect(html).toContain(`href="${siteUrl}"`);
+    expect(html).toContain(
+      'style="font-size:14px;font-weight:600;color:#171614;text-decoration:none;"></a>',
+    );
   });
 });
 
@@ -243,6 +265,24 @@ describe("sectionText", () => {
     expect(text).toContain(
       "Overflow 4 [MCP server] — https://heyclau.de/entry/mcp/o4",
     );
+  });
+
+  it("omits the description line and falls back to the site URL for a featured item with neither", () => {
+    const text = sectionText(
+      SECTIONS[0],
+      [item({ description: undefined, url: undefined })],
+      siteUrl,
+    );
+    expect(text).toContain(`• Demo Entry [MCP server]\n    ${siteUrl}`);
+  });
+
+  it("falls back to the site URL for an overflow item with no url", () => {
+    const rows = Array.from({ length: 5 }, (_, index) =>
+      item({ title: `Overflow ${index}`, url: `/entry/mcp/o${index}` }),
+    );
+    rows[4] = item({ title: "Overflow 4", url: undefined });
+    const text = sectionText(SECTIONS[0], rows, siteUrl);
+    expect(text).toContain(`Overflow 4 [MCP server] — ${siteUrl}`);
   });
 });
 
@@ -349,5 +389,14 @@ describe("buildBriefEmail", () => {
       dateLabel: "2026-06-19",
     });
     expect(result.text).toContain("https://heyclau.de/entry/mcp/relative");
+  });
+
+  it("falls back to the empty-state when the brief omits sections entirely", () => {
+    const result = buildBriefEmail({
+      brief: {},
+      siteUrl,
+      dateLabel: "2026-06-19",
+    });
+    expect(result.html).toContain("No notable activity this week.");
   });
 });


### PR DESCRIPTION
## What

Brings `apps/web/src/lib/brief-email-lib.ts` to **100% coverage** (was 91.91% branch, 91/99) with 5 new tests covering the `?? ""` / `?? {}` fallback branches in `cardHtml`, `overflowRowHtml`, `sectionText`, and `buildBriefEmail` — every case where an item's `url`/`title`/`description` or the brief's `sections` field is absent rather than merely empty. Existing tests always supplied a real `url`/`title` (via the `item()` fixture default) or an explicit `sections: {}`, so these specific nullish-coalescing branches were never exercised.

## Notes

- **Test-only change** — no source behaviour is modified.
- Verified locally: `vitest run tests/brief-email-lib.test.ts --coverage` → 29 tests pass, 100% statements/branches/functions/lines; `prettier --check` and `pnpm --filter web type-check` clean.