### PR TITLE
fix(registry): classify a single high-severity risk flag as risk tier "high"

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -19,7 +19,11 @@ const SEVERITY_WEIGHT = {
   info: 0,
   low: 1,
   medium: 3,
-  high: 6,
+  // `high` is weighted at the "high" tier threshold (7) so a single high-severity
+  // flag on its own reaches riskTier "high" and routes to maintainer review,
+  // instead of falling one point short into "medium" (auto-eligible). Kept at 7
+  // (not lowering the tier threshold to 6) so two `medium` flags stay "medium".
+  high: 7,
   critical: 100,
 };
 
@@ -1167,7 +1171,12 @@ function addDisclosureNoteSignals(report, fields) {
   }
 }
 
-function tierFromFlags(flags) {
+// Classify a set of review flags into a risk tier from their summed severity
+// weights (any `critical` flag short-circuits to "critical"). Exported for
+// focused boundary tests. Threshold 7 with SEVERITY_WEIGHT.high === 7 means a
+// single high-severity flag reaches "high"; two `medium` flags (3 + 3 = 6) stay
+// "medium".
+export function tierFromFlags(flags) {
   if (flags.some((flag) => flag.severity === "critical")) return "critical";
   const score = flags.reduce(
     (total, flag) => total + (SEVERITY_WEIGHT[flag.severity] ?? 0),

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -9,6 +9,7 @@ import {
   analyzeSubmissionDraftRisk,
   directContentRequestChangesReasons,
   formatSubmissionRiskMarkdown,
+  tierFromFlags,
 } from "@heyclaude/registry/submission-risk";
 
 const dayMs = 86_400_000;
@@ -436,5 +437,44 @@ describe("submission risk invariants", () => {
     expect(markdown).toContain("### Blocking findings");
     expect(markdown).toContain("Capability buckets");
     expect(markdown).not.toMatch(/private reviewer|prompt|scoring threshold/i);
+  });
+});
+
+describe("tierFromFlags risk-tier boundaries", () => {
+  const flag = (severity: string) => ({ severity });
+
+  it("returns low when there are no flags", () => {
+    expect(tierFromFlags([])).toBe("low");
+  });
+
+  it("returns low for a single low-severity flag", () => {
+    expect(tierFromFlags([flag("low")])).toBe("low");
+  });
+
+  it("returns medium for a single medium-severity flag", () => {
+    expect(tierFromFlags([flag("medium")])).toBe("medium");
+  });
+
+  it("keeps two medium-severity flags at medium (3 + 3 = 6, below the high threshold)", () => {
+    expect(tierFromFlags([flag("medium"), flag("medium")])).toBe("medium");
+  });
+
+  it("classifies a single high-severity flag as high (regression: previously fell to medium)", () => {
+    expect(tierFromFlags([flag("high")])).toBe("high");
+  });
+
+  it("classifies a high plus a medium flag as high", () => {
+    expect(tierFromFlags([flag("high"), flag("medium")])).toBe("high");
+  });
+
+  it("classifies any critical flag as critical regardless of the rest", () => {
+    expect(tierFromFlags([flag("critical")])).toBe("critical");
+    expect(tierFromFlags([flag("low"), flag("critical")])).toBe("critical");
+  });
+
+  it("ignores info-severity flags in the score", () => {
+    expect(tierFromFlags([flag("info"), flag("info"), flag("info")])).toBe(
+      "low",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Closes #5219.

Fixes the risk-tier threshold so a submission whose only risk signal is a **single `high`-severity flag** is classified as risk tier `"high"` (routing to maintainer review) instead of `"medium"` (auto `submit_pr_eligible`).

**Root cause:** `SEVERITY_WEIGHT.high` was `6`, but `tierFromFlags()` requires `score >= 7` for `"high"`, so a lone high flag scored one point short and fell through to `"medium"`.

**Fix (chosen to keep multi-flag boundaries unchanged):** raise `SEVERITY_WEIGHT.high` from `6` to `7` (the `"high"` tier threshold), rather than lowering the tier threshold to `>= 6`. Lowering the threshold would have pushed **two `medium` flags** (`3 + 3 = 6`) up to `"high"`; raising the `high` weight fixes only the lone-high case and leaves every other boundary intact. `high` is not in the issue's out-of-scope weight list. Added a code comment documenting the reasoning, and exported `tierFromFlags` for focused boundary tests.

## Files

- `packages/registry/src/submission-risk.js` — `SEVERITY_WEIGHT.high` 6→7 with comment; `tierFromFlags` exported + documented.
- `tests/submission-risk-invariants.test.ts` — boundary + regression tests for `tierFromFlags`.

## Quality evidence (no visual impact)

Every tier boundary case covered by the new tests — a reviewer can confirm none shifted except the fixed single-high case:

| flags | riskTier | changed? |
|---|---|---|
| `[]` | `low` | no |
| `[low]` | `low` | no |
| `[medium]` | `medium` | no |
| `[medium, medium]` (3+3=6) | `medium` | **no** (would have regressed under a `>=6` threshold) |
| `[high]` (7) | `high` | **YES — the fix / regression lock** |
| `[high, medium]` | `high` | no |
| `[critical]`, `[low, critical]` | `critical` | no |
| `[info, info, info]` | `low` | no |

`SEVERITY_WEIGHT` is used only inside `tierFromFlags`, so the weight change has no other effect.

## Validation

```
pnpm exec vitest run tests/submission-risk-invariants.test.ts          # 16 passed (8 new)
pnpm exec vitest run tests/submission-preflight-lib.test.ts \
  tests/submission-pr-first.test.ts                                    # 48 passed (no regression)
pnpm --filter web type-check                                          # clean
pnpm exec prettier --check <changed files>                            # clean
```
