### PR TITLE
chore(skills): add contributor-pipeline-gardening skill

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: contributor-pipeline-gardening
+description: >-
+  Maintenance of the contributor issue pipeline for JSONbored/awesome-claude (HeyClaude) —
+  closing issues that are already done but not marked so, and keeping a small, high-value
+  contributor-available backlog stocked with real website/content/feature/bugfix work. Runs
+  every ~24h via a dedicated scheduled task. Invoke for "run the issue gardening", "audit open
+  issues for stale/complete ones", "generate new contributor issues", or any recurring/scheduled
+  run of this process. `reference.md` (next to this file) has the exhaustive label/milestone/
+  template detail — read it before doing real work, not just this file. This is the
+  awesome-claude-specific instance; JSONbored/loopover and JSONbored/metagraphed each have their
+  own separate copy with different conventions and a much larger backlog target — do not
+  cross-apply either repo's specifics to this one without being asked.
+---
+
+# Contributor pipeline gardening — awesome-claude (HeyClaude)
+
+HeyClaude is a curated registry/directory of Claude and AI-workflow assets, plus the website
+(`apps/web`), registry/schema library (`packages/registry`), and MCP package (`packages/mcp`)
+that serve it. **This is a much smaller, quieter repo than loopover/metagraphed** — as of
+2026-07-17 it had zero open `gittensor:*`-labeled issues and a thin, fully-closed 2-milestone
+history. This skill exists to build and then maintain a small, deliberately curated backlog —
+**15-25 contributor-available issues**, not 50-100 — because padding a codebase this size to a
+larger number would mean weak/duplicate issues, which is explicitly worse than a smaller real
+backlog here.
+
+## The one thing this skill exists to prevent
+
+**Confirmed by the maintainer, 2026-07-17:** contributors here have recently gravitated to
+`test(...): cover X` PRs — real tests, but zero behavior change, added purely to nudge Codecov's
+`codecov/patch: 70%` bar (a soft, easily-hit target — unlike loopover's 99% gate, 70% patch
+coverage is trivially satisfied by testing already-written code). A second anti-pattern found
+during this skill's initial research: issue #550 (a "growth sprint" umbrella with a long child
+checklist) was being farmed almost entirely for its single easiest repeatable pattern — wiring
+one more page into the existing `intent-event`/analytics-click convention, dozens of
+near-identical PRs (#5205, #5202, #5201, ... #5168, all `Made with Cursor`), rather than any of
+the umbrella's harder, more valuable child issues.
+
+**Never generate a standalone `test(...): cover X` issue.** A regression test attached to a real
+bug fix is fine and expected (see the template in `reference.md`); a test-only issue with no
+behavior change is not. **Never generate more instances of an already-being-farmed shallow
+repeatable pattern** (check open issues and recent merged-PR titles for a dense run of
+near-identical titles before filing anything that looks like "wire pattern X into one more
+file/page/route" — if 5+ near-identical PRs already exist for the same pattern, that vein is
+farmed out, not a gardening opportunity). The whole point of this skill is issues that "drive
+real value... website/content/features grow... fix bugs/issues in frontend/backend" (the
+maintainer's own words) — not more of what a low-effort automated farmer already does better and
+faster than a well-scoped issue ever could.
+
+## Scope: code only, not content submissions
+
+`content/` (the curated directory entries themselves) is a legitimate, real contribution surface
+per `.gittensory.yml`'s `wantedPaths` — but content submissions are explicitly **PR-first**, with
+`linkedIssuePolicy: optional` and `issueDiscoveryPolicy: discouraged`, routed through a private
+submission gate that doesn't need or want a GitHub issue first. **This skill does not generate
+content-entry issues.** It scopes to the three code surfaces: `apps/web/src/` (the TanStack Start
+website — routes, components, lib), `packages/registry/src/` (schema/validation/submission-risk
+library), and `packages/mcp/` (the MCP server package), plus `scripts/` when a real gap is there.
+
+Unlike loopover/metagraphed, **a linked issue is advisory here, not a hard gate**
+(`gate.linkedIssue: advisory` in `.gittensory.yml`) — there is no auto-close mechanic forcing a
+contributor to pick an issue. That means an issue has to be genuinely worth picking up on its own
+merits (clear, valuable, narrow, low-ambiguity) rather than relying on gate pressure to make it
+attractive. Write every issue like it has to compete for a contributor's attention, because it
+does.
+
+## Pass 1 — stale-issue sweep (do this first, every run)
+
+Same method as loopover/metagraphed's copy of this skill: for every open issue, query
+`timelineItems(itemTypes: [CROSS_REFERENCED_EVENT])` for merged PRs that referenced it, then read
+the actual PR body for any hit where `willCloseTarget` was false. Close what's genuinely done
+(with a comment naming the shipping PR and a direct code check confirming it exists); leave
+partial work open. Given this repo starts with a near-empty gittensor backlog, most runs will find
+little or nothing to sweep here until the backlog this skill builds has had time to accumulate
+real activity — that's expected, not a sign the check is broken.
+
+Also check issue #550 (the growth-sprint umbrella) and any other checklist-style tracker each run:
+sync stale checkboxes against real child-issue state, same as the sibling repos' Pass 1. Do not
+add new child issues to #550's shallow analytics-wiring pattern (see above) even if asked to "keep
+it topped up" — that pattern is already over-farmed.
+
+## Pass 2 — backlog top-up
+
+1. Compute the current contributor-available count: `gh issue list --repo JSONbored/awesome-claude
+   --state open --limit 1000 --json number,labels,assignees`, filtered to unassigned, no
+   `maintainer-only`, carrying a `gittensor:*` label. Target: **15-25, maintained continuously**.
+   If already in range, a quiet run that files 0-2 issues (or none) is a correct, expected
+   outcome — this is a small repo, don't force volume.
+2. Real gaps to scope from, in priority order:
+   - A genuine functional gap in `apps/web/src/routes/*.tsx` (~70 routes) — missing feature
+     parity between similar pages, a real UX/accessibility gap, a bug found by reading the code
+     against its own stated behavior.
+   - A real correctness/hardening gap in `packages/registry/src/` (schema/validation/risk-scoring
+     logic) — found by reading the code, not by grepping for TODOs (a repo-wide TODO/FIXME sweep
+     came back essentially empty as of 2026-07-17; this repo is clean, so gap-finding here means
+     reading real logic against its own documented intent, the same technique loopover's gardening
+     uses for its "hardening round" audits).
+   - `packages/mcp/`'s tool/resource surface for a real, narrow parity or correctness gap.
+   - Closed-milestone follow-ups: `Code Quality — Round 5` (#3) and `Growth & Maintainability —
+     Round 7` (#4) are both fully closed, historical sprints — read a few of their closed issues
+     for the kind of real, valuable work this repo's maintainer has asked for before, as a
+     calibration reference for what "real value" looks like here, not as a source of reopenable
+     work.
+3. **Every new issue gets `Contributor Backlog (Gardening)` (milestone #5)** — the two historical
+   Round milestones are closed and not the target. This milestone was created 2026-07-17
+   specifically as the evergreen home for this skill's output (see `reference.md`'s
+   milestone-discipline note for why a new one was warranted here).
+4. Apply `gittensor:bug` / `gittensor:feature` / `gittensor:priority` (same 0.05x/0.25x/1.5x
+   convention as loopover — `gittensor:priority` reserved, sparingly applied) plus `help wanted`.
+   Do not apply `size:*`, `category:*`, `contributor:*`, `pr:*`, or `submission-*` labels — those
+   belong to this repo's separate content-submission/PR-automation machinery, not gardening-filed
+   issues.
+5. **Use the repo's own existing `product-feature.yml` issue-form template** (via
+   `gh issue create --template` or matching its field structure manually) — see `reference.md` for
+   the exact field list. This is a real, maintainer-authored template already built for exactly
+   this use case; do not invent a different body structure.
+6. Check every new batch for a real dependency, then link with native `addSubIssue`/
+   `addBlockedBy` (confirmed working on this repo via GraphQL) — same discipline as the sibling
+   repos: most independent bug/feature issues need no link; only connect a genuine prerequisite
+   relationship.
+7. Quality over volume, always — this repo's small size makes padding especially visible and
+   especially damaging to the "issues are worth picking up voluntarily" value proposition Pass 2's
+   intro describes.
+
+## Daily digest
+
+Same shape as the sibling repos': issues closed + why, checklists fixed, new issues filed with
+milestone/label, before/after contributor-available count (against the 15-25 target, not 50-100),
+anything left alone on purpose — including explicitly naming any shallow-pattern-farming or
+test-coverage-padding temptation that was deliberately declined.

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -1,0 +1,138 @@
+# Contributor pipeline gardening — reference (awesome-claude / HeyClaude)
+
+## Product shape
+
+Three code surfaces gardening scopes to:
+- **`apps/web/src/`** — the TanStack Start website. `routes/` (~70 route files: browse, compare,
+  entry detail, brief, jobs, validators, `.well-known` endpoints, OG images), `lib/` (~250 files,
+  following a `foo.ts` + `foo-lib.ts` split for pure-function testability), `data/`. `generated/`
+  is maintainer-owned — never a gardening-issue target.
+- **`packages/registry/src/`** — schema/validation/submission-risk/content-builder libraries
+  (`.js` + `.d.ts`) that define what a valid content entry is and score submission risk.
+  `submission-risk.js` alone is ~76KB — a real, complex module worth auditing for gaps. No README
+  exists here despite being the schema source-of-truth (a legitimate, low-effort docs-gap issue if
+  nothing more substantive is found).
+- **`packages/mcp/`** — the MCP server package (`registry-*-lib.js` files) exposing the registry
+  over MCP tools/resources.
+
+`content/` (curated directory entries) is a real contribution surface but explicitly PR-first —
+never a gardening-issue target (see SKILL.md's "Scope" section for why).
+
+## The gate — advisory, not a hard block
+
+Platform/code PRs go through required CI + maintainer review; the shared `gittensory-orb` bot
+posts an advisory readiness/coverage comment but never auto-merges or auto-closes here (unlike
+loopover/metagraphed's one-shot gate). `.gittensory.yml` sets `gate.linkedIssue: advisory` — a PR
+can merge without ever linking an issue. This means gardening's job is to make issues *worth*
+picking up, not to rely on a gate forcing contributors toward them.
+
+`.gittensory.yml`'s `linkedIssueLabelPropagation` block does auto-propagate `gittensor:bug`/
+`gittensor:feature` from a linked issue onto the PR (trusting a maintainer-authored issue's
+categorization) — `gittensor:priority` deliberately does NOT auto-propagate, since it's the
+scarce, reward-bearing label and requires more trust than a linked-issue mechanic alone provides.
+
+## Codecov — why this matters for what NOT to file
+
+`codecov.yml`: `codecov/patch` target 70%, threshold 5%, **enforcing**; `codecov/project` target
+auto, threshold 1%, enforcing (base-relative per-PR). This is a soft bar compared to loopover's
+99% patch gate — trivially satisfied by adding tests to already-written code, which is the
+mechanical reason contributors have defaulted to `test(...): cover X` PRs (path of least
+resistance to a green, mergeable PR). Gardening does not need to "fix" this gate — just avoid
+generating issues that invite the same low-effort response. See SKILL.md's "the one thing this
+skill exists to prevent" section.
+
+## Milestones
+
+| Milestone | Number | State | Nature |
+|---|---|---|---|
+| `Code Quality — Round 5` | #3 | Closed | Historical sprint (CSP nonces, a11y fixes, perf memoization, timeout hardening — 20 issues, all closed). Reference for "what real value work looks like here," not a target. |
+| `Growth & Maintainability — Round 7` | #4 | Closed | Historical sprint (SEO recency scoring, submission-gate refactor of a 5,137-line file, Lighthouse CI budgets, Core Web Vitals reporting — 26 issues, all closed). Same: reference only. |
+| `Contributor Backlog (Gardening)` | #5 | **Open** | **Created 2026-07-17, the target for every gardening-generated issue.** Both Round milestones were fully closed/historical when this skill was built — nothing existing fit an ongoing, continuously-refreshed backlog, and this skill's own output is exactly the "recurring category that will keep needing a home" case that justifies a new milestone (same reasoning as loopover's `Miner Wave 4.5 — AMS Hardening Round 2`). Deliberately not numbered/dated like the Round milestones — it's evergreen, not a sprint, since gardening runs every 24h indefinitely. |
+
+**Every gardening-generated issue gets milestone #5.** If a future run finds #5 has grown stale or
+unwieldy (e.g. very old issues nobody picked up), that's a Pass 1 hygiene question (close/refresh
+stale ones), not a reason to fragment into a new milestone without the same "recurring category"
+bar the original creation used.
+
+## Labels
+
+- `gittensor:bug` (0.05x), `gittensor:feature` (0.25x), `gittensor:priority` (1.5x, scarce —
+  reserved for real urgency, same convention as loopover; this repo does not have metagraphed's
+  looser "used on a third of open issues" density) — same point-multiplier convention as the
+  sibling repos, since `.gittensory.yml` explicitly says it's "Modeled on the upstream
+  JSONbored/gittensory manifest."
+- `help wanted` — paired with the points label, matching the existing `product-feature.yml`
+  template's own default label.
+- `maintainer-only` — "Owner-only work — yields no Gittensor points" (the label's own repo
+  description). Use for anything requiring a business/design decision, touching generated
+  artifacts, or needing access a contributor can't have.
+- **Never apply**: `size:*` (XS/S/M/L/XL/XXL — this repo's own PR-sizing automation, not an
+  issue-time label), `category:*` (content-taxonomy labels for directory entries, not code
+  issues), `contributor:*`/`pr:*`/`submission-*` (the content-submission-gate's own bot-managed
+  labels), `roadmap`, `slop`, `mod:warning`, `review-evasion`, `banned` (all gate/moderation
+  machinery, not gardening's concern).
+
+## Issue body — use the repo's own `product-feature.yml` template
+
+This repo already has a maintainer-authored issue-form template built for exactly this purpose —
+`.github/ISSUE_TEMPLATE/product-feature.yml`, description: "Propose contributor work for HeyClaude
+product, website, API, MCP, Raycast, discovery, or design improvements." Its own guidance: "Good
+issues are narrow enough for one PR, explicit about what is out of scope, and clear about the
+proof required before merge." Use its exact field structure (either via `gh issue create --repo
+JSONbored/awesome-claude --template product-feature.yml` if the CLI supports it cleanly, or by
+matching the field labels manually in the issue body if scripting the creation):
+
+```md
+## Goal
+<one clear outcome this issue should deliver>
+
+## Why this matters
+<user, contributor, traffic, trust, or product-growth value>
+
+## Current behavior
+<link relevant pages, files, APIs, or docs>
+
+## Desired behavior
+<exactly what should exist after the PR lands>
+
+## Scope
+<list allowed areas to edit — specific file paths, not vague directories>
+
+## Out of scope
+<explicitly forbid unrelated rewrites, generated artifact churn, automation changes not part of the issue>
+
+## Acceptance criteria
+- PR includes `Closes #<issue>`.
+<concrete behavior/quality/accessibility/data/SEO/compatibility requirements>
+
+## Quality evidence required in the PR
+<exactly what screenshots/invariants/review proof the contributor must provide — frontend/UI changes need desktop+mobile screenshots or an explicit "No visual impact" note; API/MCP changes need invariants + backward-compatibility notes>
+
+## Validation
+<exact commands to run from repo root, e.g. `pnpm build`, `pnpm exec vitest run tests/<file>.test.ts`>
+```
+
+No separate "Test Coverage Requirements" section like loopover's template — this repo's Codecov
+gate is soft enough that a dedicated coverage callout isn't needed; "Validation" covers what to
+run, and "Acceptance criteria"/"Quality evidence" cover what must be true.
+
+## Native relationship linking
+
+Same as the sibling repos — GraphQL `addSubIssue`/`addBlockedBy` confirmed working on this repo
+(2026-07-17). Most independent bug/feature issues need no link. Reserve for a genuine prerequisite
+relationship.
+
+```graphql
+mutation { addSubIssue(input: { issueId: "<parent node id>", subIssueId: "<child node id>" }) { issue { number } } }
+mutation { addBlockedBy(input: { issueId: "<blocked node id>", blockingIssueId: "<blocker node id>" }) { issue { number } } }
+```
+
+Get a node ID: `gh api graphql -f query='query { repository(owner:"JSONbored", name:"awesome-claude") { issue(number: N) { id } } }'`.
+
+## gh CLI gotchas (same as sibling repos)
+
+- `gh api graphql -f query=@file.txt` does not read the file — use `-F query=@file.txt`.
+- `gh issue close` has no `--comment-file` flag — write the comment to a file, then
+  `-c "$(cat file.md)"` (double-quoted).
+- Never embed a body/comment string containing backticks inside a `python3 -c "..."`
+  double-quoted bash argument — write to a file first.


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/contributor-pipeline-gardening/{SKILL.md,reference.md}`, mirroring the mature gardening automation already running on JSONbored/loopover and JSONbored/metagraphed, adapted to this repo's own conventions.
- Backlog target is 15-25 (not 50-100) given this repo's much smaller code surface.
- Scope is code-only (`apps/web/src`, `packages/registry/src`, `packages/mcp`, `scripts`) — content submissions stay PR-first per this repo's existing `linkedIssuePolicy: optional` convention and are never gardening-issue targets.
- Uses the repo's own `product-feature.yml` issue template rather than inventing a new body structure.
- Explicitly guards against two anti-patterns found during research: standalone `test(...): cover X` issues (the soft 70% Codecov patch gate makes these the path of least resistance, but they add no real value), and piling onto an already-farmed shallow repeatable pattern (found: issue #550's analytics-wiring child pattern, farmed by dozens of near-identical PRs).
- Creates milestone #5 "Contributor Backlog (Gardening)" as the evergreen home for gardening-filed issues — the two existing milestones (#3, #4) are both fully closed historical sprints.

## Test plan
- [x] Docs-only change, no code/behavior diff — nothing to run.
- [x] Cross-checked repo conventions directly (`.gittensory.yml`, `codecov.yml`, `.github/ISSUE_TEMPLATE/product-feature.yml`, milestone/label state) rather than assuming loopover/metagraphed's conventions apply.