### PR TITLE
feat(web): add category ranking trust badge browse analytics

### DIFF
--- a/apps/web/src/components/category-ranking-table.tsx
+++ b/apps/web/src/components/category-ranking-table.tsx
@@ -4,9 +4,14 @@ import {
   InstallRiskBadge,
   NotesPresenceChips,
   SourceBadge,
+  TrustBadge,
 } from "@/components/badges";
 import { HarnessBadgeRow } from "@/components/harness-badge";
 import { trackEvent } from "@/lib/analytics";
+import {
+  badgeChromeTrustAnalyticsData,
+  badgeChromeTrustAnalyticsEvent,
+} from "@/lib/badge-chrome-cta-events";
 import {
   hubCategoryRankingEntryAnalyticsData,
   hubCategoryRankingEntryAnalyticsEvent,
@@ -28,19 +33,27 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
       <h2 className="h-display-2 text-ink">Top {label}, compared</h2>
       <p className="mt-2 max-w-3xl text-sm text-ink-muted">
         The leading {label.toLowerCase()} side by side on the signals that matter before you install
-        — source provenance, install risk, setup, and disclosed safety notes. Ordered by
+        — trust tier, source provenance, install risk, setup, and disclosed safety notes. Ordered by
         HeyClaude&apos;s metadata review, not by repo popularity.
       </p>
       <div className="mt-5 overflow-x-auto rounded-xl border border-border">
-        <table className="w-full min-w-[44rem] border-collapse text-left">
+        <table className="w-full min-w-[48rem] border-collapse text-left">
           <caption className="sr-only">
-            Top Claude {label} compared by source, install risk, setup, platform support, harness,
-            and disclosed notes.
+            Top Claude {label} compared by trust, source, install risk, setup, platform support,
+            harness, and disclosed notes.
           </caption>
           <thead className="bg-surface">
             <tr>
-              {["Resource", "Source", "Install risk", "Setup", "Platforms", "Harness", "Notes"].map(
-                (head) => (
+              {[
+                "Resource",
+                "Trust",
+                "Source",
+                "Install risk",
+                "Setup",
+                "Platforms",
+                "Harness",
+                "Notes",
+              ].map((head) => (
                 <th
                   key={head}
                   scope="col"
@@ -48,8 +61,7 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                 >
                   {head}
                 </th>
-                ),
-              )}
+              ))}
             </tr>
           </thead>
           <tbody>
@@ -71,6 +83,18 @@ export function CategoryRankingTable({ entries, label }: { entries: Entry[]; lab
                   </Link>
                   <div className="mt-0.5 text-xs text-ink-subtle">{e.author}</div>
                 </th>
+                <td className="px-3 py-2.5 align-top">
+                  <TrustBadge
+                    level={e.trust}
+                    asLink
+                    onNavigate={() =>
+                      trackEvent(
+                        badgeChromeTrustAnalyticsEvent(),
+                        badgeChromeTrustAnalyticsData(e.trust, "category-ranking"),
+                      )
+                    }
+                  />
+                </td>
                 <td className="px-3 py-2.5 align-top">
                   <SourceBadge status={e.source} asLink surface="category-ranking" />
                 </td>

--- a/apps/web/src/lib/badge-chrome-cta-events-lib.ts
+++ b/apps/web/src/lib/badge-chrome-cta-events-lib.ts
@@ -15,7 +15,8 @@ export type BadgeChromeSurface =
   | "trending-podium"
   | "validators-attention"
   | "validators-recent-reviewed"
-  | "hub-highlights";
+  | "hub-highlights"
+  | "category-ranking";
 
 export type BadgeChromeNoteKind = "safety" | "privacy";
 

--- a/tests/badge-chrome-cta-events-lib.test.ts
+++ b/tests/badge-chrome-cta-events-lib.test.ts
@@ -177,5 +177,11 @@ describe("badge chrome cta events lib", () => {
       surface: "hub-highlights",
       trust: "review",
     });
+    expect(
+      badgeChromeTrustAnalyticsData("trusted", "category-ranking"),
+    ).toEqual({
+      surface: "category-ranking",
+      trust: "trusted",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add Trust column to category ranking table with TrustBadge asLink browse egress
- Extend BadgeChromeSurface with `category-ranking` and cover in unit tests

## Test plan
- [ ] Open a category hub with ranking table and click a Trust badge
- [ ] Confirm browse opens with matching `trust` filter
- [ ] Confirm analytics payload is privacy-light (surface + trust)

Refs #550

Made with [Cursor](https://cursor.com)