### PR TITLE
feat(web): add jobs, contributors, and freshness headline egress

### DIFF
--- a/apps/web/src/components/browse-freshness-distribution-panel.tsx
+++ b/apps/web/src/components/browse-freshness-distribution-panel.tsx
@@ -2,6 +2,9 @@ import { Link } from "@tanstack/react-router";
 import { toneClass } from "@/lib/browse-rollout-tone-lib";
 import type { BrowseFreshnessDistributionState } from "@/lib/browse-freshness-distribution";
 import {
+  browseFreshnessBucketAnalyticsData,
+  browseFreshnessBucketAnalyticsEvent,
+  browseFreshnessBucketSignal,
   browseFreshnessStaleEntryAnalyticsData,
   browseFreshnessStaleEntryAnalyticsEvent,
   parseBrowseFreshnessEntryRef,
@@ -31,27 +34,47 @@ export function BrowseFreshnessDistributionPanel({
       </div>
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-        {state.buckets.map((bucket) => (
-          <article key={bucket.id} className="rounded-md border border-border bg-background p-2.5">
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <p className="text-xs font-medium text-ink">{bucket.label}</p>
-                <p className="mt-0.5 text-[11px] text-ink-muted">{bucket.rangeLabel}</p>
+        {state.buckets.map((bucket) => {
+          const signal = browseFreshnessBucketSignal(bucket.id);
+          return (
+            <button
+              key={bucket.id}
+              type="button"
+              disabled={!signal}
+              onClick={() => {
+                if (!signal) return;
+                trackEvent(
+                  browseFreshnessBucketAnalyticsEvent(),
+                  browseFreshnessBucketAnalyticsData(
+                    bucket.id,
+                    bucket.count,
+                    bucket.percent,
+                    state.scannedCount,
+                  ),
+                );
+              }}
+              className="rounded-md border border-border bg-background p-2.5 text-left transition-colors duration-200 ease-out hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:cursor-default disabled:opacity-100"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-ink">{bucket.label}</p>
+                  <p className="mt-0.5 text-[11px] text-ink-muted">{bucket.rangeLabel}</p>
+                </div>
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                    toneClass(bucket.tone),
+                  )}
+                >
+                  {bucket.percent}%
+                </span>
               </div>
-              <span
-                className={cn(
-                  "inline-flex rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
-                  toneClass(bucket.tone),
-                )}
-              >
-                {bucket.percent}%
-              </span>
-            </div>
-            <p className="mt-1.5 font-mono text-[11px] text-ink">
-              {bucket.count} {bucket.count === 1 ? "entry" : "entries"}
-            </p>
-          </article>
-        ))}
+              <p className="mt-1.5 font-mono text-[11px] text-ink">
+                {bucket.count} {bucket.count === 1 ? "entry" : "entries"}
+              </p>
+            </button>
+          );
+        })}
       </div>
 
       {state.staleEntries.length > 0 ? (

--- a/apps/web/src/lib/browse-distribution-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-distribution-cta-events-lib.ts
@@ -60,3 +60,38 @@ export function parseBrowseFreshnessEntryRef(
     slug: entryRef.slice(slash + 1),
   };
 }
+
+export function browseFreshnessBucketAnalyticsEvent(): string {
+  return "browse_freshness_bucket_click";
+}
+
+export function browseFreshnessBucketAnalyticsData(
+  bucketId: string,
+  count: number,
+  percent: number,
+  scannedCount: number,
+) {
+  return {
+    surface: BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
+    bucketId,
+    count,
+    percent,
+    scannedCount,
+  };
+}
+
+/** Map a freshness bucket id to a browse signal hint for analytics context. */
+export function browseFreshnessBucketSignal(bucketId: string): string | null {
+  switch (bucketId) {
+    case "fresh":
+      return "fresh";
+    case "recent":
+      return "recent";
+    case "aging":
+      return "aging";
+    case "stale":
+      return "stale";
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/browse-distribution-cta-events.ts
+++ b/apps/web/src/lib/browse-distribution-cta-events.ts
@@ -4,6 +4,9 @@
 export {
   BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
   BROWSE_THEME_DISTRIBUTION_SURFACE,
+  browseFreshnessBucketAnalyticsData,
+  browseFreshnessBucketAnalyticsEvent,
+  browseFreshnessBucketSignal,
   browseFreshnessStaleEntryAnalyticsData,
   browseFreshnessStaleEntryAnalyticsEvent,
   browseThemeDistributionSelectAnalyticsData,

--- a/apps/web/src/lib/contributors-index-cta-events-lib.ts
+++ b/apps/web/src/lib/contributors-index-cta-events-lib.ts
@@ -63,3 +63,60 @@ export function contributorsIndexGithubAnalyticsData(
     contributorCount,
   };
 }
+
+export type ContributorsIndexStatId = "contributors" | "accepted-entries";
+
+export type ContributorsIndexStatDestination = {
+  to: "/contributors" | "/browse";
+  hash?: string;
+};
+
+export function contributorsIndexStatAnalyticsEvent(): string {
+  return "contributors_index_stat_click";
+}
+
+export function contributorsIndexStatAnalyticsData(
+  statId: string,
+  value: number,
+  contributorCount: number,
+  totalAccepted: number,
+) {
+  return {
+    surface: CONTRIBUTORS_INDEX_SURFACE,
+    statId,
+    value,
+    contributorCount,
+    totalAccepted,
+  };
+}
+
+/** Map a contributors index headline stat to an in-app destination. */
+export function contributorsIndexStatDestination(
+  statId: string,
+): ContributorsIndexStatDestination | null {
+  switch (statId) {
+    case "contributors":
+      return { to: "/contributors", hash: "contributor-grid" };
+    case "accepted-entries":
+      return { to: "/browse" };
+    default:
+      return null;
+  }
+}
+
+export function contributorsIndexFeaturedProfileAnalyticsEvent(): string {
+  return "contributors_index_featured_profile_click";
+}
+
+export function contributorsIndexFeaturedProfileAnalyticsData(
+  contributorSlug: string,
+  acceptedCount: number,
+  contributorCount: number,
+) {
+  return {
+    surface: CONTRIBUTORS_INDEX_SURFACE,
+    contributorSlug,
+    acceptedCount,
+    contributorCount,
+  };
+}

--- a/apps/web/src/lib/contributors-index-cta-events.ts
+++ b/apps/web/src/lib/contributors-index-cta-events.ts
@@ -3,11 +3,18 @@
  */
 export {
   CONTRIBUTORS_INDEX_SURFACE,
+  contributorsIndexFeaturedProfileAnalyticsData,
+  contributorsIndexFeaturedProfileAnalyticsEvent,
   contributorsIndexGithubAnalyticsData,
   contributorsIndexGithubAnalyticsEvent,
   contributorsIndexProfileAnalyticsData,
   contributorsIndexProfileAnalyticsEvent,
+  contributorsIndexStatAnalyticsData,
+  contributorsIndexStatAnalyticsEvent,
+  contributorsIndexStatDestination,
   contributorsIndexSubmitAnalyticsData,
   contributorsIndexSubmitAnalyticsEvent,
   type ContributorsIndexGithubVariant,
+  type ContributorsIndexStatDestination,
+  type ContributorsIndexStatId,
 } from "@/lib/contributors-index-cta-events-lib";

--- a/apps/web/src/lib/jobs-hub-cta-events-lib.ts
+++ b/apps/web/src/lib/jobs-hub-cta-events-lib.ts
@@ -180,3 +180,50 @@ export function jobsDetailShareCopyAnalyticsData(jobSlug: string, tier: string) 
     tier,
   };
 }
+
+export type JobsIndexStatId = "total" | "remote" | "fresh" | "featured";
+
+export type JobsIndexStatFilterPatch = {
+  q?: string;
+  tier?: string;
+  remote?: string;
+  type?: string;
+  freshOnly?: boolean;
+  featuredOnly?: boolean;
+};
+
+export function jobsIndexStatAnalyticsEvent(): string {
+  return "jobs_index_stat_click";
+}
+
+export function jobsIndexStatAnalyticsData(statId: string, count: number, jobCount: number) {
+  return {
+    surface: JOBS_INDEX_SURFACE,
+    statId,
+    count,
+    jobCount,
+  };
+}
+
+/** Map a headline jobs stat to a filter patch applied on click. */
+export function jobsIndexStatFilterPatch(statId: string): JobsIndexStatFilterPatch | null {
+  switch (statId) {
+    case "total":
+      return {
+        q: "",
+        tier: "all",
+        remote: "all",
+        type: "all",
+        freshOnly: false,
+        featuredOnly: false,
+      };
+    case "remote":
+      return { remote: "remote" };
+    case "fresh":
+      return { freshOnly: true };
+    case "featured":
+      return { featuredOnly: true };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/jobs-hub-cta-events.ts
+++ b/apps/web/src/lib/jobs-hub-cta-events.ts
@@ -24,6 +24,9 @@ export {
   jobsIndexPostAnalyticsEvent,
   jobsIndexSortSelectAnalyticsData,
   jobsIndexSortSelectAnalyticsEvent,
+  jobsIndexStatAnalyticsData,
+  jobsIndexStatAnalyticsEvent,
+  jobsIndexStatFilterPatch,
   type JobsDetailEgressDestination,
   type JobsDetailIndexSource,
   type JobsErrorSurface,
@@ -31,4 +34,6 @@ export {
   type JobsIndexJobVariant,
   type JobsIndexPostSource,
   type JobsIndexSortMode,
+  type JobsIndexStatFilterPatch,
+  type JobsIndexStatId,
 } from "@/lib/jobs-hub-cta-events-lib";

--- a/apps/web/src/routes/contributors.index.tsx
+++ b/apps/web/src/routes/contributors.index.tsx
@@ -3,12 +3,18 @@ import { Github } from "lucide-react";
 import { CONTRIBUTORS } from "@/data/contributors";
 import { trackEvent } from "@/lib/analytics";
 import {
+  contributorsIndexFeaturedProfileAnalyticsData,
+  contributorsIndexFeaturedProfileAnalyticsEvent,
   contributorsIndexGithubAnalyticsData,
   contributorsIndexGithubAnalyticsEvent,
   contributorsIndexProfileAnalyticsData,
   contributorsIndexProfileAnalyticsEvent,
+  contributorsIndexStatAnalyticsData,
+  contributorsIndexStatAnalyticsEvent,
+  contributorsIndexStatDestination,
   contributorsIndexSubmitAnalyticsData,
   contributorsIndexSubmitAnalyticsEvent,
+  type ContributorsIndexStatId,
 } from "@/lib/contributors-index-cta-events";
 import { contributorCardSummary } from "@/lib/contributor-profile-summary";
 import { PageContainer } from "@/components/page-container";
@@ -65,33 +71,73 @@ function ContributorsPage() {
   const rest = sorted.slice(1);
   const total = sorted.reduce((s, c) => s + c.acceptedCount, 0);
 
+  const headlineStats: Array<{ id: ContributorsIndexStatId; label: string; value: number }> = [
+    { id: "contributors", label: "Contributors", value: sorted.length },
+    { id: "accepted-entries", label: "Accepted entries", value: total },
+  ];
+
   return (
     <PageContainer>
       <PageHeader
         eyebrow="People"
         title="Contributors"
-        description={
-          <>
-            Derived from accepted submissions. Provenance is preserved on every entry.{" "}
-            <span className="text-ink-subtle">
-              {sorted.length} contributors · {total} accepted entries.
-            </span>
-          </>
-        }
+        description="Derived from accepted submissions. Provenance is preserved on every entry."
       />
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+        {headlineStats.map((stat) => {
+          const destination = contributorsIndexStatDestination(stat.id);
+          if (!destination) return null;
+          return (
+            <Link
+              key={stat.id}
+              to={destination.to}
+              hash={destination.hash}
+              onClick={() =>
+                trackEvent(
+                  contributorsIndexStatAnalyticsEvent(),
+                  contributorsIndexStatAnalyticsData(stat.id, stat.value, sorted.length, total),
+                )
+              }
+              className="rounded-xl border border-border bg-surface p-4 transition-colors duration-200 ease-out hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+            >
+              <div className="text-xs uppercase tracking-wider text-ink-subtle">{stat.label}</div>
+              <div className="mt-2 font-display text-2xl font-semibold tabular-nums text-ink">
+                {stat.value}
+              </div>
+            </Link>
+          );
+        })}
+      </div>
 
       {top && (
         <div className="mt-8 surface-raised rounded-xl border border-accent/30 bg-gradient-to-br from-surface to-accent/[0.06] p-6">
           <div className="eyebrow text-accent-ink dark:text-accent">Top contributor</div>
           <div className="mt-3 flex items-center gap-4">
-            <Monogram name={top.name || top.handle} size={56} className="rounded-full" />
-            <div className="min-w-0 flex-1">
-              <div className="font-display text-xl font-semibold text-ink">{top.name}</div>
-              <div className="text-sm text-ink-muted">
-                @{top.handle} · {contributorCardSummary(top)}
+            <Link
+              to="/contributors/$slug"
+              params={{ slug: top.slug }}
+              onClick={() =>
+                trackEvent(
+                  contributorsIndexFeaturedProfileAnalyticsEvent(),
+                  contributorsIndexFeaturedProfileAnalyticsData(
+                    top.slug,
+                    top.acceptedCount,
+                    sorted.length,
+                  ),
+                )
+              }
+              className="flex min-w-0 flex-1 items-center gap-4 rounded-lg outline-none transition-colors focus-visible:ring-2 focus-visible:ring-accent/60"
+            >
+              <Monogram name={top.name || top.handle} size={56} className="rounded-full" />
+              <div className="min-w-0 flex-1">
+                <div className="font-display text-xl font-semibold text-ink">{top.name}</div>
+                <div className="text-sm text-ink-muted">
+                  @{top.handle} · {contributorCardSummary(top)}
+                </div>
+                {top.bio && <p className="mt-1 text-sm text-ink-muted">{top.bio}</p>}
               </div>
-              {top.bio && <p className="mt-1 text-sm text-ink-muted">{top.bio}</p>}
-            </div>
+            </Link>
             {top.github && (
               <a
                 href={top.github}
@@ -109,7 +155,7 @@ function ContributorsPage() {
                     ),
                   )
                 }
-                className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-background px-3 text-sm text-ink hover:bg-surface-2"
+                className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-3 text-sm text-ink hover:bg-surface-2"
               >
                 <Github className="h-3.5 w-3.5" /> GitHub
               </a>
@@ -118,7 +164,10 @@ function ContributorsPage() {
         </div>
       )}
 
-      <div className="mt-8 grid gap-3 stagger-children sm:grid-cols-2 lg:grid-cols-3">
+      <div
+        id="contributor-grid"
+        className="mt-8 grid scroll-mt-24 gap-3 stagger-children sm:grid-cols-2 lg:grid-cols-3"
+      >
         {rest.map((c, rowIndex) => (
           <Link
             key={c.slug}

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -23,7 +23,11 @@ import {
   jobsIndexPostAnalyticsEvent,
   jobsIndexSortSelectAnalyticsData,
   jobsIndexSortSelectAnalyticsEvent,
+  jobsIndexStatAnalyticsData,
+  jobsIndexStatAnalyticsEvent,
+  jobsIndexStatFilterPatch,
   type JobsIndexFilterAxis,
+  type JobsIndexStatId,
 } from "@/lib/jobs-hub-cta-events";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import type { ErrorComponentProps } from "@tanstack/react-router";
@@ -311,6 +315,31 @@ function JobsPage() {
     setFeaturedOnly(false);
   }, [filterState, jobs.length]);
 
+  const onStatClick = useCallback(
+    (statId: JobsIndexStatId, count: number) => {
+      const patch = jobsIndexStatFilterPatch(statId);
+      if (!patch) return;
+      trackEvent(
+        jobsIndexStatAnalyticsEvent(),
+        jobsIndexStatAnalyticsData(statId, count, jobs.length),
+      );
+      if (patch.q !== undefined) setQ(patch.q);
+      if (patch.tier !== undefined) setTier(patch.tier as JobTier | "all");
+      if (patch.remote !== undefined) setRemote(patch.remote as RemoteFilter);
+      if (patch.type !== undefined) setType(patch.type);
+      if (patch.freshOnly !== undefined) setFreshOnly(patch.freshOnly);
+      if (patch.featuredOnly !== undefined) setFeaturedOnly(patch.featuredOnly);
+    },
+    [jobs.length],
+  );
+
+  const headlineStats: Array<{ id: JobsIndexStatId; label: string; count: number }> = [
+    { id: "total", label: "Open roles", count: counts.total },
+    { id: "remote", label: "Remote", count: counts.remote },
+    { id: "fresh", label: "This week", count: counts.fresh },
+    { id: "featured", label: "Featured", count: counts.featured },
+  ];
+
   return (
     <PageContainer>
       <div className="flex flex-wrap items-end justify-between gap-4">
@@ -319,10 +348,7 @@ function JobsPage() {
           <h1 className="mt-2 h-display-1 text-ink text-balance">Roles building with Claude.</h1>
           <p className="mt-2 max-w-2xl text-ink-muted">
             Source-verified jobs from teams shipping agent workflows, MCP servers, and Claude Code
-            platforms.
-            <span className="ml-1 text-ink-subtle">
-              {counts.total} open · {counts.remote} remote · {counts.fresh} this week.
-            </span>
+            platforms. Click a headline stat to focus the board.
           </p>
         </div>
         <Link
@@ -337,6 +363,22 @@ function JobsPage() {
         >
           Post a role <ArrowUpRight className="h-4 w-4" />
         </Link>
+      </div>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {headlineStats.map((stat) => (
+          <button
+            key={stat.id}
+            type="button"
+            onClick={() => onStatClick(stat.id, stat.count)}
+            className="rounded-xl border border-border bg-surface p-4 text-left transition-colors duration-200 ease-out hover:border-border-strong hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+          >
+            <div className="text-xs uppercase tracking-wider text-ink-subtle">{stat.label}</div>
+            <div className="mt-2 font-display text-2xl font-semibold tabular-nums text-ink">
+              {stat.count}
+            </div>
+          </button>
+        ))}
       </div>
 
       {/* Sticky filter bar */}

--- a/tests/browse-distribution-cta-events-lib.test.ts
+++ b/tests/browse-distribution-cta-events-lib.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
   BROWSE_THEME_DISTRIBUTION_SURFACE,
+  browseFreshnessBucketAnalyticsData,
+  browseFreshnessBucketAnalyticsEvent,
+  browseFreshnessBucketSignal,
   browseFreshnessStaleEntryAnalyticsData,
   browseFreshnessStaleEntryAnalyticsEvent,
   browseThemeDistributionSelectAnalyticsData,
@@ -46,5 +49,23 @@ describe("browse distribution cta events lib", () => {
       slug: "browser",
     });
     expect(parseBrowseFreshnessEntryRef("invalid")).toBeNull();
+  });
+
+  it("maps browse freshness bucket clicks to analytics signals", () => {
+    expect(browseFreshnessBucketAnalyticsEvent()).toBe(
+      "browse_freshness_bucket_click",
+    );
+    expect(browseFreshnessBucketAnalyticsData("fresh", 12, 40, 30)).toEqual({
+      surface: BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
+      bucketId: "fresh",
+      count: 12,
+      percent: 40,
+      scannedCount: 30,
+    });
+    expect(browseFreshnessBucketSignal("fresh")).toBe("fresh");
+    expect(browseFreshnessBucketSignal("recent")).toBe("recent");
+    expect(browseFreshnessBucketSignal("aging")).toBe("aging");
+    expect(browseFreshnessBucketSignal("stale")).toBe("stale");
+    expect(browseFreshnessBucketSignal("unknown")).toBeNull();
   });
 });

--- a/tests/contributors-index-cta-events-lib.test.ts
+++ b/tests/contributors-index-cta-events-lib.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   CONTRIBUTORS_INDEX_SURFACE,
+  contributorsIndexFeaturedProfileAnalyticsData,
+  contributorsIndexFeaturedProfileAnalyticsEvent,
   contributorsIndexGithubAnalyticsData,
   contributorsIndexGithubAnalyticsEvent,
   contributorsIndexProfileAnalyticsData,
   contributorsIndexProfileAnalyticsEvent,
+  contributorsIndexStatAnalyticsData,
+  contributorsIndexStatAnalyticsEvent,
+  contributorsIndexStatDestination,
   contributorsIndexSubmitAnalyticsData,
   contributorsIndexSubmitAnalyticsEvent,
 } from "@/lib/contributors-index-cta-events-lib";
@@ -56,6 +61,40 @@ describe("contributors index cta events lib", () => {
       acceptedCount: 4,
       variant: "card",
       rowIndex: 2,
+      contributorCount: 24,
+    });
+  });
+
+  it("maps contributors index headline stats and featured profile egress", () => {
+    expect(contributorsIndexStatAnalyticsEvent()).toBe(
+      "contributors_index_stat_click",
+    );
+    expect(
+      contributorsIndexStatAnalyticsData("contributors", 24, 24, 310),
+    ).toEqual({
+      surface: CONTRIBUTORS_INDEX_SURFACE,
+      statId: "contributors",
+      value: 24,
+      contributorCount: 24,
+      totalAccepted: 310,
+    });
+    expect(contributorsIndexStatDestination("contributors")).toEqual({
+      to: "/contributors",
+      hash: "contributor-grid",
+    });
+    expect(contributorsIndexStatDestination("accepted-entries")).toEqual({
+      to: "/browse",
+    });
+    expect(contributorsIndexStatDestination("unknown")).toBeNull();
+    expect(contributorsIndexFeaturedProfileAnalyticsEvent()).toBe(
+      "contributors_index_featured_profile_click",
+    );
+    expect(
+      contributorsIndexFeaturedProfileAnalyticsData("alice", 12, 24),
+    ).toEqual({
+      surface: CONTRIBUTORS_INDEX_SURFACE,
+      contributorSlug: "alice",
+      acceptedCount: 12,
       contributorCount: 24,
     });
   });

--- a/tests/jobs-hub-cta-events-lib.test.ts
+++ b/tests/jobs-hub-cta-events-lib.test.ts
@@ -22,6 +22,9 @@ import {
   jobsIndexPostAnalyticsEvent,
   jobsIndexSortSelectAnalyticsData,
   jobsIndexSortSelectAnalyticsEvent,
+  jobsIndexStatAnalyticsData,
+  jobsIndexStatAnalyticsEvent,
+  jobsIndexStatFilterPatch,
 } from "@/lib/jobs-hub-cta-events-lib";
 
 describe("jobs hub cta events lib", () => {
@@ -143,5 +146,29 @@ describe("jobs hub cta events lib", () => {
       jobSlug: "senior-mcp",
       tier: "featured",
     });
+  });
+
+  it("maps jobs index headline stats to filter patches", () => {
+    expect(jobsIndexStatAnalyticsEvent()).toBe("jobs_index_stat_click");
+    expect(jobsIndexStatAnalyticsData("remote", 8, 24)).toEqual({
+      surface: JOBS_INDEX_SURFACE,
+      statId: "remote",
+      count: 8,
+      jobCount: 24,
+    });
+    expect(jobsIndexStatFilterPatch("total")).toEqual({
+      q: "",
+      tier: "all",
+      remote: "all",
+      type: "all",
+      freshOnly: false,
+      featuredOnly: false,
+    });
+    expect(jobsIndexStatFilterPatch("remote")).toEqual({ remote: "remote" });
+    expect(jobsIndexStatFilterPatch("fresh")).toEqual({ freshOnly: true });
+    expect(jobsIndexStatFilterPatch("featured")).toEqual({
+      featuredOnly: true,
+    });
+    expect(jobsIndexStatFilterPatch("unknown")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add clickable jobs index headline stats that apply filter patches (`total` / `remote` / `fresh` / `featured`) with surface-tagged analytics
- Add contributors index headline stats + featured profile egress (grid hash target) with destination mapping
- Make browse freshness distribution buckets interactive with bucket signal analytics

## Test plan
- [x] Vitest covers all new switch arms including defaults
- [ ] Codecov patch/project green
- [ ] validate-ci / required-pr-gate / LoopOver pass
- [ ] No path overlap with currently open PRs (submission-gate tests, content MDX)

Refs #550

Made with [Cursor](https://cursor.com)