### PR TITLE
test(submissions): cover drafts field-fallback and default-copy chains

### DIFF
--- a/tests/submission-gate-drafts-fallback-defaults.test.ts
+++ b/tests/submission-gate-drafts-fallback-defaults.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { buildContributorMdx } from "../apps/submission-gate/src/drafts";
+
+describe("submission-gate drafts field fallback chains", () => {
+  it("derives slug and title from the title field when slug and name are absent", () => {
+    const mdx = buildContributorMdx({
+      category: "skills",
+      title: "Only A Title Here",
+    });
+
+    expect(mdx).toContain('slug: "only-a-title-here"');
+    expect(mdx).toContain('title: "Only A Title Here"');
+  });
+
+  it("falls back to card_description for the description when description is absent", () => {
+    const mdx = buildContributorMdx({
+      category: "skills",
+      title: "Card Fallback Skill",
+      card_description: "Only the card copy was provided.",
+    });
+
+    expect(mdx).toContain('description: "Only the card copy was provided."');
+  });
+});
+
+describe("submission-gate drafts default safety/privacy body copy", () => {
+  it("omits the frontmatter list fields and defaults the body sections when notes are absent", () => {
+    const mdx = buildContributorMdx({
+      category: "skills",
+      title: "No Notes Skill",
+      description: "A skill with no safety or privacy notes supplied.",
+    });
+
+    expect(mdx).not.toContain("safetyNotes:");
+    expect(mdx).not.toContain("privacyNotes:");
+
+    const safetyHeadingIndex = mdx.indexOf("## Safety");
+    const privacyHeadingIndex = mdx.indexOf("## Privacy");
+    expect(safetyHeadingIndex).toBeGreaterThan(-1);
+    expect(privacyHeadingIndex).toBeGreaterThan(safetyHeadingIndex);
+    expect(mdx.slice(safetyHeadingIndex, privacyHeadingIndex)).toContain(
+      "Maintainer review required.",
+    );
+    expect(mdx.slice(privacyHeadingIndex)).toContain(
+      "Maintainer review required.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
`apps/submission-gate/src/drafts.ts` had a few untested fallback branches in `buildContributorMdx`:

- deriving slug/title from the `title` field when both `slug` and `name` are absent
- falling back to `card_description` when `description` is absent
- (separately from the frontmatter `safetyNotes`/`privacyNotes` list fields, which are omitted entirely when notes are absent) the "Maintainer review required." default body copy for the Safety and Privacy sections

## Test plan
- `pnpm exec vitest run tests/submission-gate-drafts-fallback-defaults.test.ts` -- 3 tests pass
- `pnpm exec prettier --check tests/submission-gate-drafts-fallback-defaults.test.ts` -- clean
- Scoped coverage on `apps/submission-gate/src/drafts.ts` improves branch coverage 92.0% -> 99.1% (the one remaining branch is a category-length guard that's unreachable given the fixed `SUPPORTED_CATEGORIES` set)
