### PR TITLE
feat(web): wire entry detail tag, compare, and collection egress

### DIFF
--- a/apps/web/src/lib/entry-detail-collection-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-collection-cta-events-lib.ts
@@ -30,3 +30,31 @@ export function entryDetailCollectionEntryAnalyticsData(
     itemCount,
   };
 }
+
+export type EntryDetailCollectionEntryDestination = {
+  to: "/entry/$category/$slug";
+  params: { category: string; slug: string };
+};
+
+/** Map a collection peer ref to an entry detail destination. */
+export function entryDetailCollectionEntryDestination(
+  category: string,
+  slug: string,
+): EntryDetailCollectionEntryDestination | null {
+  const categoryId = category.trim();
+  const entrySlug = slug.trim();
+  switch (categoryId) {
+    case "":
+      return null;
+    default:
+      switch (entrySlug) {
+        case "":
+          return null;
+        default:
+          return {
+            to: "/entry/$category/$slug",
+            params: { category: categoryId, slug: entrySlug },
+          };
+      }
+  }
+}

--- a/apps/web/src/lib/entry-detail-collection-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-collection-cta-events.ts
@@ -5,5 +5,6 @@ export {
   ENTRY_DETAIL_COLLECTION_ITEMS_SURFACE,
   entryDetailCollectionEntryAnalyticsData,
   entryDetailCollectionEntryAnalyticsEvent,
+  entryDetailCollectionEntryDestination,
   entryDetailCollectionEntryKey,
 } from "@/lib/entry-detail-collection-cta-events-lib";

--- a/apps/web/src/lib/entry-detail-compare-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-compare-egress-cta-events-lib.ts
@@ -43,3 +43,36 @@ export function entryDetailCompareEgressAnalyticsData(
     hasInteractive,
   };
 }
+
+export type EntryDetailCompareEgressDestination =
+  | { to: "/best/$slug"; params: { slug: string } }
+  | { to: "/compare/$slug"; params: { slug: string } }
+  | { to: "/compare"; search: { ids: string } };
+
+/**
+ * Map a compare-egress link kind + target (list/comparison slug, or interactive
+ * ids payload) to a route destination.
+ */
+export function entryDetailCompareEgressDestination(
+  linkKind: string,
+  target: string,
+): EntryDetailCompareEgressDestination | null {
+  const value = target.trim();
+  switch (value) {
+    case "":
+      return null;
+    default:
+      switch (linkKind) {
+        case "best-list":
+          return { to: "/best/$slug", params: { slug: value } };
+        case "comparison-page":
+          return { to: "/compare/$slug", params: { slug: value } };
+        case "best-list-interactive":
+        case "comparison-interactive":
+        case "dossier-interactive":
+          return { to: "/compare", search: { ids: value } };
+        default:
+          return null;
+      }
+  }
+}

--- a/apps/web/src/lib/entry-detail-compare-egress-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-compare-egress-cta-events.ts
@@ -6,6 +6,7 @@ export {
   ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
   entryDetailCompareEgressAnalyticsData,
   entryDetailCompareEgressAnalyticsEvent,
+  entryDetailCompareEgressDestination,
   entryDetailCompareEgressEntryKey,
   type EntryDetailCompareEgressLinkKind,
   type EntryDetailCompareEgressSurface,

--- a/apps/web/src/lib/entry-detail-tag-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-tag-cta-events-lib.ts
@@ -43,3 +43,39 @@ export function entryDetailCategoryHubAnalyticsData(category: string, slug: stri
     category,
   };
 }
+
+export type EntryDetailTagSelectDestination = {
+  to: "/tags/$tag";
+  params: { tag: string };
+};
+
+/** Map a tag slug to a tags hub destination. */
+export function entryDetailTagSelectDestination(
+  tagSlug: string,
+): EntryDetailTagSelectDestination | null {
+  const slug = tagSlug.trim();
+  switch (slug) {
+    case "":
+      return null;
+    default:
+      return { to: "/tags/$tag", params: { tag: slug } };
+  }
+}
+
+export type EntryDetailCategoryHubDestination = {
+  to: "/$category";
+  params: { category: string };
+};
+
+/** Map an entry category to its category hub destination. */
+export function entryDetailCategoryHubDestination(
+  category: string,
+): EntryDetailCategoryHubDestination | null {
+  const id = category.trim();
+  switch (id) {
+    case "":
+      return null;
+    default:
+      return { to: "/$category", params: { category: id } };
+  }
+}

--- a/apps/web/src/lib/entry-detail-tag-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-tag-cta-events.ts
@@ -6,7 +6,9 @@ export {
   ENTRY_DETAIL_TAGS_SURFACE,
   entryDetailCategoryHubAnalyticsData,
   entryDetailCategoryHubAnalyticsEvent,
+  entryDetailCategoryHubDestination,
   entryDetailTagAnalyticsData,
   entryDetailTagAnalyticsEvent,
   entryDetailTagEntryKey,
+  entryDetailTagSelectDestination,
 } from "@/lib/entry-detail-tag-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -99,8 +99,10 @@ import {
 import {
   entryDetailCategoryHubAnalyticsData,
   entryDetailCategoryHubAnalyticsEvent,
+  entryDetailCategoryHubDestination,
   entryDetailTagAnalyticsData,
   entryDetailTagAnalyticsEvent,
+  entryDetailTagSelectDestination,
 } from "@/lib/entry-detail-tag-cta-events";
 import {
   ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
@@ -143,12 +145,14 @@ import {
   ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
   entryDetailCompareEgressAnalyticsData,
   entryDetailCompareEgressAnalyticsEvent,
+  entryDetailCompareEgressDestination,
   type EntryDetailCompareEgressLinkKind,
   type EntryDetailCompareEgressSurface,
 } from "@/lib/entry-detail-compare-egress-cta-events";
 import {
   entryDetailCollectionEntryAnalyticsData,
   entryDetailCollectionEntryAnalyticsEvent,
+  entryDetailCollectionEntryDestination,
 } from "@/lib/entry-detail-collection-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
@@ -962,11 +966,19 @@ function Dossier() {
                     </span>
                   );
                 }
+                const destination = entryDetailTagSelectDestination(slug);
+                if (!destination) {
+                  return (
+                    <span key={t} className={base}>
+                      #{t}
+                    </span>
+                  );
+                }
                 return (
                   <Link
                     key={t}
-                    to="/tags/$tag"
-                    params={{ tag: slug }}
+                    to={destination.to}
+                    params={destination.params}
                     onClick={() =>
                       trackEvent(
                         entryDetailTagAnalyticsEvent(),
@@ -1019,24 +1031,33 @@ function Dossier() {
                 </div>
               ) : null}
               <ComparisonTable entries={[entry, ...alternatives]} showNextActions />
-              {dossierCompareUi.interactiveSearch ? (
-                <Link
-                  to="/compare"
-                  search={dossierCompareUi.interactiveSearch}
-                  className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
-                  onClick={() =>
-                    trackCompareEgress(
-                      ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+              {dossierCompareUi.interactiveSearch
+                ? (() => {
+                    const destination = entryDetailCompareEgressDestination(
                       "dossier-interactive",
-                      alternatives.length + 1,
-                      true,
-                    )
-                  }
-                >
-                  <ArrowLeft className="h-4 w-4" />
-                  {dossierCompareUi.interactiveLinkLabel}
-                </Link>
-              ) : null}
+                      dossierCompareUi.interactiveSearch.ids,
+                    );
+                    if (!destination || !("search" in destination)) return null;
+                    return (
+                      <Link
+                        to={destination.to}
+                        search={destination.search}
+                        className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+                        onClick={() =>
+                          trackCompareEgress(
+                            ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+                            "dossier-interactive",
+                            alternatives.length + 1,
+                            true,
+                          )
+                        }
+                      >
+                        <ArrowLeft className="h-4 w-4" />
+                        {dossierCompareUi.interactiveLinkLabel}
+                      </Link>
+                    );
+                  })()
+                : null}
             </DossierSection>
           )}
 
@@ -1073,19 +1094,25 @@ function Dossier() {
                 </div>
               )}
               <div className="mt-3 text-right">
-                <Link
-                  to="/$category"
-                  params={{ category: entry.category }}
-                  onClick={() =>
-                    trackEvent(
-                      entryDetailCategoryHubAnalyticsEvent(),
-                      entryDetailCategoryHubAnalyticsData(entry.category, entry.slug),
-                    )
-                  }
-                  className="story-link text-xs font-medium text-ink"
-                >
-                  More in {categoryLabels[entry.category] ?? entry.category} →
-                </Link>
+                {(() => {
+                  const destination = entryDetailCategoryHubDestination(entry.category);
+                  if (!destination) return null;
+                  return (
+                    <Link
+                      to={destination.to}
+                      params={destination.params}
+                      onClick={() =>
+                        trackEvent(
+                          entryDetailCategoryHubAnalyticsEvent(),
+                          entryDetailCategoryHubAnalyticsData(entry.category, entry.slug),
+                        )
+                      }
+                      className="story-link text-xs font-medium text-ink"
+                    >
+                      More in {categoryLabels[entry.category] ?? entry.category} →
+                    </Link>
+                  );
+                })()}
               </div>
             </DossierSection>
           )}
@@ -1115,14 +1142,22 @@ function Dossier() {
                   const bestListLink = featuredUi.bestListLinks.find(
                     (link) => link.slug === l.slug,
                   );
+                  const listDestination = entryDetailCompareEgressDestination("best-list", l.slug);
+                  const interactiveDestination =
+                    bestListLink?.search &&
+                    entryDetailCompareEgressDestination(
+                      "best-list-interactive",
+                      bestListLink.search.ids,
+                    );
+                  if (!listDestination || !("params" in listDestination)) return null;
                   return (
                     <li
                       key={`best-${l.slug}`}
                       className="flex flex-wrap items-baseline gap-x-2 gap-y-1"
                     >
                       <Link
-                        to="/best/$slug"
-                        params={{ slug: l.slug }}
+                        to={listDestination.to}
+                        params={listDestination.params}
                         className="story-link text-ink"
                         onClick={() =>
                           trackCompareEgress(
@@ -1135,10 +1170,10 @@ function Dossier() {
                       >
                         Best list: {l.title}
                       </Link>
-                      {bestListLink?.search ? (
+                      {interactiveDestination && "search" in interactiveDestination ? (
                         <Link
-                          to="/compare"
-                          search={bestListLink.search}
+                          to={interactiveDestination.to}
+                          search={interactiveDestination.search}
                           className="text-xs text-ink-muted hover:text-ink"
                           onClick={() =>
                             trackCompareEgress(
@@ -1149,7 +1184,7 @@ function Dossier() {
                             )
                           }
                         >
-                          {bestListLink.label}
+                          {bestListLink?.label}
                         </Link>
                       ) : null}
                     </li>
@@ -1159,14 +1194,25 @@ function Dossier() {
                   const featuredLink = featuredUi.comparisonLinks.find(
                     (link) => link.slug === c.slug,
                   );
+                  const pageDestination = entryDetailCompareEgressDestination(
+                    "comparison-page",
+                    c.slug,
+                  );
+                  const interactiveDestination =
+                    featuredLink?.search &&
+                    entryDetailCompareEgressDestination(
+                      "comparison-interactive",
+                      featuredLink.search.ids,
+                    );
+                  if (!pageDestination || !("params" in pageDestination)) return null;
                   return (
                     <li
                       key={`cmp-${c.slug}`}
                       className="flex flex-wrap items-baseline gap-x-2 gap-y-1"
                     >
                       <Link
-                        to="/compare/$slug"
-                        params={{ slug: c.slug }}
+                        to={pageDestination.to}
+                        params={pageDestination.params}
                         className="story-link text-ink"
                         onClick={() =>
                           trackCompareEgress(
@@ -1179,10 +1225,10 @@ function Dossier() {
                       >
                         Comparison: {c.title}
                       </Link>
-                      {featuredLink?.search ? (
+                      {interactiveDestination && "search" in interactiveDestination ? (
                         <Link
-                          to="/compare"
-                          search={featuredLink.search}
+                          to={interactiveDestination.to}
+                          search={interactiveDestination.search}
                           className="text-xs text-ink-muted hover:text-ink"
                           onClick={() =>
                             trackCompareEgress(
@@ -1193,7 +1239,7 @@ function Dossier() {
                             )
                           }
                         >
-                          {featuredLink.label}
+                          {featuredLink?.label}
                         </Link>
                       ) : null}
                     </li>
@@ -1584,11 +1630,22 @@ function CollectionItemList({
         {values.map((value, itemIndex) => {
           const [category, slug] = value.split("/");
           if (category && slug) {
+            const destination = entryDetailCollectionEntryDestination(category, slug);
+            if (!destination) {
+              return (
+                <span
+                  key={value}
+                  className="inline-flex rounded-md border border-border bg-surface px-2 py-0.5 font-mono text-xs text-ink-muted"
+                >
+                  {value}
+                </span>
+              );
+            }
             return (
               <Link
                 key={value}
-                to="/entry/$category/$slug"
-                params={{ category, slug }}
+                to={destination.to}
+                params={destination.params}
                 onClick={() =>
                   trackEvent(
                     entryDetailCollectionEntryAnalyticsEvent(),

--- a/tests/entry-detail-collection-cta-events-lib.test.ts
+++ b/tests/entry-detail-collection-cta-events-lib.test.ts
@@ -3,6 +3,7 @@ import {
   ENTRY_DETAIL_COLLECTION_ITEMS_SURFACE,
   entryDetailCollectionEntryAnalyticsData,
   entryDetailCollectionEntryAnalyticsEvent,
+  entryDetailCollectionEntryDestination,
 } from "@/lib/entry-detail-collection-cta-events-lib";
 
 describe("entry detail collection cta events lib", () => {
@@ -25,5 +26,16 @@ describe("entry detail collection cta events lib", () => {
       itemIndex: 1,
       itemCount: 5,
     });
+  });
+
+  it("maps collection entry destinations", () => {
+    expect(entryDetailCollectionEntryDestination("mcp", "browser")).toEqual({
+      to: "/entry/$category/$slug",
+      params: { category: "mcp", slug: "browser" },
+    });
+    expect(entryDetailCollectionEntryDestination("", "browser")).toBeNull();
+    expect(entryDetailCollectionEntryDestination("mcp", "")).toBeNull();
+    expect(entryDetailCollectionEntryDestination("  ", "browser")).toBeNull();
+    expect(entryDetailCollectionEntryDestination("mcp", "  ")).toBeNull();
   });
 });

--- a/tests/entry-detail-compare-egress-cta-events-lib.test.ts
+++ b/tests/entry-detail-compare-egress-cta-events-lib.test.ts
@@ -4,6 +4,7 @@ import {
   ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
   entryDetailCompareEgressAnalyticsData,
   entryDetailCompareEgressAnalyticsEvent,
+  entryDetailCompareEgressDestination,
   entryDetailCompareEgressEntryKey,
 } from "@/lib/entry-detail-compare-egress-cta-events-lib";
 
@@ -63,5 +64,43 @@ describe("entry detail compare egress cta events lib", () => {
       refCount: 4,
       hasInteractive: true,
     });
+  });
+
+  it("maps compare egress destinations", () => {
+    expect(entryDetailCompareEgressDestination("best-list", "top-mcp")).toEqual(
+      {
+        to: "/best/$slug",
+        params: { slug: "top-mcp" },
+      },
+    );
+    expect(
+      entryDetailCompareEgressDestination("comparison-page", "browser-vs-fs"),
+    ).toEqual({
+      to: "/compare/$slug",
+      params: { slug: "browser-vs-fs" },
+    });
+    expect(
+      entryDetailCompareEgressDestination("dossier-interactive", "a,b,c"),
+    ).toEqual({
+      to: "/compare",
+      search: { ids: "a,b,c" },
+    });
+    expect(
+      entryDetailCompareEgressDestination("best-list-interactive", "x,y"),
+    ).toEqual({
+      to: "/compare",
+      search: { ids: "x,y" },
+    });
+    expect(
+      entryDetailCompareEgressDestination("comparison-interactive", "p,q"),
+    ).toEqual({
+      to: "/compare",
+      search: { ids: "p,q" },
+    });
+    expect(entryDetailCompareEgressDestination("best-list", "")).toBeNull();
+    expect(entryDetailCompareEgressDestination("best-list", "  ")).toBeNull();
+    expect(
+      entryDetailCompareEgressDestination("unknown", "top-mcp"),
+    ).toBeNull();
   });
 });

--- a/tests/entry-detail-tag-cta-events-lib.test.ts
+++ b/tests/entry-detail-tag-cta-events-lib.test.ts
@@ -4,8 +4,10 @@ import {
   ENTRY_DETAIL_TAGS_SURFACE,
   entryDetailCategoryHubAnalyticsData,
   entryDetailCategoryHubAnalyticsEvent,
+  entryDetailCategoryHubDestination,
   entryDetailTagAnalyticsData,
   entryDetailTagAnalyticsEvent,
+  entryDetailTagSelectDestination,
 } from "@/lib/entry-detail-tag-cta-events-lib";
 
 describe("entry detail tag cta events lib", () => {
@@ -28,5 +30,20 @@ describe("entry detail tag cta events lib", () => {
       surface: ENTRY_DETAIL_RELATED_SURFACE,
       category: "skills",
     });
+  });
+
+  it("maps tag select and category hub destinations", () => {
+    expect(entryDetailTagSelectDestination("browser")).toEqual({
+      to: "/tags/$tag",
+      params: { tag: "browser" },
+    });
+    expect(entryDetailTagSelectDestination("")).toBeNull();
+    expect(entryDetailTagSelectDestination("  ")).toBeNull();
+    expect(entryDetailCategoryHubDestination("mcp")).toEqual({
+      to: "/$category",
+      params: { category: "mcp" },
+    });
+    expect(entryDetailCategoryHubDestination("")).toBeNull();
+    expect(entryDetailCategoryHubDestination("  ")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add covered destination helpers for entry detail tag chips, category hub, compare/featured-in egress, and collection peer links
- Wire `entry.$category.$slug` through those helpers so those CTAs stop hardcoding routes
- Extend Vitest coverage for every destination arm including empty/unknown → null

## Test plan
- [x] `vitest` for the three entry-detail *-cta-events-lib suites
- [x] `prettier` + `trunk check --upstream origin/main`
- [ ] CI: codecov patch/project, validate-ci/web, required-pr-gate

Refs #550

Made with [Cursor](https://cursor.com)