### PR TITLE
feat(web): wire agents, skills, and validators headline browse egress

### DIFF
--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -118,8 +118,7 @@ export type StateReportStatDestination = {
 
 /**
  * Map a state-report headline stat to browse/quality egress.
- * Wired for claude-tooling / mcp-servers / claude-code-hooks; other report
- * ids return null so open PRs covering ai-agents/skills stay conflict-free.
+ * Covers all five public state reports (tooling, mcp, hooks, agents, skills).
  */
 export function stateReportStatDestination(
   reportId: string,
@@ -175,6 +174,49 @@ export function stateReportStatDestination(
           return {
             to: "/browse",
             search: { category: "hooks" },
+            destination: "browse",
+          };
+        default:
+          return null;
+      }
+    case "ai-agents":
+      switch (statKey) {
+        case "documented":
+          return {
+            to: "/browse",
+            search: { category: "agents", signal: "safety-notes" },
+            destination: "browse",
+          };
+        case "source-backed":
+          return {
+            to: "/browse",
+            search: { category: "agents", source: "source-backed" },
+            destination: "browse",
+          };
+        case "total":
+        case "ready":
+          return {
+            to: "/browse",
+            search: { category: "agents" },
+            destination: "browse",
+          };
+        default:
+          return null;
+      }
+    case "agent-skills":
+      switch (statKey) {
+        case "packaged":
+          return {
+            to: "/browse",
+            search: { category: "skills", signal: "trusted-package" },
+            destination: "browse",
+          };
+        case "total":
+        case "validated":
+        case "packs":
+          return {
+            to: "/browse",
+            search: { category: "skills" },
             destination: "browse",
           };
         default:

--- a/apps/web/src/lib/validators-tools-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-tools-cta-events-lib.ts
@@ -40,3 +40,56 @@ export function validatorsSummaryStatAnalyticsData(
     destination,
   };
 }
+
+export type ValidatorsSummaryStatDestination = {
+  to: "/browse" | "/quality";
+  search?: { source?: string };
+  destination: "browse" | "quality";
+};
+
+/** Map a validators summary headline stat to browse/quality egress. */
+export function validatorsSummaryStatDestination(
+  statId: string,
+): ValidatorsSummaryStatDestination | null {
+  switch (statId) {
+    case "entries":
+      return { to: "/browse", destination: "browse" };
+    case "safety-coverage":
+      return { to: "/quality", destination: "quality" };
+    case "source-backed":
+      return {
+        to: "/browse",
+        search: { source: "source-backed" },
+        destination: "browse",
+      };
+    case "needs-attention":
+      return { to: "/quality", destination: "quality" };
+    default:
+      return null;
+  }
+}
+
+export type ValidatorsToolCardDestination = {
+  to: "/validators/skill-package" | "/validators/mcp-config";
+  destination: "validators-skill-package" | "validators-mcp-config";
+};
+
+/** Map a validators local-tool card to its tool route. */
+export function validatorsToolCardDestination(
+  toolId: string,
+): ValidatorsToolCardDestination | null {
+  switch (toolId) {
+    case "skill-package":
+      return {
+        to: "/validators/skill-package",
+        destination: "validators-skill-package",
+      };
+    case "mcp-config":
+      return {
+        to: "/validators/mcp-config",
+        destination: "validators-mcp-config",
+      };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/validators-tools-cta-events.ts
+++ b/apps/web/src/lib/validators-tools-cta-events.ts
@@ -5,8 +5,12 @@ export {
   VALIDATORS_TOOLS_SURFACE,
   validatorsSummaryStatAnalyticsData,
   validatorsSummaryStatAnalyticsEvent,
+  validatorsSummaryStatDestination,
   validatorsToolCardAnalyticsData,
   validatorsToolCardAnalyticsEvent,
+  validatorsToolCardDestination,
+  type ValidatorsSummaryStatDestination,
   type ValidatorsSummaryStatId,
+  type ValidatorsToolCardDestination,
   type ValidatorsToolId,
 } from "@/lib/validators-tools-cta-events-lib";

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -27,6 +27,7 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatDestination,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
@@ -45,9 +46,11 @@ function trackStateReportCite() {
 }
 
 function trackStat(statKey: string) {
+  const destination = stateReportStatDestination(REPORT_ID, statKey);
+  if (!destination) return;
   trackEvent(
     stateReportStatAnalyticsEvent(),
-    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, destination.destination),
   );
 }
 
@@ -126,22 +129,21 @@ function StateOfAgentSkillsPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        {MODEL.stats.map((stat) => (
-          <DataStat
-            key={stat.key}
-            icon={STAT_ICON[stat.key] ?? Sparkles}
-            label={stat.label}
-            value={stat.value}
-            hint={statHint(stat)}
-            to="/browse"
-            search={
-              stat.key === "packaged"
-                ? { category: REPORT_CATEGORY, signal: "trusted-package" }
-                : { category: REPORT_CATEGORY }
-            }
-            onNavigate={() => trackStat(stat.key)}
-          />
-        ))}
+        {MODEL.stats.map((stat) => {
+          const destination = stateReportStatDestination(REPORT_ID, stat.key);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={STAT_ICON[stat.key] ?? Sparkles}
+              label={stat.label}
+              value={stat.value}
+              hint={statHint(stat)}
+              to={destination?.to}
+              search={destination?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       {MODEL.dimensions.map((dimension) => {

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -27,6 +27,7 @@ import {
   stateReportEgressAnalyticsEvent,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
+  stateReportStatDestination,
   type StateReportEgressDestination,
 } from "@/lib/state-report-page-cta-events";
 
@@ -45,9 +46,11 @@ function trackStateReportCite() {
 }
 
 function trackStat(statKey: string) {
+  const destination = stateReportStatDestination(REPORT_ID, statKey);
+  if (!destination) return;
   trackEvent(
     stateReportStatAnalyticsEvent(),
-    stateReportStatAnalyticsData(REPORT_ID, statKey, "browse"),
+    stateReportStatAnalyticsData(REPORT_ID, statKey, destination.destination),
   );
 }
 
@@ -126,24 +129,21 @@ function StateOfAiAgentsPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        {MODEL.stats.map((stat) => (
-          <DataStat
-            key={stat.key}
-            icon={STAT_ICON[stat.key] ?? Bot}
-            label={stat.label}
-            value={stat.value}
-            hint={statHint(stat)}
-            to="/browse"
-            search={
-              stat.key === "source-backed"
-                ? { category: REPORT_CATEGORY, source: "source-backed" }
-                : stat.key === "documented"
-                  ? { category: REPORT_CATEGORY, signal: "safety-notes" }
-                  : { category: REPORT_CATEGORY }
-            }
-            onNavigate={() => trackStat(stat.key)}
-          />
-        ))}
+        {MODEL.stats.map((stat) => {
+          const destination = stateReportStatDestination(REPORT_ID, stat.key);
+          return (
+            <DataStat
+              key={stat.key}
+              icon={STAT_ICON[stat.key] ?? Bot}
+              label={stat.label}
+              value={stat.value}
+              hint={statHint(stat)}
+              to={destination?.to}
+              search={destination?.search}
+              onNavigate={() => trackStat(stat.key)}
+            />
+          );
+        })}
       </div>
 
       {MODEL.dimensions.map((dimension) => {

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -29,8 +29,10 @@ import {
 import {
   validatorsSummaryStatAnalyticsData,
   validatorsSummaryStatAnalyticsEvent,
+  validatorsSummaryStatDestination,
   validatorsToolCardAnalyticsData,
   validatorsToolCardAnalyticsEvent,
+  validatorsToolCardDestination,
   type ValidatorsSummaryStatId,
   type ValidatorsToolId,
 } from "@/lib/validators-tools-cta-events";
@@ -132,37 +134,46 @@ function ValidatorsPage() {
       />
 
       <div className="mt-8 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
-        <SummaryStat
-          label="Entries"
-          value={REVIEW_SUMMARY.total}
-          to="/browse"
-          statId="entries"
-          destination="browse"
-        />
-        <SummaryStat
-          label="Reviewed"
-          value={`${REVIEW_SUMMARY.pct(REVIEW_SUMMARY.reviewed, REVIEW_SUMMARY.total)}%`}
-          help={`${REVIEW_SUMMARY.reviewed} entries`}
-          to="/quality"
-          statId="safety-coverage"
-          destination="quality"
-        />
-        <SummaryStat
-          label="Source-backed"
-          value={`${REVIEW_SUMMARY.pct(REVIEW_SUMMARY.sourceBacked, REVIEW_SUMMARY.total)}%`}
-          help={`${REVIEW_SUMMARY.sourceBacked} entries`}
-          to="/browse"
-          search={{ source: "source-backed" }}
-          statId="source-backed"
-          destination="browse"
-        />
-        <SummaryStat
-          label="Needs attention"
-          value={REVIEW_SUMMARY.needsAttention}
-          to="/quality"
-          statId="needs-attention"
-          destination="quality"
-        />
+        {(
+          [
+            {
+              label: "Entries",
+              value: REVIEW_SUMMARY.total,
+              statId: "entries" as const,
+            },
+            {
+              label: "Reviewed",
+              value: `${REVIEW_SUMMARY.pct(REVIEW_SUMMARY.reviewed, REVIEW_SUMMARY.total)}%`,
+              help: `${REVIEW_SUMMARY.reviewed} entries`,
+              statId: "safety-coverage" as const,
+            },
+            {
+              label: "Source-backed",
+              value: `${REVIEW_SUMMARY.pct(REVIEW_SUMMARY.sourceBacked, REVIEW_SUMMARY.total)}%`,
+              help: `${REVIEW_SUMMARY.sourceBacked} entries`,
+              statId: "source-backed" as const,
+            },
+            {
+              label: "Needs attention",
+              value: REVIEW_SUMMARY.needsAttention,
+              statId: "needs-attention" as const,
+            },
+          ] as const
+        ).map((stat) => {
+          const destination = validatorsSummaryStatDestination(stat.statId);
+          return (
+            <SummaryStat
+              key={stat.statId}
+              label={stat.label}
+              value={stat.value}
+              help={"help" in stat ? stat.help : undefined}
+              to={destination?.to}
+              search={destination?.search}
+              statId={stat.statId}
+              destination={destination?.destination}
+            />
+          );
+        })}
       </div>
 
       <div className="mt-8 flex flex-wrap items-center gap-2">
@@ -402,20 +413,36 @@ function ValidatorsPage() {
           or install approval.
         </p>
         <div className="mt-5 grid gap-4 sm:grid-cols-2">
-          <ToolCard
-            icon={FileJson}
-            title="SKILL.md package"
-            blurb="Frontmatter, package references, checksum facts, submission metadata."
-            toolId="skill-package"
-            to="/validators/skill-package"
-          />
-          <ToolCard
-            icon={Terminal}
-            title="MCP config JSON"
-            blurb="Server shape, package targets, placeholders, risky shell syntax, secret-like values."
-            toolId="mcp-config"
-            to="/validators/mcp-config"
-          />
+          {(
+            [
+              {
+                icon: FileJson,
+                title: "SKILL.md package",
+                blurb: "Frontmatter, package references, checksum facts, submission metadata.",
+                toolId: "skill-package" as const,
+              },
+              {
+                icon: Terminal,
+                title: "MCP config JSON",
+                blurb:
+                  "Server shape, package targets, placeholders, risky shell syntax, secret-like values.",
+                toolId: "mcp-config" as const,
+              },
+            ] as const
+          ).map((tool) => {
+            const destination = validatorsToolCardDestination(tool.toolId);
+            if (!destination) return null;
+            return (
+              <ToolCard
+                key={tool.toolId}
+                icon={tool.icon}
+                title={tool.title}
+                blurb={tool.blurb}
+                toolId={tool.toolId}
+                to={destination.to}
+              />
+            );
+          })}
         </div>
       </section>
 

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -152,8 +152,50 @@ describe("state report page cta events lib", () => {
       stateReportStatDestination("claude-code-hooks", "unknown"),
     ).toBeNull();
 
-    expect(stateReportStatDestination("ai-agents", "total")).toBeNull();
-    expect(stateReportStatDestination("agent-skills", "total")).toBeNull();
+    expect(stateReportStatDestination("ai-agents", "total")).toEqual({
+      to: "/browse",
+      search: { category: "agents" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("ai-agents", "documented")).toEqual({
+      to: "/browse",
+      search: { category: "agents", signal: "safety-notes" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("ai-agents", "source-backed")).toEqual({
+      to: "/browse",
+      search: { category: "agents", source: "source-backed" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("ai-agents", "ready")).toEqual({
+      to: "/browse",
+      search: { category: "agents" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("ai-agents", "unknown")).toBeNull();
+
+    expect(stateReportStatDestination("agent-skills", "total")).toEqual({
+      to: "/browse",
+      search: { category: "skills" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("agent-skills", "validated")).toEqual({
+      to: "/browse",
+      search: { category: "skills" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("agent-skills", "packs")).toEqual({
+      to: "/browse",
+      search: { category: "skills" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("agent-skills", "packaged")).toEqual({
+      to: "/browse",
+      search: { category: "skills", signal: "trusted-package" },
+      destination: "browse",
+    });
+    expect(stateReportStatDestination("agent-skills", "unknown")).toBeNull();
+
     expect(stateReportStatDestination("unknown-report", "total")).toBeNull();
   });
 });

--- a/tests/validators-tools-cta-events-lib.test.ts
+++ b/tests/validators-tools-cta-events-lib.test.ts
@@ -3,8 +3,10 @@ import {
   VALIDATORS_TOOLS_SURFACE,
   validatorsSummaryStatAnalyticsData,
   validatorsSummaryStatAnalyticsEvent,
+  validatorsSummaryStatDestination,
   validatorsToolCardAnalyticsData,
   validatorsToolCardAnalyticsEvent,
+  validatorsToolCardDestination,
 } from "@/lib/validators-tools-cta-events-lib";
 
 describe("validators tools cta events lib", () => {
@@ -37,5 +39,36 @@ describe("validators tools cta events lib", () => {
       statId: "needs-attention",
       destination: "quality",
     });
+  });
+
+  it("maps validators summary stats and tool cards to destinations", () => {
+    expect(validatorsSummaryStatDestination("entries")).toEqual({
+      to: "/browse",
+      destination: "browse",
+    });
+    expect(validatorsSummaryStatDestination("safety-coverage")).toEqual({
+      to: "/quality",
+      destination: "quality",
+    });
+    expect(validatorsSummaryStatDestination("source-backed")).toEqual({
+      to: "/browse",
+      search: { source: "source-backed" },
+      destination: "browse",
+    });
+    expect(validatorsSummaryStatDestination("needs-attention")).toEqual({
+      to: "/quality",
+      destination: "quality",
+    });
+    expect(validatorsSummaryStatDestination("unknown")).toBeNull();
+
+    expect(validatorsToolCardDestination("skill-package")).toEqual({
+      to: "/validators/skill-package",
+      destination: "validators-skill-package",
+    });
+    expect(validatorsToolCardDestination("mcp-config")).toEqual({
+      to: "/validators/mcp-config",
+      destination: "validators-mcp-config",
+    });
+    expect(validatorsToolCardDestination("unknown")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Extend \`stateReportStatDestination\` for \`ai-agents\` and \`agent-skills\` headline stats and wire both report routes through the helper
- Add \`validatorsSummaryStatDestination\` / \`validatorsToolCardDestination\` and wire the validators hub summary tiles + tool cards
- Completes the #5282 state-report destination series across all five public reports

## Test plan
- [x] Vitest covers every new switch arm including defaults
- [ ] codecov/patch and codecov/project green
- [ ] validate-ci / validate-web / required-pr-gate pass
- [ ] No path overlap with open PRs at open time

Refs #550

Made with [Cursor](https://cursor.com)