### PR TITLE
feat(web): wire data-report headline stats to browse egress

### DIFF
--- a/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
@@ -78,3 +78,49 @@ export function mcpSecurityReportStatAnalyticsData(
     destination,
   };
 }
+
+/** Browse search used by MCP security headline stats. */
+export type McpSecurityReportStatBrowseSearch = {
+  category?: string;
+  signal?: string;
+};
+
+export type McpSecurityReportStatBrowseEgress = {
+  to: "/browse";
+  search: McpSecurityReportStatBrowseSearch;
+  destination: "browse";
+};
+
+/** Map an MCP security headline stat to a scoped browse destination. */
+export function mcpSecurityReportStatBrowseEgress(
+  statKey: string,
+): McpSecurityReportStatBrowseEgress | null {
+  switch (statKey) {
+    case "total":
+      return {
+        to: "/browse",
+        search: { category: "mcp" },
+        destination: "browse",
+      };
+    case "safety-notes":
+      return {
+        to: "/browse",
+        search: { category: "mcp", signal: "safety-notes" },
+        destination: "browse",
+      };
+    case "privacy-notes":
+      return {
+        to: "/browse",
+        search: { category: "mcp", signal: "privacy-notes" },
+        destination: "browse",
+      };
+    case "verified-package":
+      return {
+        to: "/browse",
+        search: { category: "mcp", signal: "trusted-package" },
+        destination: "browse",
+      };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/mcp-security-report-page-cta-events.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events.ts
@@ -13,5 +13,8 @@ export {
   mcpSecurityReportEgressAnalyticsEvent,
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
+  mcpSecurityReportStatBrowseEgress,
   type McpSecurityReportEgressDestination,
+  type McpSecurityReportStatBrowseEgress,
+  type McpSecurityReportStatBrowseSearch,
 } from "@/lib/mcp-security-report-page-cta-events-lib";

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -102,3 +102,78 @@ export function stateReportStatAnalyticsData(
     destination,
   };
 }
+
+/** Browse/quality search used by headline report stats. */
+export type StateReportStatBrowseSearch = {
+  category?: string;
+  source?: string;
+  signal?: string;
+};
+
+export type StateReportStatBrowseEgress = {
+  to: "/browse" | "/quality";
+  search?: StateReportStatBrowseSearch;
+  destination: "browse" | "quality";
+};
+
+/** Map a state-report headline stat to an in-app browse/quality destination. */
+export function stateReportStatBrowseEgress(
+  statKey: string,
+  reportCategory?: string,
+): StateReportStatBrowseEgress | null {
+  switch (statKey) {
+    case "categories":
+      return { to: "/browse", destination: "browse" };
+    case "reviewed":
+      return { to: "/quality", destination: "quality" };
+    case "source-backed":
+      return {
+        to: "/browse",
+        search: {
+          ...(reportCategory ? { category: reportCategory } : {}),
+          source: "source-backed",
+        },
+        destination: "browse",
+      };
+    case "validated":
+      return {
+        to: "/browse",
+        search: {
+          ...(reportCategory ? { category: reportCategory } : {}),
+          signal: "reviewed",
+        },
+        destination: "browse",
+      };
+    case "safety-privacy":
+      return {
+        to: "/browse",
+        search: {
+          ...(reportCategory ? { category: reportCategory } : {}),
+          signal: "safety-notes",
+        },
+        destination: "browse",
+      };
+    case "total":
+    case "remote":
+    case "local":
+    case "events":
+    case "simple":
+    case "packs":
+    case "packaged":
+    case "ready":
+    case "documented":
+      return {
+        to: "/browse",
+        search: reportCategory ? { category: reportCategory } : undefined,
+        destination: "browse",
+      };
+    default:
+      return reportCategory
+        ? {
+            to: "/browse",
+            search: { category: reportCategory },
+            destination: "browse",
+          }
+        : null;
+  }
+}

--- a/apps/web/src/lib/state-report-page-cta-events.ts
+++ b/apps/web/src/lib/state-report-page-cta-events.ts
@@ -12,6 +12,9 @@ export {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatBrowseEgress,
   type StateReportEgressDestination,
   type StateReportId,
+  type StateReportStatBrowseEgress,
+  type StateReportStatBrowseSearch,
 } from "@/lib/state-report-page-cta-events-lib";

--- a/apps/web/src/routes/mcp-security-report.tsx
+++ b/apps/web/src/routes/mcp-security-report.tsx
@@ -30,6 +30,7 @@ import {
   mcpSecurityReportEgressAnalyticsEvent,
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
+  mcpSecurityReportStatBrowseEgress,
   type McpSecurityReportEgressDestination,
 } from "@/lib/mcp-security-report-page-cta-events";
 
@@ -48,10 +49,12 @@ function trackDistRow(dimension: string, row: DistRow, rowIndex: number, rowCoun
   );
 }
 
-function trackStat(statKey: string, destination: "browse" | "quality" = "browse") {
+function trackStat(statKey: string) {
+  const egress = mcpSecurityReportStatBrowseEgress(statKey);
+  if (!egress) return;
   trackEvent(
     mcpSecurityReportStatAnalyticsEvent(),
-    mcpSecurityReportStatAnalyticsData(statKey, destination),
+    mcpSecurityReportStatAnalyticsData(statKey, egress.destination),
   );
 }
 
@@ -242,42 +245,52 @@ function McpSecurityReportPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        <DataStat
-          icon={Boxes}
-          label="MCP servers"
-          value={TOTAL}
-          hint="analyzed"
-          to="/browse"
-          search={{ category: "mcp" }}
-          onNavigate={() => trackStat("total")}
-        />
-        <DataStat
-          icon={ShieldCheck}
-          label="Safety notes"
-          value={NOTES.safety}
-          hint={`${pctOf(NOTES.safety, TOTAL)}% of total`}
-          to="/browse"
-          search={{ category: "mcp" }}
-          onNavigate={() => trackStat("safety-notes")}
-        />
-        <DataStat
-          icon={Eye}
-          label="Privacy notes"
-          value={NOTES.privacy}
-          hint={`${pctOf(NOTES.privacy, TOTAL)}% of total`}
-          to="/browse"
-          search={{ category: "mcp" }}
-          onNavigate={() => trackStat("privacy-notes")}
-        />
-        <DataStat
-          icon={PackageCheck}
-          label="Verified package"
-          value={SUPPLY.packageVerified}
-          hint={`${pctOf(SUPPLY.packageVerified, TOTAL)}% of total`}
-          to="/browse"
-          search={{ category: "mcp" }}
-          onNavigate={() => trackStat("verified-package")}
-        />
+        {(
+          [
+            {
+              key: "total",
+              icon: Boxes,
+              label: "MCP servers",
+              value: TOTAL,
+              hint: "analyzed",
+            },
+            {
+              key: "safety-notes",
+              icon: ShieldCheck,
+              label: "Safety notes",
+              value: NOTES.safety,
+              hint: `${pctOf(NOTES.safety, TOTAL)}% of total`,
+            },
+            {
+              key: "privacy-notes",
+              icon: Eye,
+              label: "Privacy notes",
+              value: NOTES.privacy,
+              hint: `${pctOf(NOTES.privacy, TOTAL)}% of total`,
+            },
+            {
+              key: "verified-package",
+              icon: PackageCheck,
+              label: "Verified package",
+              value: SUPPLY.packageVerified,
+              hint: `${pctOf(SUPPLY.packageVerified, TOTAL)}% of total`,
+            },
+          ] as const
+        ).map((stat) => {
+          const egress = mcpSecurityReportStatBrowseEgress(stat.key);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={stat.icon}
+              label={stat.label}
+              value={stat.value}
+              hint={stat.hint}
+              to={egress?.to}
+              search={egress?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       <DataSection

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -27,6 +27,7 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatBrowseEgress,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
@@ -45,9 +46,11 @@ function trackStateReportCite() {
 }
 
 function trackStat(statKey: string) {
+  const egress = stateReportStatBrowseEgress(statKey, REPORT_CATEGORY);
+  if (!egress) return;
   trackEvent(
     stateReportStatAnalyticsEvent(),
-    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, egress.destination),
   );
 }
 
@@ -126,18 +129,21 @@ function StateOfAgentSkillsPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        {MODEL.stats.map((stat) => (
-          <DataStat
-            key={stat.key}
-            icon={STAT_ICON[stat.key] ?? Sparkles}
-            label={stat.label}
-            value={stat.value}
-            hint={statHint(stat)}
-            to="/browse"
-            search={{ category: REPORT_CATEGORY }}
-            onNavigate={() => trackStat(stat.key)}
-          />
-        ))}
+        {MODEL.stats.map((stat) => {
+          const egress = stateReportStatBrowseEgress(stat.key, REPORT_CATEGORY);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={STAT_ICON[stat.key] ?? Sparkles}
+              label={stat.label}
+              value={stat.value}
+              hint={statHint(stat)}
+              to={egress?.to}
+              search={egress?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       {MODEL.dimensions.map((dimension) => {

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -27,6 +27,7 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatBrowseEgress,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
@@ -45,9 +46,11 @@ function trackStateReportCite() {
 }
 
 function trackStat(statKey: string) {
+  const egress = stateReportStatBrowseEgress(statKey, REPORT_CATEGORY);
+  if (!egress) return;
   trackEvent(
     stateReportStatAnalyticsEvent(),
-    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, egress.destination),
   );
 }
 
@@ -126,22 +129,21 @@ function StateOfAiAgentsPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        {MODEL.stats.map((stat) => (
-          <DataStat
-            key={stat.key}
-            icon={STAT_ICON[stat.key] ?? Bot}
-            label={stat.label}
-            value={stat.value}
-            hint={statHint(stat)}
-            to="/browse"
-            search={
-              stat.key === "source-backed"
-                ? { category: REPORT_CATEGORY, source: "source-backed" }
-                : { category: REPORT_CATEGORY }
-            }
-            onNavigate={() => trackStat(stat.key)}
-          />
-        ))}
+        {MODEL.stats.map((stat) => {
+          const egress = stateReportStatBrowseEgress(stat.key, REPORT_CATEGORY);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={STAT_ICON[stat.key] ?? Bot}
+              label={stat.label}
+              value={stat.value}
+              hint={statHint(stat)}
+              to={egress?.to}
+              search={egress?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       {MODEL.dimensions.map((dimension) => {

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -27,6 +27,7 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatBrowseEgress,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
@@ -45,9 +46,11 @@ function trackStateReportCite() {
 }
 
 function trackStat(statKey: string) {
+  const egress = stateReportStatBrowseEgress(statKey, REPORT_CATEGORY);
+  if (!egress) return;
   trackEvent(
     stateReportStatAnalyticsEvent(),
-    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, egress.destination),
   );
 }
 
@@ -126,18 +129,21 @@ function StateOfClaudeCodeHooksPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        {MODEL.stats.map((stat) => (
-          <DataStat
-            key={stat.key}
-            icon={STAT_ICON[stat.key] ?? Webhook}
-            label={stat.label}
-            value={stat.value}
-            hint={statHint(stat)}
-            to="/browse"
-            search={{ category: REPORT_CATEGORY }}
-            onNavigate={() => trackStat(stat.key)}
-          />
-        ))}
+        {MODEL.stats.map((stat) => {
+          const egress = stateReportStatBrowseEgress(stat.key, REPORT_CATEGORY);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={STAT_ICON[stat.key] ?? Webhook}
+              label={stat.label}
+              value={stat.value}
+              hint={statHint(stat)}
+              to={egress?.to}
+              search={egress?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       {MODEL.dimensions.map((dimension) => {

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -37,6 +37,7 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatBrowseEgress,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 import {
@@ -70,10 +71,12 @@ function trackDistRow(dimension: string, row: DistRow, rowIndex: number, rowCoun
   );
 }
 
-function trackStat(statKey: string, destination: "browse" | "quality" = "browse") {
+function trackStat(statKey: string) {
+  const egress = stateReportStatBrowseEgress(statKey);
+  if (!egress) return;
   trackEvent(
     stateReportStatAnalyticsEvent(),
-    stateReportStatAnalyticsData(REPORT_ID, statKey, destination),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, egress.destination),
   );
 }
 
@@ -237,39 +240,52 @@ function StateOfClaudeToolingPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        <DataStat
-          icon={Boxes}
-          label="Total resources"
-          value={TOTAL}
-          hint="across the registry"
-          to="/browse"
-          onNavigate={() => trackStat("total")}
-        />
-        <DataStat
-          icon={Layers}
-          label="Categories tracked"
-          value={CATEGORIES.length}
-          hint="agents to statuslines"
-          to="/browse"
-          onNavigate={() => trackStat("categories")}
-        />
-        <DataStat
-          icon={GitBranch}
-          label="Source-backed"
-          value={QUALITY_STATS.sourceBacked}
-          hint={`${pctOf(QUALITY_STATS.sourceBacked, TOTAL)}% of total`}
-          to="/browse"
-          search={{ source: "source-backed" }}
-          onNavigate={() => trackStat("source-backed")}
-        />
-        <DataStat
-          icon={ShieldCheck}
-          label="Maintainer-reviewed"
-          value={QUALITY_STATS.reviewed}
-          hint={`${pctOf(QUALITY_STATS.reviewed, TOTAL)}% of total`}
-          to="/quality"
-          onNavigate={() => trackStat("reviewed", "quality")}
-        />
+        {(
+          [
+            {
+              key: "total",
+              icon: Boxes,
+              label: "Total resources",
+              value: TOTAL,
+              hint: "across the registry",
+            },
+            {
+              key: "categories",
+              icon: Layers,
+              label: "Categories tracked",
+              value: CATEGORIES.length,
+              hint: "agents to statuslines",
+            },
+            {
+              key: "source-backed",
+              icon: GitBranch,
+              label: "Source-backed",
+              value: QUALITY_STATS.sourceBacked,
+              hint: `${pctOf(QUALITY_STATS.sourceBacked, TOTAL)}% of total`,
+            },
+            {
+              key: "reviewed",
+              icon: ShieldCheck,
+              label: "Maintainer-reviewed",
+              value: QUALITY_STATS.reviewed,
+              hint: `${pctOf(QUALITY_STATS.reviewed, TOTAL)}% of total`,
+            },
+          ] as const
+        ).map((stat) => {
+          const egress = stateReportStatBrowseEgress(stat.key);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={stat.icon}
+              label={stat.label}
+              value={stat.value}
+              hint={stat.hint}
+              to={egress?.to}
+              search={egress?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       <DataSection

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -42,10 +42,12 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatBrowseEgress,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
 const REPORT_ID = "mcp-servers" as const;
+const REPORT_CATEGORY = "mcp";
 
 function trackStateReportEgress(destination: StateReportEgressDestination) {
   trackEvent(
@@ -66,10 +68,12 @@ function trackDistRow(dimension: string, row: DistRow, rowIndex: number, rowCoun
   );
 }
 
-function trackStat(statKey: string, destination: "browse" | "quality" = "browse") {
+function trackStat(statKey: string) {
+  const egress = stateReportStatBrowseEgress(statKey, REPORT_CATEGORY);
+  if (!egress) return;
   trackEvent(
     stateReportStatAnalyticsEvent(),
-    stateReportStatAnalyticsData(REPORT_ID, statKey, destination),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, egress.destination),
   );
 }
 
@@ -249,42 +253,52 @@ function StateOfMcpServersPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        <DataStat
-          icon={Boxes}
-          label="MCP servers"
-          value={TOTAL}
-          hint="in the registry"
-          to="/browse"
-          search={{ category: "mcp" }}
-          onNavigate={() => trackStat("total")}
-        />
-        <DataStat
-          icon={Cloud}
-          label="Hosted (remote)"
-          value={REMOTE}
-          hint={`${pctOf(REMOTE, TOTAL)}% of total`}
-          to="/browse"
-          search={{ category: "mcp" }}
-          onNavigate={() => trackStat("remote")}
-        />
-        <DataStat
-          icon={HardDrive}
-          label="Local (stdio)"
-          value={LOCAL}
-          hint={`${pctOf(LOCAL, TOTAL)}% of total`}
-          to="/browse"
-          search={{ category: "mcp" }}
-          onNavigate={() => trackStat("local")}
-        />
-        <DataStat
-          icon={GitBranch}
-          label="Source-backed"
-          value={SOURCE_BACKED}
-          hint={`${pctOf(SOURCE_BACKED, TOTAL)}% of total`}
-          to="/browse"
-          search={{ category: "mcp", source: "source-backed" }}
-          onNavigate={() => trackStat("source-backed")}
-        />
+        {(
+          [
+            {
+              key: "total",
+              icon: Boxes,
+              label: "MCP servers",
+              value: TOTAL,
+              hint: "in the registry",
+            },
+            {
+              key: "remote",
+              icon: Cloud,
+              label: "Hosted (remote)",
+              value: REMOTE,
+              hint: `${pctOf(REMOTE, TOTAL)}% of total`,
+            },
+            {
+              key: "local",
+              icon: HardDrive,
+              label: "Local (stdio)",
+              value: LOCAL,
+              hint: `${pctOf(LOCAL, TOTAL)}% of total`,
+            },
+            {
+              key: "source-backed",
+              icon: GitBranch,
+              label: "Source-backed",
+              value: SOURCE_BACKED,
+              hint: `${pctOf(SOURCE_BACKED, TOTAL)}% of total`,
+            },
+          ] as const
+        ).map((stat) => {
+          const egress = stateReportStatBrowseEgress(stat.key, REPORT_CATEGORY);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={stat.icon}
+              label={stat.label}
+              value={stat.value}
+              hint={stat.hint}
+              to={egress?.to}
+              search={egress?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       <DataSection

--- a/tests/mcp-security-report-page-cta-events-lib.test.ts
+++ b/tests/mcp-security-report-page-cta-events-lib.test.ts
@@ -11,6 +11,7 @@ import {
   mcpSecurityReportEgressAnalyticsEvent,
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
+  mcpSecurityReportStatBrowseEgress,
 } from "@/lib/mcp-security-report-page-cta-events-lib";
 
 describe("mcp security report page cta events lib", () => {
@@ -60,5 +61,29 @@ describe("mcp security report page cta events lib", () => {
       statKey: "total",
       destination: "browse",
     });
+  });
+
+  it("maps mcp security headline stats to browse egress", () => {
+    expect(mcpSecurityReportStatBrowseEgress("total")).toEqual({
+      to: "/browse",
+      search: { category: "mcp" },
+      destination: "browse",
+    });
+    expect(mcpSecurityReportStatBrowseEgress("safety-notes")).toEqual({
+      to: "/browse",
+      search: { category: "mcp", signal: "safety-notes" },
+      destination: "browse",
+    });
+    expect(mcpSecurityReportStatBrowseEgress("privacy-notes")).toEqual({
+      to: "/browse",
+      search: { category: "mcp", signal: "privacy-notes" },
+      destination: "browse",
+    });
+    expect(mcpSecurityReportStatBrowseEgress("verified-package")).toEqual({
+      to: "/browse",
+      search: { category: "mcp", signal: "trusted-package" },
+      destination: "browse",
+    });
+    expect(mcpSecurityReportStatBrowseEgress("unknown")).toBeNull();
   });
 });

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -10,6 +10,7 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatBrowseEgress,
 } from "@/lib/state-report-page-cta-events-lib";
 
 describe("state report page cta events lib", () => {
@@ -79,5 +80,92 @@ describe("state report page cta events lib", () => {
       statKey: "total",
       destination: "browse",
     });
+  });
+
+  it("maps state report headline stats to browse egress", () => {
+    expect(stateReportStatBrowseEgress("categories")).toEqual({
+      to: "/browse",
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("reviewed")).toEqual({
+      to: "/quality",
+      destination: "quality",
+    });
+    expect(stateReportStatBrowseEgress("source-backed")).toEqual({
+      to: "/browse",
+      search: { source: "source-backed" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("source-backed", "mcp")).toEqual({
+      to: "/browse",
+      search: { category: "mcp", source: "source-backed" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("validated", "skills")).toEqual({
+      to: "/browse",
+      search: { category: "skills", signal: "reviewed" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("safety-privacy", "hooks")).toEqual({
+      to: "/browse",
+      search: { category: "hooks", signal: "safety-notes" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("total")).toEqual({
+      to: "/browse",
+      search: undefined,
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("total", "mcp")).toEqual({
+      to: "/browse",
+      search: { category: "mcp" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("remote", "mcp")).toEqual({
+      to: "/browse",
+      search: { category: "mcp" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("local", "mcp")).toEqual({
+      to: "/browse",
+      search: { category: "mcp" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("events", "hooks")).toEqual({
+      to: "/browse",
+      search: { category: "hooks" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("simple", "hooks")).toEqual({
+      to: "/browse",
+      search: { category: "hooks" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("packs", "skills")).toEqual({
+      to: "/browse",
+      search: { category: "skills" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("packaged", "skills")).toEqual({
+      to: "/browse",
+      search: { category: "skills" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("ready", "agents")).toEqual({
+      to: "/browse",
+      search: { category: "agents" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("documented", "agents")).toEqual({
+      to: "/browse",
+      search: { category: "agents" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("unknown", "agents")).toEqual({
+      to: "/browse",
+      search: { category: "agents" },
+      destination: "browse",
+    });
+    expect(stateReportStatBrowseEgress("unknown")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add `stateReportStatBrowseEgress` / `mcpSecurityReportStatBrowseEgress` switch helpers that map headline stats to browse/quality destinations
- Wire all six data-report routes so `DataStat` tiles derive `to`/`search` from those helpers
- Fix MCP security safety/privacy/verified-package tiles that previously all linked to bare `/browse?category=mcp`

## Test plan
- [x] Vitest covers every switch arm including `default`
- [ ] codecov/patch and codecov/project green
- [ ] validate-ci / validate-web / required-pr-gate pass
- [ ] No path overlap with open PRs (none at open time)

Refs #550

Made with [Cursor](https://cursor.com)