### PR TITLE
feat(web): add contributor profile install-risk and notes browse analytics

### DIFF
--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -30,7 +30,8 @@ export type InstallRiskBadgeSurface =
   | "platform-hub"
   | "platform-category"
   | "detail-related"
-  | "detail-guides";
+  | "detail-guides"
+  | "contributor-profile";
 
 export function installRiskBadgeAnalyticsEvent(): string {
   return "install_risk_badge_click";

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -30,7 +30,8 @@ export type NotesPresenceSurface =
   | "platform-hub"
   | "platform-category"
   | "detail-related"
-  | "detail-guides";
+  | "detail-guides"
+  | "contributor-profile";
 
 export type NotesPresenceKind = "safety" | "privacy";
 

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -18,7 +18,13 @@ import {
   type ContributorAcceptedEntryRole,
 } from "@/data/contributors";
 import { ENTRIES } from "@/data/entries";
-import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
+import {
+  CategoryPill,
+  InstallRiskBadge,
+  NotesPresenceChips,
+  SourceBadge,
+  TrustBadge,
+} from "@/components/badges";
 import { Monogram } from "@/components/monogram";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -396,6 +402,8 @@ function ContributionRow({
             )
           }
         />
+        <InstallRiskBadge entry={entry} size="xs" asLink surface="contributor-profile" />
+        <NotesPresenceChips entry={entry} asLink surface="contributor-profile" />
       </div>
 
       <div className="mt-3">

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -37,6 +37,12 @@ describe("install risk badge cta events lib", () => {
       surface: "trending-list",
       risk: "review",
     });
+    expect(installRiskBadgeAnalyticsData("low", "contributor-profile")).toEqual(
+      {
+        surface: "contributor-profile",
+        risk: "low",
+      },
+    );
     expect(installRiskBadgeAnalyticsData("high", "browse-grid")).toEqual({
       surface: "browse-grid",
       risk: "high",

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -54,6 +54,13 @@ describe("notes presence cta events lib", () => {
         present: true,
       },
     );
+    expect(
+      notesPresenceAnalyticsData("privacy", true, "contributor-profile"),
+    ).toEqual({
+      surface: "contributor-profile",
+      noteKind: "privacy",
+      present: true,
+    });
     expect(notesPresenceAnalyticsData("privacy", true, "browse-grid")).toEqual({
       surface: "browse-grid",
       noteKind: "privacy",


### PR DESCRIPTION
## Summary
- Wire InstallRiskBadge and NotesPresenceChips as browse Links on contributor ContributionRow
- Extend surface unions with `contributor-profile` and cover in unit tests

## Test plan
- [ ] Open a contributor profile and click install-risk / notes chips on a contribution row
- [ ] Confirm browse destinations (trust / signal filters)
- [ ] Confirm analytics payloads are privacy-light (surface + risk/noteKind)

Refs #550

Made with [Cursor](https://cursor.com)