### PR TITLE
feat(web): add trending list install-risk and notes browse analytics

### DIFF
--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -14,6 +14,7 @@ export type InstallRiskBadgeSurface =
   | "category-ranking"
   | "peek-panel"
   | "compare-tray"
+  | "trending-list"
   | "browse-card"
   | "browse-grid"
   | "browse-row"

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -14,6 +14,7 @@ export type NotesPresenceSurface =
   | "category-ranking"
   | "peek-panel"
   | "compare-tray"
+  | "trending-list"
   | "browse-card"
   | "browse-grid"
   | "browse-row"

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -7,7 +7,13 @@ import { ArrowRight, Clock, Flame, Info, Rss, Star, TrendingUp } from "lucide-re
 import { BRIEF_ISSUES } from "@/data/entries";
 import { PageContainer } from "@/components/page-container";
 import { getEntry, search } from "@/data/search";
-import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
+import {
+  CategoryPill,
+  SourceBadge,
+  TrustBadge,
+  InstallRiskBadge,
+  NotesPresenceChips,
+} from "@/components/badges";
 import { TrendingPodium } from "@/components/trending-podium";
 import { ShareMenu } from "@/components/share-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -498,6 +504,8 @@ function TrendingPage() {
                       )
                     }
                   />
+                  <InstallRiskBadge entry={entry} size="xs" asLink surface="trending-list" />
+                  <NotesPresenceChips entry={entry} asLink surface="trending-list" />
                 </div>
                 <Link
                   to="/entry/$category/$slug"

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -33,6 +33,10 @@ describe("install risk badge cta events lib", () => {
       surface: "compare-tray",
       risk: "high",
     });
+    expect(installRiskBadgeAnalyticsData("review", "trending-list")).toEqual({
+      surface: "trending-list",
+      risk: "review",
+    });
     expect(installRiskBadgeAnalyticsData("high", "browse-grid")).toEqual({
       surface: "browse-grid",
       risk: "high",

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -47,6 +47,13 @@ describe("notes presence cta events lib", () => {
         present: true,
       },
     );
+    expect(notesPresenceAnalyticsData("safety", true, "trending-list")).toEqual(
+      {
+        surface: "trending-list",
+        noteKind: "safety",
+        present: true,
+      },
+    );
     expect(notesPresenceAnalyticsData("privacy", true, "browse-grid")).toEqual({
       surface: "browse-grid",
       noteKind: "privacy",


### PR DESCRIPTION
## Summary
- Add trending-list `InstallRiskBadge` + `NotesPresenceChips` asLink beside existing Category/Trust/Source chrome
- Fire privacy-light `install_risk_badge_click` / `notes_presence_chip_click` with `surface: trending-list` — no titles/URLs
- Extend surface unions + cover `trending-list` in CTA lib tests

## Test plan
- [ ] Trending list risk/notes chips navigate to browse filters
- [ ] Clicks emit events with surface `trending-list`
- [ ] vitest + type-check + build pass

Refs #550

Made with [Cursor](https://cursor.com)