### PR TITLE
feat(web): add contributor profile headline stat browse analytics

### DIFF
--- a/apps/web/src/lib/contributor-profile-cta-events-lib.ts
+++ b/apps/web/src/lib/contributor-profile-cta-events-lib.ts
@@ -135,3 +135,40 @@ export function contributorProfileTraceEgressAnalyticsData(
     rowCount,
   };
 }
+
+export type ContributorProfileStatId = "accepted" | "reviewed" | "categories" | "source-linked";
+
+export function contributorProfileStatAnalyticsEvent(): string {
+  return "contributor_profile_stat_click";
+}
+
+export function contributorProfileStatAnalyticsData(
+  contributorSlug: string,
+  statId: ContributorProfileStatId,
+  count: number,
+) {
+  return {
+    surface: CONTRIBUTOR_PROFILE_SURFACE,
+    contributorSlug,
+    statId,
+    count,
+  };
+}
+
+/** Map a contributor headline stat to an in-app destination (route + hash/search). */
+export function contributorProfileStatDestination(statId: ContributorProfileStatId): {
+  to: "/contributors/$slug" | "/browse";
+  hash?: string;
+  search?: { signal?: string };
+} {
+  switch (statId) {
+    case "accepted":
+      return { to: "/contributors/$slug", hash: "accepted" };
+    case "reviewed":
+      return { to: "/contributors/$slug", hash: "reviewed" };
+    case "categories":
+      return { to: "/contributors/$slug", hash: "category-credits" };
+    case "source-linked":
+      return { to: "/browse", search: { signal: "source-backed" } };
+  }
+}

--- a/apps/web/src/lib/contributor-profile-cta-events.ts
+++ b/apps/web/src/lib/contributor-profile-cta-events.ts
@@ -17,5 +17,9 @@ export {
   contributorProfileSubmitterAnalyticsEvent,
   contributorProfileTraceEgressAnalyticsData,
   contributorProfileTraceEgressAnalyticsEvent,
+  contributorProfileStatAnalyticsData,
+  contributorProfileStatAnalyticsEvent,
+  contributorProfileStatDestination,
+  type ContributorProfileStatId,
   type ContributorProfileTraceDestination,
 } from "@/lib/contributor-profile-cta-events-lib";

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -57,6 +57,10 @@ import {
   contributorProfileSubmitterAnalyticsEvent,
   contributorProfileTraceEgressAnalyticsData,
   contributorProfileTraceEgressAnalyticsEvent,
+  contributorProfileStatAnalyticsData,
+  contributorProfileStatAnalyticsEvent,
+  contributorProfileStatDestination,
+  type ContributorProfileStatId,
   type ContributorProfileTraceDestination,
 } from "@/lib/contributor-profile-cta-events";
 import { contributorPersonJsonLd } from "@/lib/contributor-person-jsonld-lib";
@@ -175,14 +179,38 @@ function ContributorPage() {
       </header>
 
       <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <ContributorStat icon={FileCheck2} label="Accepted" value={acceptedEntries.length} />
-        <ContributorStat icon={ShieldCheck} label="Reviewed" value={reviewedEntries.length} />
-        <ContributorStat icon={Layers3} label="Categories" value={categorySummaries.length} />
-        <ContributorStat icon={GitPullRequest} label="Source-linked" value={sourceLinkedCount} />
+        <ContributorStat
+          icon={FileCheck2}
+          label="Accepted"
+          value={acceptedEntries.length}
+          contributorSlug={contributor.slug}
+          statId="accepted"
+        />
+        <ContributorStat
+          icon={ShieldCheck}
+          label="Reviewed"
+          value={reviewedEntries.length}
+          contributorSlug={contributor.slug}
+          statId="reviewed"
+        />
+        <ContributorStat
+          icon={Layers3}
+          label="Categories"
+          value={categorySummaries.length}
+          contributorSlug={contributor.slug}
+          statId="categories"
+        />
+        <ContributorStat
+          icon={GitPullRequest}
+          label="Source-linked"
+          value={sourceLinkedCount}
+          contributorSlug={contributor.slug}
+          statId="source-linked"
+        />
       </div>
 
       {categorySummaries.length > 0 && (
-        <section className="mt-10">
+        <section id="category-credits" className="mt-10 scroll-mt-24">
           <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
             Category Credits
           </h2>
@@ -213,20 +241,21 @@ function ContributorPage() {
       )}
 
       <ContributionSection
+        id="accepted"
         title="Accepted Entries"
         entries={acceptedEntries}
         contributor={contributor}
         empty="No accepted entries yet."
       />
 
-      {reviewedEntries.length > 0 && (
-        <ContributionSection
-          title="Reviewed Entries"
-          entries={reviewedEntries}
-          contributor={contributor}
-          role="reviewed"
-        />
-      )}
+      <ContributionSection
+        id="reviewed"
+        title="Reviewed Entries"
+        entries={reviewedEntries}
+        contributor={contributor}
+        role="reviewed"
+        empty="No reviewed entries yet."
+      />
 
       <div className="mt-12 rounded-xl border border-border bg-surface p-6 text-sm text-ink-muted">
         Want to contribute?{" "}
@@ -277,29 +306,48 @@ function ContributorStat({
   icon: Icon,
   label,
   value,
+  contributorSlug,
+  statId,
 }: {
   icon: ElementType;
   label: string;
   value: number;
+  contributorSlug: string;
+  statId: ContributorProfileStatId;
 }) {
+  const destination = contributorProfileStatDestination(statId);
   return (
-    <div className="rounded-xl border border-border bg-surface p-4">
+    <Link
+      to={destination.to}
+      params={destination.to === "/contributors/$slug" ? { slug: contributorSlug } : undefined}
+      hash={destination.hash}
+      search={destination.to === "/browse" ? destination.search : undefined}
+      onClick={() =>
+        trackEvent(
+          contributorProfileStatAnalyticsEvent(),
+          contributorProfileStatAnalyticsData(contributorSlug, statId, value),
+        )
+      }
+      className="rounded-xl border border-border bg-surface p-4 transition-colors duration-200 ease-out hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+    >
       <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-ink-subtle">
         <Icon className="h-3.5 w-3.5" aria-hidden />
         {label}
       </div>
       <div className="mt-2 font-display text-2xl font-semibold text-ink tabular-nums">{value}</div>
-    </div>
+    </Link>
   );
 }
 
 function ContributionSection({
+  id,
   title,
   entries,
   contributor,
   role,
   empty,
 }: {
+  id: string;
   title: string;
   entries: Entry[];
   contributor: Contributor;
@@ -307,7 +355,7 @@ function ContributionSection({
   empty?: string;
 }) {
   return (
-    <section className="mt-10">
+    <section id={id} className="mt-10 scroll-mt-24">
       <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
         {title} ({entries.length})
       </h2>

--- a/tests/contributor-profile-cta-events-lib.test.ts
+++ b/tests/contributor-profile-cta-events-lib.test.ts
@@ -15,6 +15,9 @@ import {
   contributorProfileSubmitterAnalyticsEvent,
   contributorProfileTraceEgressAnalyticsData,
   contributorProfileTraceEgressAnalyticsEvent,
+  contributorProfileStatAnalyticsData,
+  contributorProfileStatAnalyticsEvent,
+  contributorProfileStatDestination,
 } from "@/lib/contributor-profile-cta-events-lib";
 
 describe("contributor profile cta events lib", () => {
@@ -105,6 +108,44 @@ describe("contributor profile cta events lib", () => {
       role: "authored",
       rowIndex: 1,
       rowCount: 4,
+    });
+  });
+
+  it("builds contributor profile headline stat analytics and destinations", () => {
+    expect(contributorProfileStatAnalyticsEvent()).toBe(
+      "contributor_profile_stat_click",
+    );
+    expect(
+      contributorProfileStatAnalyticsData("alice", "accepted", 12),
+    ).toEqual({
+      surface: CONTRIBUTOR_PROFILE_SURFACE,
+      contributorSlug: "alice",
+      statId: "accepted",
+      count: 12,
+    });
+    expect(
+      contributorProfileStatAnalyticsData("alice", "source-linked", 9),
+    ).toEqual({
+      surface: CONTRIBUTOR_PROFILE_SURFACE,
+      contributorSlug: "alice",
+      statId: "source-linked",
+      count: 9,
+    });
+    expect(contributorProfileStatDestination("accepted")).toEqual({
+      to: "/contributors/$slug",
+      hash: "accepted",
+    });
+    expect(contributorProfileStatDestination("reviewed")).toEqual({
+      to: "/contributors/$slug",
+      hash: "reviewed",
+    });
+    expect(contributorProfileStatDestination("categories")).toEqual({
+      to: "/contributors/$slug",
+      hash: "category-credits",
+    });
+    expect(contributorProfileStatDestination("source-linked")).toEqual({
+      to: "/browse",
+      search: { signal: "source-backed" },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Promote contributor profile headline ContributorStat tiles to Links with privacy-light `contributor_profile_stat_click` analytics
- Destinations: accepted/reviewed/categories → in-page anchors; source-linked → browse `signal=source-backed`

## Test plan
- [ ] Open a contributor profile and click each headline stat
- [ ] Confirm in-page scroll for accepted / reviewed / category-credits
- [ ] Confirm source-linked opens browse with source-backed signal
- [ ] Confirm analytics payload is privacy-light (surface, contributorSlug, statId, count)

Refs #550

Made with [Cursor](https://cursor.com)