### PR TITLE
fix(mcp): report MCP install-target compatibility from config snippets

### DIFF
--- a/packages/mcp/src/mcp-install-config-lib.js
+++ b/packages/mcp/src/mcp-install-config-lib.js
@@ -1,0 +1,217 @@
+/**
+ * Pure MCP install-config normalizers for the publishable MCP package.
+ *
+ * Mirrors `packages/registry/src/mcp-install-config-lib.js` without importing
+ * `@heyclaude/registry`, so packed tarballs stay self-contained.
+ */
+
+import { hasEmbeddedUrlUserinfo, isPublicHttpsUrl } from "./public-url-lib.js";
+
+export const MCP_INSTALL_TARGET_IDS = [
+  "claude-code",
+  "codex",
+  "cursor",
+  "antigravity",
+];
+
+const SERVER_CONFIG_TYPES = new Set(["stdio", "http", "sse"]);
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function scalarRecordIsValid(value) {
+  return (
+    value === undefined ||
+    (isRecord(value) &&
+      Object.values(value).every(
+        (item) =>
+          typeof item === "string" ||
+          typeof item === "number" ||
+          typeof item === "boolean",
+      ))
+  );
+}
+
+function normalizeType(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "streamable-http") return "http";
+  if (normalized === "http" || normalized === "sse" || normalized === "stdio") {
+    return normalized;
+  }
+  return "";
+}
+
+function isLoopbackHostname(hostname) {
+  const host = String(hostname || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host === "::1" || host === "0.0.0.0") return true;
+  const ipv4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  return Boolean(ipv4 && Number(ipv4[1]) === 127);
+}
+
+function isSafeRemoteMcpUrl(value) {
+  try {
+    const url = new URL(String(value).trim());
+    if (hasEmbeddedUrlUserinfo(value)) return false;
+    if (isPublicHttpsUrl(value)) return true;
+    return url.protocol === "http:" && isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function normalizeArgs(value) {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return null;
+  if (
+    !value.every(
+      (item) =>
+        typeof item === "string" ||
+        typeof item === "number" ||
+        typeof item === "boolean",
+    )
+  ) {
+    return null;
+  }
+  return value.map(String);
+}
+
+export function normalizeMcpServerConfig(value) {
+  if (!isRecord(value)) return null;
+  const config = cloneJson(value);
+
+  if (config.transport !== undefined) return null;
+
+  if (config.serverUrl !== undefined) {
+    if (typeof config.serverUrl !== "string" || !config.serverUrl.trim()) {
+      return null;
+    }
+    if (config.url === undefined) config.url = config.serverUrl;
+    delete config.serverUrl;
+  }
+
+  const type = normalizeType(config.type);
+  const hasCommand =
+    typeof config.command === "string" && config.command.trim();
+  const hasUrl = typeof config.url === "string" && config.url.trim();
+
+  if (!type && hasCommand) config.type = "stdio";
+  else if (!type && hasUrl) config.type = "http";
+  else if (type) config.type = type;
+
+  const normalizedType = normalizeType(config.type);
+  if (!SERVER_CONFIG_TYPES.has(normalizedType)) return null;
+  if (normalizedType === "stdio" && !hasCommand) return null;
+  if (normalizedType === "http" || normalizedType === "sse") {
+    if (!hasUrl || !isSafeRemoteMcpUrl(config.url)) return null;
+  }
+
+  const args = normalizeArgs(config.args);
+  if (args === null) return null;
+  if (args !== undefined) config.args = args;
+  if (!scalarRecordIsValid(config.env)) return null;
+  if (!scalarRecordIsValid(config.headers)) return null;
+  if (!scalarRecordIsValid(config.http_headers)) return null;
+  if (!scalarRecordIsValid(config.env_http_headers)) return null;
+
+  return config;
+}
+
+function singleServerFromMap(value) {
+  if (!isRecord(value)) return null;
+  const servers = Object.entries(value).filter(([, config]) =>
+    isRecord(config),
+  );
+  if (servers.length !== 1) return null;
+  const [name, config] = servers[0];
+  const normalized = normalizeMcpServerConfig(config);
+  return normalized ? { name, config: normalized } : null;
+}
+
+export function extractMcpServerConfig(value) {
+  const parsed = typeof value === "string" ? JSON.parse(value.trim()) : value;
+  if (!isRecord(parsed)) return null;
+
+  return singleServerFromMap(parsed.mcpServers);
+}
+
+function bearerTokenEnvVar(config) {
+  return (
+    (typeof config.bearerTokenEnvVar === "string" &&
+      config.bearerTokenEnvVar.trim()) ||
+    (typeof config.bearer_token_env_var === "string" &&
+      config.bearer_token_env_var.trim()) ||
+    ""
+  );
+}
+
+function hasStaticOrEnvHttpHeaders(config) {
+  return (
+    (isRecord(config.headers) && Object.keys(config.headers).length > 0) ||
+    (isRecord(config.http_headers) &&
+      Object.keys(config.http_headers).length > 0) ||
+    (isRecord(config.env_http_headers) &&
+      Object.keys(config.env_http_headers).length > 0)
+  );
+}
+
+export function mcpConfigSupportsTarget(config, target) {
+  const normalized = normalizeMcpServerConfig(config);
+  if (!normalized) return false;
+  const type = normalizeType(normalized.type);
+
+  if (target === "codex") {
+    if (type === "sse") return false;
+    if (type === "http" && hasStaticOrEnvHttpHeaders(normalized)) {
+      return Boolean(bearerTokenEnvVar(normalized));
+    }
+  }
+
+  return MCP_INSTALL_TARGET_IDS.includes(target);
+}
+
+export function mcpInstallTargetsForConfig(config) {
+  return MCP_INSTALL_TARGET_IDS.filter((target) =>
+    mcpConfigSupportsTarget(config, target),
+  );
+}
+
+export function formatMcpConfigSnippet(name, config) {
+  const serverName = String(name || "heyclaude-mcp").trim() || "heyclaude-mcp";
+  return `${JSON.stringify(
+    { mcpServers: { [serverName]: config } },
+    null,
+    2,
+  )}\n`;
+}
+
+export function resolveMcpInstallConfig(entry) {
+  if (!entry || entry.category !== "mcp") return null;
+  const snippet = String(entry.configSnippet || "").trim();
+  if (!snippet) return null;
+  try {
+    const extracted = extractMcpServerConfig(snippet);
+    if (!extracted) return null;
+    const name = extracted.name || entry.slug || "heyclaude-mcp";
+    const targets = mcpInstallTargetsForConfig(extracted.config);
+    if (!targets.length) return null;
+    return {
+      name,
+      config: extracted.config,
+      configSnippet: formatMcpConfigSnippet(name, extracted.config),
+      targets,
+    };
+  } catch {
+    // Non-JSON shell commands and prose are intentionally manual-only.
+  }
+  return null;
+}

--- a/packages/mcp/src/platforms-lib.js
+++ b/packages/mcp/src/platforms-lib.js
@@ -7,7 +7,49 @@
  * The public surface (`platforms.js` / `@heyclaude/mcp/platforms`) re-exports
  * everything below so existing imports stay unchanged.
  */
+import { resolveMcpInstallConfig } from "./mcp-install-config-lib.js";
+
 export const SITE_URL = "https://heyclau.de";
+
+const MCP_PLATFORM_COMPATIBILITY = {
+  "claude-code": {
+    platform: "Claude Code",
+    support: "native-mcp",
+    artifact: "MCP server config",
+    installHint: "Add the config snippet to your Claude Code MCP settings.",
+  },
+  codex: {
+    platform: "Codex",
+    support: "native-mcp",
+    artifact: "MCP server config",
+    installHint: "Add the config snippet to your Codex MCP settings.",
+  },
+  cursor: {
+    platform: "Cursor",
+    support: "mcp-config",
+    artifact: "MCP server config",
+    installHint: "Add the config snippet to your Cursor mcp.json settings.",
+  },
+  antigravity: {
+    platform: "Antigravity",
+    support: "mcp-config",
+    artifact: "MCP server config",
+    installHint: "Add the config snippet to your Antigravity MCP settings.",
+  },
+};
+
+function buildMcpPlatformCompatibility(entry) {
+  if (Array.isArray(entry.platformCompatibility)) {
+    return entry.platformCompatibility;
+  }
+
+  const installConfig = resolveMcpInstallConfig(entry);
+  if (!installConfig?.targets?.length) return [];
+
+  return installConfig.targets
+    .map((target) => MCP_PLATFORM_COMPATIBILITY[target])
+    .filter(Boolean);
+}
 
 function slugPart(value, options = {}) {
   const text = String(value || "")
@@ -44,6 +86,9 @@ export function platformFeedSlug(platform) {
 }
 
 export function buildSkillPlatformCompatibility(entry) {
+  if (entry?.category === "mcp") {
+    return buildMcpPlatformCompatibility(entry);
+  }
   if (entry?.category !== "skills") return [];
   if (Array.isArray(entry.platformCompatibility)) {
     return entry.platformCompatibility;

--- a/packages/mcp/src/registry-normalize-lib.js
+++ b/packages/mcp/src/registry-normalize-lib.js
@@ -28,6 +28,7 @@ const platformAliases = new Map([
   ["agents", "cli"],
   ["agents-context", "cli"],
   ["agents-md", "cli"],
+  ["antigravity", "antigravity"],
 ]);
 
 export function normalizeText(value) {

--- a/tests/mcp-platforms-lib.test.ts
+++ b/tests/mcp-platforms-lib.test.ts
@@ -20,9 +20,78 @@ describe("platforms-lib feed slugs", () => {
 });
 
 describe("platforms-lib skill compatibility", () => {
-  it("builds default skill compatibility while preserving explicit metadata", () => {
+  it("returns empty compatibility for mcp entries without install metadata", () => {
     expect(buildSkillPlatformCompatibility({ category: "mcp" })).toEqual([]);
+    expect(buildSkillPlatformCompatibility({ category: "agents" })).toEqual([]);
+  });
 
+  it("builds MCP install-target compatibility from config snippets", () => {
+    const compatibility = buildSkillPlatformCompatibility({
+      category: "mcp",
+      slug: "demo-server",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          demo: {
+            command: "npx",
+            args: ["-y", "@example/demo-mcp"],
+          },
+        },
+      }),
+    });
+
+    expect(compatibility.map((item) => item.platform)).toEqual([
+      "Claude Code",
+      "Codex",
+      "Cursor",
+      "Antigravity",
+    ]);
+    expect(compatibility[0]).toMatchObject({
+      platform: "Claude Code",
+      support: "native-mcp",
+      artifact: "MCP server config",
+    });
+    expect(compatibility[2]).toMatchObject({
+      platform: "Cursor",
+      support: "mcp-config",
+    });
+  });
+
+  it("excludes codex for sse configs while preserving explicit MCP metadata", () => {
+    const sseCompatibility = buildSkillPlatformCompatibility({
+      category: "mcp",
+      slug: "sse-server",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          sse: {
+            type: "sse",
+            url: "https://example.com/sse",
+          },
+        },
+      }),
+    });
+    expect(sseCompatibility.map((item) => item.platform)).toEqual([
+      "Claude Code",
+      "Cursor",
+      "Antigravity",
+    ]);
+
+    const explicit = [
+      {
+        platform: "Custom MCP",
+        support: "manual",
+        artifact: "custom",
+        installHint: "Use the custom installer.",
+      },
+    ];
+    expect(
+      buildSkillPlatformCompatibility({
+        category: "mcp",
+        platformCompatibility: explicit,
+      }),
+    ).toBe(explicit);
+  });
+
+  it("builds default skill compatibility while preserving explicit metadata", () => {
     const explicit = [
       {
         platform: "Custom",

--- a/tests/mcp-platforms.test.ts
+++ b/tests/mcp-platforms.test.ts
@@ -14,6 +14,7 @@ describe("MCP platform helpers", () => {
 
   it("builds default skill compatibility while preserving explicit metadata", () => {
     expect(buildSkillPlatformCompatibility({ category: "mcp" })).toEqual([]);
+    expect(buildSkillPlatformCompatibility({ category: "agents" })).toEqual([]);
 
     const explicit = [
       {

--- a/tests/mcp-registry-normalize-lib.test.ts
+++ b/tests/mcp-registry-normalize-lib.test.ts
@@ -35,7 +35,12 @@ describe("registry-normalize-lib platform aliases", () => {
     expect(normalizePlatform("   ")).toBe("");
   });
 
+  it("resolves antigravity MCP install target aliases", () => {
+    expect(normalizePlatform("Antigravity")).toBe("antigravity");
+    expect(normalizePlatform("antigravity")).toBe("antigravity");
+  });
+
   it("preserves unknown platform labels without alias mapping", () => {
-    expect(normalizePlatform("Antigravity")).toBe("Antigravity");
+    expect(normalizePlatform("Zed Pro")).toBe("Zed Pro");
   });
 });

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -1108,7 +1108,12 @@ describe("non-UI branch matrix", () => {
       count: 1,
     });
     expect(buildArtifactHash({ ok: true })).toMatch(/^[a-f0-9]{64}$/);
-    expect(buildSkillPlatformCompatibility(entry("mcp"))).toEqual([]);
+    expect(buildSkillPlatformCompatibility(entry("mcp")).map((item) => item.platform)).toEqual([
+      "Claude Code",
+      "Codex",
+      "Cursor",
+      "Antigravity",
+    ]);
   });
 
   it("covers commercial policy helpers and command safety classifications", () => {


### PR DESCRIPTION
## Summary

`buildSkillPlatformCompatibility()` now derives real per-client install-target compatibility for `mcp`-category entries by reusing the same `resolveMcpInstallConfig()` logic already used in the registry and Raycast integration.

## Motivation

For MCP server entries with a valid `configSnippet`, tools such as `getCompatibility`, `getInstallGuidance`, `getCopyableAsset`, `compareEntries`, `reviewEntrySafety`, and `compareEntryTrust` previously returned `platformCompatibility: []` and `selectedCompatibility: null`. That made it impossible to answer which clients can install a given MCP server, even though install-target metadata was already computable.

Fixes #5221

## Changes

- Add a self-contained `packages/mcp/src/mcp-install-config-lib.js` (mirrors registry install-config helpers for the publishable `@heyclaude/mcp` package)
- Extend `buildSkillPlatformCompatibility()` in `platforms-lib.js` to map MCP install targets into `{ platform, support, artifact, installHint }` compatibility rows
- Add `antigravity` to MCP platform alias normalization so `getInstallGuidance({ platform: "antigravity" })` can select the Antigravity row
- Add focused unit tests in `tests/mcp-platforms-lib.test.ts` and update related expectations

## Before / after example

**Before** (`getCompatibility` / `install.guidance` on an MCP entry with stdio config):

```json
{
  "platformCompatibility": [],
  "selectedCompatibility": null
}
```

**After** (same entry):

```json
{
  "platformCompatibility": [
    { "platform": "Claude Code", "support": "native-mcp", "artifact": "MCP server config", "installHint": "Add the config snippet to your Claude Code MCP settings." },
    { "platform": "Codex", "support": "native-mcp", "artifact": "MCP server config", "installHint": "Add the config snippet to your Codex MCP settings." },
    { "platform": "Cursor", "support": "mcp-config", "artifact": "MCP server config", "installHint": "Add the config snippet to your Cursor mcp.json settings." },
    { "platform": "Antigravity", "support": "mcp-config", "artifact": "MCP server config", "installHint": "Add the config snippet to your Antigravity MCP settings." }
  ],
  "selectedCompatibility": { "platform": "Cursor", "support": "mcp-config", "artifact": "MCP server config", "installHint": "Add the config snippet to your Cursor mcp.json settings." }
}
```

SSE configs continue to exclude Codex per existing install-target rules.

## Tests

- `pnpm exec vitest run tests/mcp-platforms-lib.test.ts tests/mcp-platforms.test.ts tests/mcp-registry-normalize-lib.test.ts`
- `pnpm run test:mcp` (72 tests)
- `pnpm --filter @heyclaude/mcp validate:package`

## Notes

- Skills-category behavior is unchanged.
- Entries without a resolvable MCP config snippet still return `[]`.
- No visual impact.