### PR TITLE
feat(web): add compare tray install-risk badge browse analytics

### DIFF
--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -28,7 +28,13 @@ import {
   badgeChromeTrustAnalyticsEvent,
 } from "@/lib/badge-chrome-cta-events";
 import { trackEvent } from "@/lib/analytics";
-import { TrustBadge, SourceBadge, NotesPresenceChips, ReadinessDot } from "./badges";
+import {
+  TrustBadge,
+  SourceBadge,
+  NotesPresenceChips,
+  InstallRiskBadge,
+  ReadinessDot,
+} from "./badges";
 import { compareSignalToneClass } from "@/lib/compare-entry-signals";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
@@ -70,6 +76,13 @@ function TrayChip({
             badgeChromeSourceAnalyticsData(entry.source, "compare-tray"),
           )
         }
+      />
+      <InstallRiskBadge
+        entry={entry}
+        size="xs"
+        asLink
+        surface="compare-tray"
+        className="hidden sm:inline-flex"
       />
       <NotesPresenceChips
         entry={entry}

--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -13,6 +13,7 @@ export type InstallRiskBadgeSurface =
   | "compare-drawer"
   | "category-ranking"
   | "peek-panel"
+  | "compare-tray"
   | "browse-card"
   | "browse-grid"
   | "browse-row"

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -29,6 +29,10 @@ describe("install risk badge cta events lib", () => {
       surface: "peek-panel",
       risk: "review",
     });
+    expect(installRiskBadgeAnalyticsData("high", "compare-tray")).toEqual({
+      surface: "compare-tray",
+      risk: "high",
+    });
     expect(installRiskBadgeAnalyticsData("high", "browse-grid")).toEqual({
       surface: "browse-grid",
       risk: "high",


### PR DESCRIPTION
## Summary
- Add compare-tray `InstallRiskBadge asLink surface=compare-tray` next to Trust/Source/Notes
- Fire privacy-light `install_risk_badge_click` with `{ surface: compare-tray, risk }` — no titles/URLs
- Extend `InstallRiskBadgeSurface` + cover `compare-tray` in install-risk CTA lib tests

## Test plan
- [ ] Compare tray install-risk badge navigates to browse trust filter
- [ ] Click emits `install_risk_badge_click` with surface `compare-tray`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)