### PR TITLE
feat(web): map ai-agents disclosure stats to notes browse signals

### DIFF
--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -35,6 +35,12 @@ const NOTES_SIGNAL_BY_LABEL: Record<string, string> = {
   "Privacy notes": "privacy-notes",
 };
 
+const DISCLOSURE_SIGNAL_BY_LABEL: Record<string, string> = {
+  "Safety & privacy": "safety-notes",
+  "Safety only": "safety-notes",
+  "Privacy only": "privacy-notes",
+};
+
 const SUPPLY_SIGNAL_BY_LABEL: Record<string, string> = {
   "Verified package": "trusted-package",
   "Checksummed download": "checksums",
@@ -67,6 +73,10 @@ export function platformFromLabel(label: string): Platform | undefined {
 
 export function notesSignalFromLabel(label: string): string | undefined {
   return NOTES_SIGNAL_BY_LABEL[label];
+}
+
+export function disclosureSignalFromLabel(label: string): string | undefined {
+  return DISCLOSURE_SIGNAL_BY_LABEL[label];
 }
 
 export function supplyChainSignalFromLabel(label: string): string | undefined {
@@ -160,6 +170,25 @@ export function withNotesSignalDrilldown(rows: DistRow[], category?: string): Di
         ...(category ? { category } : {}),
         signal,
       }),
+    };
+  });
+}
+
+/** Map agent disclosure buckets to notes browse signals (with category fallback). */
+export function withDisclosureDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => {
+    const signal = disclosureSignalFromLabel(row.label);
+    if (!signal) {
+      return {
+        ...row,
+        rowKey: row.rowKey ?? row.label,
+        drilldown: browseDrilldown({ category }),
+      };
+    }
+    return {
+      ...row,
+      rowKey: signal,
+      drilldown: browseDrilldown({ category, signal }),
     };
   });
 }
@@ -301,8 +330,9 @@ export function withReportDimensionDrilldown(
       return withInstallMethodDrilldown(rows, category);
     case "use-cases":
       return withTagDrilldown(rows);
-    case "prerequisites":
     case "disclosure":
+      return withDisclosureDrilldown(rows, category);
+    case "prerequisites":
     case "skill-type":
     case "maturity":
     case "verification":

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -137,7 +137,9 @@ function StateOfAiAgentsPage() {
             search={
               stat.key === "source-backed"
                 ? { category: REPORT_CATEGORY, source: "source-backed" }
-                : { category: REPORT_CATEGORY }
+                : stat.key === "documented"
+                  ? { category: REPORT_CATEGORY, signal: "safety-notes" }
+                  : { category: REPORT_CATEGORY }
             }
             onNavigate={() => trackStat(stat.key)}
           />

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -5,6 +5,7 @@ import {
   hostingKeyFromLabel,
   installMethodKeyFromLabel,
   notesSignalFromLabel,
+  disclosureSignalFromLabel,
   platformFromLabel,
   sourceStatusFromLabel,
   supplyChainSignalFromLabel,
@@ -12,6 +13,7 @@ import {
   transportKeyFromLabel,
   trustLevelFromLabel,
   withCategoryHubDrilldown,
+  withDisclosureDrilldown,
   withDocsCoverageDrilldown,
   withHostingDrilldown,
   withInstallMethodDrilldown,
@@ -47,6 +49,10 @@ describe("data report drilldown lib", () => {
     expect(notesSignalFromLabel("Safety notes")).toBe("safety-notes");
     expect(notesSignalFromLabel("Privacy notes")).toBe("privacy-notes");
     expect(notesSignalFromLabel("Both")).toBeUndefined();
+    expect(disclosureSignalFromLabel("Safety & privacy")).toBe("safety-notes");
+    expect(disclosureSignalFromLabel("Safety only")).toBe("safety-notes");
+    expect(disclosureSignalFromLabel("Privacy only")).toBe("privacy-notes");
+    expect(disclosureSignalFromLabel("Neither documented")).toBeUndefined();
   });
 
   it("attaches browse, tag, and category drilldowns with privacy-light keys", () => {
@@ -516,10 +522,29 @@ describe("data report drilldown lib", () => {
     expect(
       withReportDimensionDrilldown(
         "disclosure",
-        [{ label: "x", count: 1, pct: 100 }],
-        "skills",
+        [{ label: "Safety only", count: 1, pct: 100 }],
+        "agents",
       )[0]?.drilldown,
-    ).toEqual({ kind: "browse", search: { category: "skills" } });
+    ).toEqual({
+      kind: "browse",
+      search: { category: "agents", signal: "safety-notes" },
+    });
+    expect(
+      withReportDimensionDrilldown(
+        "disclosure",
+        [{ label: "Neither documented", count: 1, pct: 100 }],
+        "agents",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "agents" } });
+    expect(
+      withDisclosureDrilldown(
+        [{ label: "Privacy only", count: 2, pct: 20 }],
+        "agents",
+      )[0]?.drilldown,
+    ).toEqual({
+      kind: "browse",
+      search: { category: "agents", signal: "privacy-notes" },
+    });
     expect(
       withReportDimensionDrilldown(
         "packaging",


### PR DESCRIPTION
## Summary
- Map ai-agents `Document safety & privacy` DataStat to browse `signal=safety-notes`
- Add disclosure DistTable drilldown mapping Safety/Privacy buckets to notes signals (category fallback for neither)

## Test plan
- [ ] Open /state-of-ai-agents and click Document safety & privacy headline
- [ ] Click disclosure DistTable rows (Safety & privacy / Safety only / Privacy only / Neither)
- [ ] Confirm browse filters match expected signals

Refs #550

Note: may need rebase after #5280 if both touch data-report-drilldown-lib.

Made with [Cursor](https://cursor.com)