### PR TITLE
feat(web): add compare table harness badge browse analytics

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -8,6 +8,7 @@ import {
   NotesPresenceChips,
   SourceBadge,
 } from "@/components/badges";
+import { HarnessBadgeRow } from "@/components/harness-badge";
 import { TrustDrilldown } from "@/components/trust-drilldown";
 import { CopyButton } from "@/components/copy-button";
 import { SourceCitations } from "@/components/source-citations";
@@ -214,6 +215,15 @@ export const COMPARISON_ROWS: RowDef[] = [
         ))}
       </div>
     ),
+  },
+  {
+    label: "Harness",
+    render: (e) =>
+      e.harness && e.harness.length > 0 ? (
+        <HarnessBadgeRow ids={e.harness} asLink surface="compare-table" />
+      ) : (
+        <span className="text-xs text-ink-subtle">—</span>
+      ),
   },
   {
     label: "Source repo",


### PR DESCRIPTION
## Summary
- Add compare-table `Harness` row with `HarnessBadgeRow asLink surface=compare-table` (parity with compare-drawer)
- Fire privacy-light `harness_badge_click` with `{ surface: compare-table, harness }` — no titles/URLs
- Surface already covered in harness-badge CTA lib tests

## Test plan
- [ ] Compare table Harness badges navigate to `/for/\`
- [ ] Click emits `harness_badge_click` with surface `compare-table`
- [ ] type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)