### PR TITLE
feat(web): map agent-skills packaged stats to trusted-package browse signal

### DIFF
--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -167,7 +167,14 @@ export function withNotesSignalDrilldown(rows: DistRow[], category?: string): Di
 export function withSupplyChainSignalDrilldown(rows: DistRow[], category?: string): DistRow[] {
   return rows.map((row) => {
     const signal = supplyChainSignalFromLabel(row.label);
-    if (!signal) return row;
+    if (!signal) {
+      if (!category) return row;
+      return {
+        ...row,
+        rowKey: row.rowKey ?? row.label,
+        drilldown: browseDrilldown({ category }),
+      };
+    }
     return {
       ...row,
       rowKey: signal,
@@ -282,6 +289,8 @@ export function withReportDimensionDrilldown(
       return withNotesSignalDrilldown(rows, category);
     case "supply-chain":
       return withSupplyChainSignalDrilldown(rows, category);
+    case "packaging":
+      return withSupplyChainSignalDrilldown(rows, category);
     case "docs-coverage":
       return withDocsCoverageDrilldown(rows, category);
     case "transport":
@@ -294,7 +303,6 @@ export function withReportDimensionDrilldown(
       return withTagDrilldown(rows);
     case "prerequisites":
     case "disclosure":
-    case "packaging":
     case "skill-type":
     case "maturity":
     case "verification":

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -134,7 +134,11 @@ function StateOfAgentSkillsPage() {
             value={stat.value}
             hint={statHint(stat)}
             to="/browse"
-            search={{ category: REPORT_CATEGORY }}
+            search={
+              stat.key === "packaged"
+                ? { category: REPORT_CATEGORY, signal: "trusted-package" }
+                : { category: REPORT_CATEGORY }
+            }
             onNavigate={() => trackStat(stat.key)}
           />
         ))}

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -326,6 +326,20 @@ describe("data report drilldown lib", () => {
       },
     ]);
     expect(
+      withSupplyChainSignalDrilldown(
+        [{ label: "Source only", count: 3, pct: 30 }],
+        "skills",
+      ),
+    ).toEqual([
+      {
+        label: "Source only",
+        count: 3,
+        pct: 30,
+        rowKey: "Source only",
+        drilldown: { kind: "browse", search: { category: "skills" } },
+      },
+    ]);
+    expect(
       withSupplyChainSignalDrilldown([
         { label: "Checksummed download", count: 1, pct: 10 },
       ]),
@@ -343,7 +357,15 @@ describe("data report drilldown lib", () => {
         [{ label: "Unknown", count: 1, pct: 10 }],
         "mcp",
       ),
-    ).toEqual([{ label: "Unknown", count: 1, pct: 10 }]);
+    ).toEqual([
+      {
+        label: "Unknown",
+        count: 1,
+        pct: 10,
+        rowKey: "Unknown",
+        drilldown: { kind: "browse", search: { category: "mcp" } },
+      },
+    ]);
 
     expect(
       withInstallMethodDrilldown(
@@ -501,7 +523,17 @@ describe("data report drilldown lib", () => {
     expect(
       withReportDimensionDrilldown(
         "packaging",
-        [{ label: "x", count: 1, pct: 100 }],
+        [{ label: "Verified package", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({
+      kind: "browse",
+      search: { category: "skills", signal: "trusted-package" },
+    });
+    expect(
+      withReportDimensionDrilldown(
+        "packaging",
+        [{ label: "Source only", count: 1, pct: 100 }],
         "skills",
       )[0]?.drilldown,
     ).toEqual({ kind: "browse", search: { category: "skills" } });


### PR DESCRIPTION
## Summary
- Map agent-skills `Verified package` DataStat to browse `signal=trusted-package`
- Route packaging DistTable through supply-chain signal drilldown (with category fallback)

## Test plan
- [ ] Open /state-of-agent-skills and click Verified package headline stat
- [ ] Click packaging DistTable Verified package / Source only rows
- [ ] Confirm browse filters match (trusted-package vs category-only)

Refs #550

Made with [Cursor](https://cursor.com)