### PR TITLE
test(submissions): cover auth-state verification fail-closed paths

### DIFF
--- a/tests/submission-gate-auth-state-verification.test.ts
+++ b/tests/submission-gate-auth-state-verification.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { verifyDraftState } from "../apps/submission-gate/src/storage";
+import { sha256Hex } from "../apps/submission-gate/src/security";
+
+function createFakeDb(first: unknown) {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return this;
+        },
+        async first() {
+          return first;
+        },
+      };
+    },
+  } as unknown as D1Database;
+}
+
+describe("submission-gate verifyDraftState", () => {
+  it("fails closed when the draft has no stored auth state hash", async () => {
+    const db = createFakeDb({ authStateHash: null });
+    await expect(verifyDraftState(db, "draft_1", "state")).resolves.toBe(false);
+  });
+
+  it("fails closed when the draft row itself is missing", async () => {
+    const db = createFakeDb(null);
+    await expect(verifyDraftState(db, "draft_1", "state")).resolves.toBe(false);
+  });
+
+  it("fails closed when the stored hash is not valid hex", async () => {
+    const db = createFakeDb({ authStateHash: "not-hex-at-all" });
+    await expect(verifyDraftState(db, "draft_1", "state")).resolves.toBe(false);
+  });
+
+  it("fails closed when the stored hash decodes to the wrong byte length", async () => {
+    // Valid hex but short of the 32-byte SHA-256 digest length.
+    const db = createFakeDb({ authStateHash: "abcd" });
+    await expect(verifyDraftState(db, "draft_1", "state")).resolves.toBe(false);
+  });
+
+  describe("with a native crypto.subtle.timingSafeEqual available", () => {
+    const subtle = crypto.subtle as SubtleCrypto & {
+      timingSafeEqual?: (left: Uint8Array, right: Uint8Array) => boolean;
+    };
+    const original = subtle.timingSafeEqual;
+
+    afterEach(() => {
+      if (original) {
+        subtle.timingSafeEqual = original;
+      } else {
+        delete subtle.timingSafeEqual;
+      }
+    });
+
+    it("delegates to the native comparison when the runtime provides one", async () => {
+      const calls: Array<[Uint8Array, Uint8Array]> = [];
+      subtle.timingSafeEqual = (left, right) => {
+        calls.push([left, right]);
+        return true;
+      };
+
+      const authHash = await sha256Hex("expected-state");
+      const db = createFakeDb({ authStateHash: authHash });
+
+      await expect(
+        verifyDraftState(db, "draft_1", "whatever-state"),
+      ).resolves.toBe(true);
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toBeInstanceOf(Uint8Array);
+      expect(calls[0][0]).toHaveLength(32);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit coverage for `verifyDraftState` in `apps/submission-gate/src/storage.ts`, specifically the fail-closed comparison paths in its `timingSafeHexEqual`/`hexToBytes` helpers
- Covers previously-untested branches: missing draft row, missing stored hash, a stored hash that is not valid hex, and a stored hash that decodes to the wrong byte length (all must safely return `false` instead of throwing)
- Also covers the native `crypto.subtle.timingSafeEqual` delegation branch, which Node does not provide by default so only the constant-time fallback loop was previously exercised

Resubmit of #5192, which the automated gate closed for a Prettier formatting failure (`trunk check --ci`) on the test file, unrelated to test correctness (Codecov and the AI reviewer both passed it with no blockers). This version is `prettier --check`-clean.

## Test plan
- `pnpm exec vitest run tests/submission-gate-auth-state-verification.test.ts` -- 5 tests pass
- `pnpm exec prettier --check tests/submission-gate-auth-state-verification.test.ts` -- clean
- Scoped coverage on `apps/submission-gate/src/storage.ts` reaches 100% line coverage (was 92.3%) and improves branch coverage (85.6% -> 88.8%)
