### PR TITLE
feat(web): add validators and hub badge browse egress

### DIFF
--- a/apps/web/src/components/hub-highlights.tsx
+++ b/apps/web/src/components/hub-highlights.tsx
@@ -18,6 +18,10 @@ import {
   hubHighlightSourceBrowseAnalyticsEvent,
 } from "@/lib/hub-entry-cta-events";
 import {
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
+import {
   hubSignalStatAnalyticsData,
   hubSignalStatAnalyticsEvent,
   hubStatBrowseSearch,
@@ -86,7 +90,16 @@ export function HubHighlights({
                   <p className="mt-1 flex-1 text-xs text-ink-muted">{h.reason}</p>
                 </Link>
                 <div className="mt-3 flex flex-wrap items-center gap-1.5">
-                  <TrustBadge level={h.entry.trust} />
+                  <TrustBadge
+                    level={h.entry.trust}
+                    asLink
+                    onNavigate={() =>
+                      trackEvent(
+                        badgeChromeTrustAnalyticsEvent(),
+                        badgeChromeTrustAnalyticsData(h.entry.trust, "hub-highlights"),
+                      )
+                    }
+                  />
                   <SourceBadge
                     status={h.entry.source}
                     asLink

--- a/apps/web/src/lib/badge-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events-lib.ts
@@ -12,7 +12,10 @@ export type BadgeChromeSurface =
   | "contributor-profile"
   | "compare-tray"
   | "trending-list"
-  | "trending-podium";
+  | "trending-podium"
+  | "validators-attention"
+  | "validators-recent-reviewed"
+  | "hub-highlights";
 
 export type BadgeChromeNoteKind = "safety" | "privacy";
 

--- a/apps/web/src/lib/hub-signal-cta-events-lib.ts
+++ b/apps/web/src/lib/hub-signal-cta-events-lib.ts
@@ -5,7 +5,7 @@
  * hub titles or free-form labels beyond stable stat keys.
  */
 
-export type HubSignalSurface = "category-hub" | "platform-hub" | "tag-hub";
+export type HubSignalSurface = "category-hub" | "platform-hub" | "tag-hub" | "platform-category";
 
 export type HubSignalStatKey = "trusted" | "sourced" | "safety" | "privacy" | "reviewed";
 

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -202,7 +202,12 @@ function IntersectionPage() {
         ))}
       </div>
 
-      <HubSignalStats stats={stats} total={entries.length} />
+      <HubSignalStats
+        stats={stats}
+        total={entries.length}
+        surface="platform-category"
+        browseBase={{ platform, category }}
+      />
 
       <NewsletterInline
         variant="quiet"

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -40,6 +40,14 @@ import {
   validatorsCoverageMetricBrowseSearch,
   type ValidatorsCoverageMetricId,
 } from "@/lib/validators-coverage-cta-events";
+import {
+  badgeChromeCategoryAnalyticsData,
+  badgeChromeCategoryAnalyticsEvent,
+  badgeChromeSourceAnalyticsData,
+  badgeChromeSourceAnalyticsEvent,
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
 import atlasRegistry from "@/generated/atlas-registry.json";
 
 const VALIDATOR_TOOL_COUNT = 2;
@@ -245,32 +253,67 @@ function ValidatorsPage() {
                 <ul className="space-y-2">
                   {coverage.needsAttention.map((entry, rowIndex) => (
                     <li key={`${entry.category}/${entry.slug}`}>
-                      <Link
-                        to="/entry/$category/$slug"
-                        params={{ category: entry.category, slug: entry.slug }}
-                        onClick={() =>
-                          trackEvent(
-                            validatorsAttentionEntryAnalyticsEvent(),
-                            validatorsAttentionEntryAnalyticsData(
-                              entry.category,
-                              entry.slug,
-                              coverage.id,
-                              rowIndex,
-                              coverage.needsAttention.length,
-                            ),
-                          )
-                        }
-                        className="block rounded-lg border border-border bg-background p-3 transition-colors hover:bg-surface-2"
-                      >
+                      <div className="rounded-lg border border-border bg-background p-3 transition-colors hover:bg-surface-2">
                         <div className="flex flex-wrap items-center gap-1.5">
-                          <CategoryPill>{entry.category}</CategoryPill>
-                          <TrustBadge level={entry.trust} />
-                          <SourceBadge status={entry.source} />
+                          <CategoryPill
+                            asLink
+                            category={entry.category}
+                            onNavigate={() =>
+                              trackEvent(
+                                badgeChromeCategoryAnalyticsEvent(),
+                                badgeChromeCategoryAnalyticsData(
+                                  entry.category,
+                                  "validators-attention",
+                                ),
+                              )
+                            }
+                          >
+                            {entry.category}
+                          </CategoryPill>
+                          <TrustBadge
+                            level={entry.trust}
+                            asLink
+                            onNavigate={() =>
+                              trackEvent(
+                                badgeChromeTrustAnalyticsEvent(),
+                                badgeChromeTrustAnalyticsData(entry.trust, "validators-attention"),
+                              )
+                            }
+                          />
+                          <SourceBadge
+                            status={entry.source}
+                            asLink
+                            onNavigate={() =>
+                              trackEvent(
+                                badgeChromeSourceAnalyticsEvent(),
+                                badgeChromeSourceAnalyticsData(
+                                  entry.source,
+                                  "validators-attention",
+                                ),
+                              )
+                            }
+                          />
                         </div>
-                        <div className="mt-1 line-clamp-1 text-sm font-medium text-ink">
+                        <Link
+                          to="/entry/$category/$slug"
+                          params={{ category: entry.category, slug: entry.slug }}
+                          onClick={() =>
+                            trackEvent(
+                              validatorsAttentionEntryAnalyticsEvent(),
+                              validatorsAttentionEntryAnalyticsData(
+                                entry.category,
+                                entry.slug,
+                                coverage.id,
+                                rowIndex,
+                                coverage.needsAttention.length,
+                              ),
+                            )
+                          }
+                          className="mt-1 block line-clamp-1 text-sm font-medium text-ink hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
+                        >
                           {entry.title}
-                        </div>
-                      </Link>
+                        </Link>
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -291,36 +334,61 @@ function ValidatorsPage() {
             </p>
           ) : (
             RECENT_REVIEWED.map((entry, rowIndex) => (
-              <Link
+              <div
                 key={`${entry.category}/${entry.slug}`}
-                to="/entry/$category/$slug"
-                params={{ category: entry.category, slug: entry.slug }}
-                onClick={() =>
-                  trackEvent(
-                    validatorsRecentReviewedEntryAnalyticsEvent(),
-                    validatorsRecentReviewedEntryAnalyticsData(
-                      entry.category,
-                      entry.slug,
-                      rowIndex,
-                      RECENT_REVIEWED.length,
-                    ),
-                  )
-                }
                 className="grid gap-3 border-b border-border px-5 py-3 text-sm last:border-0 hover:bg-surface-2 sm:grid-cols-[1fr_120px]"
               >
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-1.5">
-                    <CategoryPill>{entry.category}</CategoryPill>
-                    <TrustBadge level={entry.trust} />
+                    <CategoryPill
+                      asLink
+                      category={entry.category}
+                      onNavigate={() =>
+                        trackEvent(
+                          badgeChromeCategoryAnalyticsEvent(),
+                          badgeChromeCategoryAnalyticsData(
+                            entry.category,
+                            "validators-recent-reviewed",
+                          ),
+                        )
+                      }
+                    >
+                      {entry.category}
+                    </CategoryPill>
+                    <TrustBadge
+                      level={entry.trust}
+                      asLink
+                      onNavigate={() =>
+                        trackEvent(
+                          badgeChromeTrustAnalyticsEvent(),
+                          badgeChromeTrustAnalyticsData(entry.trust, "validators-recent-reviewed"),
+                        )
+                      }
+                    />
                   </div>
-                  <div className="mt-1 truncate font-display font-semibold text-ink">
+                  <Link
+                    to="/entry/$category/$slug"
+                    params={{ category: entry.category, slug: entry.slug }}
+                    onClick={() =>
+                      trackEvent(
+                        validatorsRecentReviewedEntryAnalyticsEvent(),
+                        validatorsRecentReviewedEntryAnalyticsData(
+                          entry.category,
+                          entry.slug,
+                          rowIndex,
+                          RECENT_REVIEWED.length,
+                        ),
+                      )
+                    }
+                    className="mt-1 block truncate font-display font-semibold text-ink hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 rounded-sm"
+                  >
                     {entry.title}
-                  </div>
+                  </Link>
                 </div>
                 <span className="font-mono text-xs text-ink-subtle sm:text-right">
                   {entry.reviewedAt?.slice(0, 10)}
                 </span>
-              </Link>
+              </div>
             ))
           )}
         </div>

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -143,5 +143,39 @@ describe("badge chrome cta events lib", () => {
       surface: "trending-podium",
       category: "skills",
     });
+    expect(
+      badgeChromeTrustAnalyticsData("limited", "validators-attention"),
+    ).toEqual({
+      surface: "validators-attention",
+      trust: "limited",
+    });
+    expect(
+      badgeChromeSourceAnalyticsData("unverified", "validators-attention"),
+    ).toEqual({
+      surface: "validators-attention",
+      source: "unverified",
+    });
+    expect(
+      badgeChromeCategoryAnalyticsData("hooks", "validators-attention"),
+    ).toEqual({
+      surface: "validators-attention",
+      category: "hooks",
+    });
+    expect(
+      badgeChromeTrustAnalyticsData("trusted", "validators-recent-reviewed"),
+    ).toEqual({
+      surface: "validators-recent-reviewed",
+      trust: "trusted",
+    });
+    expect(
+      badgeChromeCategoryAnalyticsData("mcp", "validators-recent-reviewed"),
+    ).toEqual({
+      surface: "validators-recent-reviewed",
+      category: "mcp",
+    });
+    expect(badgeChromeTrustAnalyticsData("review", "hub-highlights")).toEqual({
+      surface: "hub-highlights",
+      trust: "review",
+    });
   });
 });

--- a/tests/hub-signal-cta-events-lib.test.ts
+++ b/tests/hub-signal-cta-events-lib.test.ts
@@ -16,6 +16,14 @@ describe("hub signal cta events lib", () => {
       count: 12,
       pct: 40,
     });
+    expect(
+      hubSignalStatAnalyticsData("platform-category", "reviewed", 4, 20),
+    ).toEqual({
+      surface: "platform-category",
+      statKey: "reviewed",
+      count: 4,
+      pct: 20,
+    });
     expect(hubStatBrowseSearch("trusted", { category: "mcp" })).toEqual({
       category: "mcp",
       trust: "trusted",


### PR DESCRIPTION
## Summary
- Restructure validators attention + recent-reviewed rows so category/trust/source badges sit outside entry Links with badge-chrome browse analytics.
- Enable hub-highlight TrustBadge browse egress.
- Wire `HubSignalStats` on platform×category hubs with `surface=\"platform-category\"`.

## Test plan
- [x] Vitest: badge-chrome new surfaces, hub-signal platform-category
- [ ] CI: validate-ci, codecov/patch, codecov/project, required-pr-gate, LoopOver
- [ ] No path overlap with open ecosystem (#5202) / trust-lib (#5187) / test PRs

Refs #550

Made with [Cursor](https://cursor.com)