### PR TITLE
feat(web): map mcp security headline stats to browse signal filters

### DIFF
--- a/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
@@ -78,3 +78,27 @@ export function mcpSecurityReportStatAnalyticsData(
     destination,
   };
 }
+
+export type McpSecurityReportStatId =
+  | "total"
+  | "safety-notes"
+  | "privacy-notes"
+  | "verified-package";
+
+/** Map an MCP security headline stat to a browse search patch. */
+export function mcpSecurityReportStatBrowseSearch(statId: McpSecurityReportStatId): {
+  category: string;
+  signal?: string;
+} {
+  switch (statId) {
+    case "safety-notes":
+      return { category: "mcp", signal: "safety-notes" };
+    case "privacy-notes":
+      return { category: "mcp", signal: "privacy-notes" };
+    case "verified-package":
+      return { category: "mcp", signal: "trusted-package" };
+    case "total":
+    default:
+      return { category: "mcp" };
+  }
+}

--- a/apps/web/src/lib/mcp-security-report-page-cta-events.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events.ts
@@ -13,5 +13,7 @@ export {
   mcpSecurityReportEgressAnalyticsEvent,
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
+  mcpSecurityReportStatBrowseSearch,
   type McpSecurityReportEgressDestination,
+  type McpSecurityReportStatId,
 } from "@/lib/mcp-security-report-page-cta-events-lib";

--- a/apps/web/src/routes/mcp-security-report.tsx
+++ b/apps/web/src/routes/mcp-security-report.tsx
@@ -30,6 +30,7 @@ import {
   mcpSecurityReportEgressAnalyticsEvent,
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
+  mcpSecurityReportStatBrowseSearch,
   type McpSecurityReportEgressDestination,
 } from "@/lib/mcp-security-report-page-cta-events";
 
@@ -248,7 +249,7 @@ function McpSecurityReportPage() {
           value={TOTAL}
           hint="analyzed"
           to="/browse"
-          search={{ category: "mcp" }}
+          search={mcpSecurityReportStatBrowseSearch("total")}
           onNavigate={() => trackStat("total")}
         />
         <DataStat
@@ -257,7 +258,7 @@ function McpSecurityReportPage() {
           value={NOTES.safety}
           hint={`${pctOf(NOTES.safety, TOTAL)}% of total`}
           to="/browse"
-          search={{ category: "mcp" }}
+          search={mcpSecurityReportStatBrowseSearch("safety-notes")}
           onNavigate={() => trackStat("safety-notes")}
         />
         <DataStat
@@ -266,7 +267,7 @@ function McpSecurityReportPage() {
           value={NOTES.privacy}
           hint={`${pctOf(NOTES.privacy, TOTAL)}% of total`}
           to="/browse"
-          search={{ category: "mcp" }}
+          search={mcpSecurityReportStatBrowseSearch("privacy-notes")}
           onNavigate={() => trackStat("privacy-notes")}
         />
         <DataStat
@@ -275,7 +276,7 @@ function McpSecurityReportPage() {
           value={SUPPLY.packageVerified}
           hint={`${pctOf(SUPPLY.packageVerified, TOTAL)}% of total`}
           to="/browse"
-          search={{ category: "mcp" }}
+          search={mcpSecurityReportStatBrowseSearch("verified-package")}
           onNavigate={() => trackStat("verified-package")}
         />
       </div>

--- a/tests/mcp-security-report-page-cta-events-lib.test.ts
+++ b/tests/mcp-security-report-page-cta-events-lib.test.ts
@@ -11,6 +11,7 @@ import {
   mcpSecurityReportEgressAnalyticsEvent,
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
+  mcpSecurityReportStatBrowseSearch,
 } from "@/lib/mcp-security-report-page-cta-events-lib";
 
 describe("mcp security report page cta events lib", () => {
@@ -59,6 +60,21 @@ describe("mcp security report page cta events lib", () => {
       surface: MCP_SECURITY_REPORT_SURFACE,
       statKey: "total",
       destination: "browse",
+    });
+    expect(mcpSecurityReportStatBrowseSearch("total")).toEqual({
+      category: "mcp",
+    });
+    expect(mcpSecurityReportStatBrowseSearch("safety-notes")).toEqual({
+      category: "mcp",
+      signal: "safety-notes",
+    });
+    expect(mcpSecurityReportStatBrowseSearch("privacy-notes")).toEqual({
+      category: "mcp",
+      signal: "privacy-notes",
+    });
+    expect(mcpSecurityReportStatBrowseSearch("verified-package")).toEqual({
+      category: "mcp",
+      signal: "trusted-package",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Map MCP security report DataStat clicks to browse `signal` filters (safety-notes, privacy-notes, trusted-package) while keeping category=mcp
- Add `mcpSecurityReportStatBrowseSearch` helper + unit coverage

## Test plan
- [ ] Open /mcp-security-report and click each headline DataStat
- [ ] Confirm safety/privacy/verified open browse with matching signal + mcp category
- [ ] Confirm total opens browse with mcp category only

Refs #550

Made with [Cursor](https://cursor.com)