### PR TITLE
feat(web): add quality page headline stat browse analytics

### DIFF
--- a/apps/web/src/lib/quality-page-cta-events-lib.ts
+++ b/apps/web/src/lib/quality-page-cta-events-lib.ts
@@ -81,3 +81,39 @@ export function qualityPageMethodToggleAnalyticsData(
     methodCount,
   };
 }
+
+export type QualityPageStatId = "total" | "source-backed" | "safety-notes" | "reviewed";
+
+export function qualityPageStatAnalyticsEvent(): string {
+  return "quality_page_stat_click";
+}
+
+export function qualityPageStatAnalyticsData(
+  statId: QualityPageStatId,
+  count: number,
+  percent: number,
+) {
+  return {
+    surface: QUALITY_PAGE_SURFACE,
+    statId,
+    count,
+    percent,
+  };
+}
+
+/** Map a quality headline stat to a browse `signal` search patch (or bare browse). */
+export function qualityPageStatBrowseSearch(
+  statId: QualityPageStatId,
+): { signal?: string } | undefined {
+  switch (statId) {
+    case "source-backed":
+      return { signal: "source-backed" };
+    case "safety-notes":
+      return { signal: "safety-notes" };
+    case "reviewed":
+      return { signal: "reviewed" };
+    case "total":
+    default:
+      return undefined;
+  }
+}

--- a/apps/web/src/lib/quality-page-cta-events.ts
+++ b/apps/web/src/lib/quality-page-cta-events.ts
@@ -13,5 +13,9 @@ export {
   qualityPageIssueAnalyticsEvent,
   qualityPageMethodToggleAnalyticsData,
   qualityPageMethodToggleAnalyticsEvent,
+  qualityPageStatAnalyticsData,
+  qualityPageStatAnalyticsEvent,
+  qualityPageStatBrowseSearch,
   type QualityMethodId,
+  type QualityPageStatId,
 } from "@/lib/quality-page-cta-events-lib";

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -38,7 +38,11 @@ import {
   qualityPageIssueAnalyticsEvent,
   qualityPageMethodToggleAnalyticsData,
   qualityPageMethodToggleAnalyticsEvent,
+  qualityPageStatAnalyticsData,
+  qualityPageStatAnalyticsEvent,
+  qualityPageStatBrowseSearch,
   type QualityMethodId,
+  type QualityPageStatId,
 } from "@/lib/quality-page-cta-events";
 import { cn } from "@/lib/utils";
 
@@ -120,24 +124,27 @@ function QualityPage() {
       </p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        <Stat icon={BadgeCheck} label="Total entries" value={total} percent={100} />
+        <Stat icon={BadgeCheck} label="Total entries" value={total} percent={100} statId="total" />
         <Stat
           icon={GitBranch}
           label="Source-backed"
           value={QUALITY_STATS.sourceBacked}
           percent={pct(QUALITY_STATS.sourceBacked)}
+          statId="source-backed"
         />
         <Stat
           icon={ShieldCheck}
           label="Safety notes present"
           value={QUALITY_STATS.withSafetyNotes}
           percent={pct(QUALITY_STATS.withSafetyNotes)}
+          statId="safety-notes"
         />
         <Stat
           icon={FileText}
           label="Reviewed by maintainer"
           value={QUALITY_STATS.reviewed}
           percent={pct(QUALITY_STATS.reviewed)}
+          statId="reviewed"
         />
       </div>
 
@@ -455,14 +462,26 @@ function Stat({
   label,
   value,
   percent,
+  statId,
 }: {
   icon: React.ElementType;
   label: string;
   value: number;
   percent: number;
+  statId: QualityPageStatId;
 }) {
   return (
-    <div className="bg-surface p-5">
+    <Link
+      to="/browse"
+      search={qualityPageStatBrowseSearch(statId)}
+      onClick={() =>
+        trackEvent(
+          qualityPageStatAnalyticsEvent(),
+          qualityPageStatAnalyticsData(statId, value, percent),
+        )
+      }
+      className="block bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60"
+    >
       <div className="flex items-center justify-between">
         <Icon className="h-4 w-4 text-ink-muted" />
         <span className="font-mono text-xs tabular-nums text-ink-subtle">{percent}%</span>
@@ -474,7 +493,7 @@ function Stat({
         <div className="text-xs text-ink-muted">{label}</div>
         <span className="font-mono text-[11px] text-ink-subtle">current snapshot</span>
       </div>
-    </div>
+    </Link>
   );
 }
 

--- a/tests/quality-page-cta-events-lib.test.ts
+++ b/tests/quality-page-cta-events-lib.test.ts
@@ -11,6 +11,9 @@ import {
   qualityPageIssueAnalyticsEvent,
   qualityPageMethodToggleAnalyticsData,
   qualityPageMethodToggleAnalyticsEvent,
+  qualityPageStatAnalyticsData,
+  qualityPageStatAnalyticsEvent,
+  qualityPageStatBrowseSearch,
 } from "@/lib/quality-page-cta-events-lib";
 
 describe("quality page cta events lib", () => {
@@ -61,6 +64,32 @@ describe("quality page cta events lib", () => {
       methodId: "install-command",
       open: false,
       methodCount: 5,
+    });
+  });
+
+  it("builds quality page headline stat analytics and browse search", () => {
+    expect(qualityPageStatAnalyticsEvent()).toBe("quality_page_stat_click");
+    expect(qualityPageStatAnalyticsData("total", 1200, 100)).toEqual({
+      surface: QUALITY_PAGE_SURFACE,
+      statId: "total",
+      count: 1200,
+      percent: 100,
+    });
+    expect(qualityPageStatAnalyticsData("source-backed", 900, 75)).toEqual({
+      surface: QUALITY_PAGE_SURFACE,
+      statId: "source-backed",
+      count: 900,
+      percent: 75,
+    });
+    expect(qualityPageStatBrowseSearch("total")).toBeUndefined();
+    expect(qualityPageStatBrowseSearch("source-backed")).toEqual({
+      signal: "source-backed",
+    });
+    expect(qualityPageStatBrowseSearch("safety-notes")).toEqual({
+      signal: "safety-notes",
+    });
+    expect(qualityPageStatBrowseSearch("reviewed")).toEqual({
+      signal: "reviewed",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Promote quality-page headline Stat strip to browse Links with privacy-light `quality_page_stat_click` analytics
- Map source-backed / safety-notes / reviewed stats to browse `signal` search; total stays bare `/browse`

## Test plan
- [ ] Open /quality and click each headline stat
- [ ] Confirm browse destinations (bare + signal filters)
- [ ] Confirm analytics payload is privacy-light (surface, statId, count, percent)

Refs #550

Made with [Cursor](https://cursor.com)