### PR TITLE
feat(web): wire platform-category hub signal stats browse analytics

### DIFF
--- a/apps/web/src/lib/hub-signal-cta-events-lib.ts
+++ b/apps/web/src/lib/hub-signal-cta-events-lib.ts
@@ -5,7 +5,7 @@
  * hub titles or free-form labels beyond stable stat keys.
  */
 
-export type HubSignalSurface = "category-hub" | "platform-hub" | "tag-hub";
+export type HubSignalSurface = "category-hub" | "platform-hub" | "tag-hub" | "platform-category";
 
 export type HubSignalStatKey = "trusted" | "sourced" | "safety" | "privacy" | "reviewed";
 

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -202,7 +202,12 @@ function IntersectionPage() {
         ))}
       </div>
 
-      <HubSignalStats stats={stats} total={entries.length} />
+      <HubSignalStats
+        stats={stats}
+        total={entries.length}
+        surface="platform-category"
+        browseBase={{ platform, category }}
+      />
 
       <NewsletterInline
         variant="quiet"

--- a/tests/hub-signal-cta-events-lib.test.ts
+++ b/tests/hub-signal-cta-events-lib.test.ts
@@ -16,9 +16,27 @@ describe("hub signal cta events lib", () => {
       count: 12,
       pct: 40,
     });
+    expect(
+      hubSignalStatAnalyticsData("platform-category", "sourced", 8, 25),
+    ).toEqual({
+      surface: "platform-category",
+      statKey: "sourced",
+      count: 8,
+      pct: 25,
+    });
     expect(hubStatBrowseSearch("trusted", { category: "mcp" })).toEqual({
       category: "mcp",
       trust: "trusted",
+    });
+    expect(
+      hubStatBrowseSearch("reviewed", {
+        platform: "cursor",
+        category: "skills",
+      }),
+    ).toEqual({
+      platform: "cursor",
+      category: "skills",
+      signal: "reviewed",
     });
     expect(hubStatBrowseSearch("sourced", { platform: "claude-code" })).toEqual(
       {


### PR DESCRIPTION
## Summary
- Pass `surface` + `browseBase` into platform×category `HubSignalStats` so coverage bars link to browse
- Extend `HubSignalSurface` with `platform-category` and cover in unit tests

## Test plan
- [ ] Open a /for/\/\ page and click each signal coverage bar
- [ ] Confirm browse search includes platform + category + trust/signal
- [ ] Confirm analytics surface is `platform-category`

Refs #550

Made with [Cursor](https://cursor.com)