### PR TITLE
feat(web): wire compare workspace and insights report egress

### DIFF
--- a/apps/web/src/lib/compare-curated-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-curated-egress-cta-events-lib.ts
@@ -36,3 +36,32 @@ export function compareCuratedNotFoundEgressAnalyticsData() {
     surface: COMPARE_CURATED_NOTFOUND_SURFACE,
   };
 }
+
+export type CompareCuratedEgressDestination =
+  | { to: "/compare"; search: { ids: string } }
+  | { to: "/compare" };
+
+/**
+ * Map a curated compare egress id (+ optional interactive ids payload) to a
+ * compare workspace destination.
+ */
+export function compareCuratedEgressDestination(
+  linkKind: string,
+  ids = "",
+): CompareCuratedEgressDestination | null {
+  switch (linkKind) {
+    case "interactive": {
+      const value = ids.trim();
+      switch (value) {
+        case "":
+          return null;
+        default:
+          return { to: "/compare", search: { ids: value } };
+      }
+    }
+    case "not-found":
+      return { to: "/compare" };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/compare-curated-egress-cta-events.ts
+++ b/apps/web/src/lib/compare-curated-egress-cta-events.ts
@@ -6,6 +6,7 @@ export {
   COMPARE_CURATED_NOTFOUND_SURFACE,
   compareCuratedEgressAnalyticsData,
   compareCuratedEgressAnalyticsEvent,
+  compareCuratedEgressDestination,
   compareCuratedNotFoundEgressAnalyticsData,
   compareCuratedNotFoundEgressAnalyticsEvent,
   type CompareCuratedEgressLinkKind,

--- a/apps/web/src/lib/compare-page-empty-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-egress-cta-events-lib.ts
@@ -31,3 +31,42 @@ export function comparePageEmptyEgressAnalyticsData(
     hasInteractive,
   };
 }
+
+export type ComparePageEmptyEgressDestination =
+  | { to: "/browse" }
+  | { to: "/compare/$slug"; params: { slug: string } }
+  | { to: "/compare"; search: { ids: string } };
+
+/**
+ * Map an empty-state compare egress link kind (+ optional slug/ids target) to a
+ * route destination.
+ */
+export function comparePageEmptyEgressDestination(
+  linkKind: string,
+  target = "",
+): ComparePageEmptyEgressDestination | null {
+  switch (linkKind) {
+    case "browse-directory":
+      return { to: "/browse" };
+    case "curated-page": {
+      const slug = target.trim();
+      switch (slug) {
+        case "":
+          return null;
+        default:
+          return { to: "/compare/$slug", params: { slug } };
+      }
+    }
+    case "interactive": {
+      const ids = target.trim();
+      switch (ids) {
+        case "":
+          return null;
+        default:
+          return { to: "/compare", search: { ids } };
+      }
+    }
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/compare-page-empty-egress-cta-events.ts
+++ b/apps/web/src/lib/compare-page-empty-egress-cta-events.ts
@@ -5,5 +5,6 @@ export {
   COMPARE_PAGE_EMPTY_SURFACE,
   comparePageEmptyEgressAnalyticsData,
   comparePageEmptyEgressAnalyticsEvent,
+  comparePageEmptyEgressDestination,
   type ComparePageEmptyEgressLinkKind,
 } from "@/lib/compare-page-empty-egress-cta-events-lib";

--- a/apps/web/src/lib/compare-panel-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-panel-entry-cta-events-lib.ts
@@ -201,3 +201,31 @@ export function parseComparePanelEntryRef(
     slug: entryRef.slice(slash + 1),
   };
 }
+
+export type ComparePanelEntryDestination = {
+  to: "/entry/$category/$slug";
+  params: { category: string; slug: string };
+};
+
+/** Map a compare panel entry ref to an entry detail destination. */
+export function comparePanelEntryDestination(
+  category: string,
+  slug: string,
+): ComparePanelEntryDestination | null {
+  const categoryId = category.trim();
+  const entrySlug = slug.trim();
+  switch (categoryId) {
+    case "":
+      return null;
+    default:
+      switch (entrySlug) {
+        case "":
+          return null;
+        default:
+          return {
+            to: "/entry/$category/$slug",
+            params: { category: categoryId, slug: entrySlug },
+          };
+      }
+  }
+}

--- a/apps/web/src/lib/compare-panel-entry-cta-events.ts
+++ b/apps/web/src/lib/compare-panel-entry-cta-events.ts
@@ -20,5 +20,6 @@ export {
   compareRolloutReadinessEntryAnalyticsEvent,
   compareScenarioRankingEntryAnalyticsData,
   compareScenarioRankingEntryAnalyticsEvent,
+  comparePanelEntryDestination,
   parseComparePanelEntryRef,
 } from "@/lib/compare-panel-entry-cta-events-lib";

--- a/apps/web/src/lib/conversion-cta-events-lib.ts
+++ b/apps/web/src/lib/conversion-cta-events-lib.ts
@@ -24,6 +24,20 @@ export function claimCtaAnalyticsData(surface: ClaimCtaSurface, category?: strin
   };
 }
 
+export type ClaimCtaDestination = {
+  to: "/claim";
+};
+
+/** Map a claim CTA id to the claim route. */
+export function claimCtaDestination(destination: string): ClaimCtaDestination | null {
+  switch (destination) {
+    case "claim":
+      return { to: "/claim" };
+    default:
+      return null;
+  }
+}
+
 export function newsletterSubscribeAnalyticsEvent(): string {
   return "newsletter-subscribe";
 }

--- a/apps/web/src/lib/conversion-cta-events.ts
+++ b/apps/web/src/lib/conversion-cta-events.ts
@@ -6,6 +6,7 @@ export {
   NEWSLETTER_CTA_SURFACE,
   claimCtaAnalyticsData,
   claimCtaAnalyticsEvent,
+  claimCtaDestination,
   newsletterSubscribeAnalyticsData,
   newsletterSubscribeAnalyticsEvent,
   sanitizeNewsletterSource,

--- a/apps/web/src/lib/insights-page-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/insights-page-entry-cta-events-lib.ts
@@ -122,3 +122,31 @@ export function stateReportEntryAnalyticsData(
     rowCount,
   };
 }
+
+export type InsightsPageEntryDestination = {
+  to: "/entry/$category/$slug";
+  params: { category: string; slug: string };
+};
+
+/** Map an insights/report entry ref to an entry detail destination. */
+export function insightsPageEntryDestination(
+  category: string,
+  slug: string,
+): InsightsPageEntryDestination | null {
+  const categoryId = category.trim();
+  const entrySlug = slug.trim();
+  switch (categoryId) {
+    case "":
+      return null;
+    default:
+      switch (entrySlug) {
+        case "":
+          return null;
+        default:
+          return {
+            to: "/entry/$category/$slug",
+            params: { category: categoryId, slug: entrySlug },
+          };
+      }
+  }
+}

--- a/apps/web/src/lib/insights-page-entry-cta-events.ts
+++ b/apps/web/src/lib/insights-page-entry-cta-events.ts
@@ -9,6 +9,7 @@ export {
   VALIDATORS_RECENT_REVIEWED_SURFACE,
   contributorProfileEntryAnalyticsData,
   contributorProfileEntryAnalyticsEvent,
+  insightsPageEntryDestination,
   insightsPageEntryKey,
   qualityQueueEntryAnalyticsData,
   qualityQueueEntryAnalyticsEvent,

--- a/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
@@ -102,3 +102,50 @@ export function mcpSecurityReportStatBrowseSearch(statId: McpSecurityReportStatI
       return { category: "mcp" };
   }
 }
+
+export type McpSecurityReportStatDestination = {
+  to: "/browse";
+  search: { category: string; signal?: string };
+};
+
+/** Map an MCP security headline stat id to a browse destination. */
+export function mcpSecurityReportStatDestination(
+  statId: string,
+): McpSecurityReportStatDestination | null {
+  switch (statId) {
+    case "total":
+    case "safety-notes":
+    case "privacy-notes":
+    case "verified-package":
+      return {
+        to: "/browse",
+        search: mcpSecurityReportStatBrowseSearch(statId),
+      };
+    default:
+      return null;
+  }
+}
+
+export type McpSecurityReportRouteDestination =
+  | { to: "/guides/$slug"; params: { slug: string } }
+  | { to: "/state-of-mcp-servers" }
+  | { to: "/$category"; params: { category: string } };
+
+/** Map an MCP security report chrome egress id to an in-app route. */
+export function mcpSecurityReportRouteDestination(
+  destination: string,
+): McpSecurityReportRouteDestination | null {
+  switch (destination) {
+    case "threat-model-guide":
+      return {
+        to: "/guides/$slug",
+        params: { slug: "threat-model-mcp-servers-before-installation" },
+      };
+    case "state-of-mcp-servers":
+      return { to: "/state-of-mcp-servers" };
+    case "mcp-category":
+      return { to: "/$category", params: { category: "mcp" } };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/mcp-security-report-page-cta-events.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events.ts
@@ -14,6 +14,8 @@ export {
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
   mcpSecurityReportStatBrowseSearch,
+  mcpSecurityReportStatDestination,
+  mcpSecurityReportRouteDestination,
   type McpSecurityReportEgressDestination,
   type McpSecurityReportStatId,
 } from "@/lib/mcp-security-report-page-cta-events-lib";

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -226,3 +226,53 @@ export function stateReportStatDestination(
       return null;
   }
 }
+
+export type StateReportEgressRouteDestination =
+  | { to: "/browse" }
+  | { to: "/quality" }
+  | { to: "/mcp-security-report" }
+  | { to: "/state-of-claude-tooling" }
+  | { to: "/state-of-mcp-servers" }
+  | { to: "/state-of-claude-code-hooks" }
+  | { to: "/state-of-agent-skills" }
+  | { to: "/state-of-ai-agents" }
+  | { to: "/$category"; params: { category: string } };
+
+/**
+ * Map a state-report egress destination id (+ optional category) to an in-app
+ * route.
+ */
+export function stateReportEgressRouteDestination(
+  destination: string,
+  category = "",
+): StateReportEgressRouteDestination | null {
+  switch (destination) {
+    case "browse":
+      return { to: "/browse" };
+    case "quality":
+      return { to: "/quality" };
+    case "mcp-security-report":
+      return { to: "/mcp-security-report" };
+    case "claude-tooling":
+      return { to: "/state-of-claude-tooling" };
+    case "mcp-servers":
+      return { to: "/state-of-mcp-servers" };
+    case "claude-code-hooks":
+      return { to: "/state-of-claude-code-hooks" };
+    case "agent-skills":
+      return { to: "/state-of-agent-skills" };
+    case "ai-agents":
+      return { to: "/state-of-ai-agents" };
+    case "category": {
+      const id = category.trim();
+      switch (id) {
+        case "":
+          return null;
+        default:
+          return { to: "/$category", params: { category: id } };
+      }
+    }
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/state-report-page-cta-events.ts
+++ b/apps/web/src/lib/state-report-page-cta-events.ts
@@ -10,6 +10,7 @@ export {
   stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportEgressRouteDestination,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   stateReportStatDestination,

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -20,6 +20,7 @@ import { trackEvent } from "@/lib/analytics";
 import {
   compareCuratedEgressAnalyticsData,
   compareCuratedEgressAnalyticsEvent,
+  compareCuratedEgressDestination,
   compareCuratedNotFoundEgressAnalyticsData,
   compareCuratedNotFoundEgressAnalyticsEvent,
 } from "@/lib/compare-curated-egress-cta-events";
@@ -65,23 +66,28 @@ export const Route = createFileRoute("/compare/$slug")({
     };
   },
   component: ComparisonPage,
-  notFoundComponent: () => (
-    <div className="mx-auto max-w-2xl px-6 py-24 text-center">
-      <h1 className="h-display-2 text-ink">Comparison not found</h1>
-      <Link
-        to="/compare"
-        className="mt-4 inline-block text-ink-muted hover:text-ink"
-        onClick={() =>
-          trackEvent(
-            compareCuratedNotFoundEgressAnalyticsEvent(),
-            compareCuratedNotFoundEgressAnalyticsData(),
-          )
-        }
-      >
-        ← Build your own comparison
-      </Link>
-    </div>
-  ),
+  notFoundComponent: () => {
+    const destination = compareCuratedEgressDestination("not-found");
+    return (
+      <div className="mx-auto max-w-2xl px-6 py-24 text-center">
+        <h1 className="h-display-2 text-ink">Comparison not found</h1>
+        {destination ? (
+          <Link
+            to={destination.to}
+            className="mt-4 inline-block text-ink-muted hover:text-ink"
+            onClick={() =>
+              trackEvent(
+                compareCuratedNotFoundEgressAnalyticsEvent(),
+                compareCuratedNotFoundEgressAnalyticsData(),
+              )
+            }
+          >
+            ← Build your own comparison
+          </Link>
+        ) : null}
+      </div>
+    );
+  },
 });
 
 function ComparisonPage() {
@@ -115,21 +121,30 @@ function ComparisonPage() {
             ))}
           </div>
         ) : null}
-        {interactiveSearch ? (
-          <Link
-            to="/compare"
-            search={interactiveSearch}
-            className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
-            onClick={() =>
-              trackEvent(
-                compareCuratedEgressAnalyticsEvent(),
-                compareCuratedEgressAnalyticsData("interactive", entries.length, true),
-              )
-            }
-          >
-            <ArrowLeft className="h-4 w-4" /> {interactiveLinkLabel}
-          </Link>
-        ) : null}
+        {interactiveSearch
+          ? (() => {
+              const destination = compareCuratedEgressDestination(
+                "interactive",
+                interactiveSearch.ids,
+              );
+              if (!destination || !("search" in destination)) return null;
+              return (
+                <Link
+                  to={destination.to}
+                  search={destination.search}
+                  className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+                  onClick={() =>
+                    trackEvent(
+                      compareCuratedEgressAnalyticsEvent(),
+                      compareCuratedEgressAnalyticsData("interactive", entries.length, true),
+                    )
+                  }
+                >
+                  <ArrowLeft className="h-4 w-4" /> {interactiveLinkLabel}
+                </Link>
+              );
+            })()
+          : null}
       </header>
 
       <div className="mt-8">

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -51,6 +51,7 @@ import {
 import {
   comparePageDecisionBriefSurface,
   comparePageEvidenceGapsSurface,
+  comparePanelEntryDestination,
 } from "@/lib/compare-panel-entry-cta-events";
 import {
   comparePageShareLinkCopyAnalyticsData,
@@ -59,6 +60,7 @@ import {
 import {
   comparePageEmptyEgressAnalyticsData,
   comparePageEmptyEgressAnalyticsEvent,
+  comparePageEmptyEgressDestination,
 } from "@/lib/compare-page-empty-egress-cta-events";
 import {
   comparePageAddOpenAnalyticsData,
@@ -72,7 +74,11 @@ import {
   comparePageRemoveAnalyticsData,
   comparePageRemoveAnalyticsEvent,
 } from "@/lib/compare-page-selection-cta-events";
-import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
+import {
+  claimCtaAnalyticsData,
+  claimCtaAnalyticsEvent,
+  claimCtaDestination,
+} from "@/lib/conversion-cta-events";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
 import { cn } from "@/lib/utils";
@@ -285,18 +291,24 @@ function ComparePage() {
             <p className="mt-2 text-sm text-amber-800">{emptyUi.invalidUrlHint}</p>
           ) : null}
           <div className="mt-5 flex justify-center gap-2">
-            <Link
-              to="/browse"
-              className="inline-flex h-9 items-center rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90"
-              onClick={() =>
-                trackEvent(
-                  comparePageEmptyEgressAnalyticsEvent(),
-                  comparePageEmptyEgressAnalyticsData("browse-directory"),
-                )
-              }
-            >
-              Browse the directory
-            </Link>
+            {(() => {
+              const destination = comparePageEmptyEgressDestination("browse-directory");
+              if (!destination) return null;
+              return (
+                <Link
+                  to={destination.to}
+                  className="inline-flex h-9 items-center rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90"
+                  onClick={() =>
+                    trackEvent(
+                      comparePageEmptyEgressAnalyticsEvent(),
+                      comparePageEmptyEgressAnalyticsData("browse-directory"),
+                    )
+                  }
+                >
+                  Browse the directory
+                </Link>
+              );
+            })()}
           </div>
           <div className="mt-6">
             <div className="eyebrow mb-2">Popular comparisons</div>
@@ -304,14 +316,25 @@ function ComparePage() {
               {emptyUi.popularComparisonLinks.map((comparison) => {
                 const refCount =
                   COMPARISONS.find((item) => item.slug === comparison.slug)?.refs.length ?? 0;
+                const curatedDestination = comparePageEmptyEgressDestination(
+                  "curated-page",
+                  comparison.slug,
+                );
+                const interactiveDestination =
+                  comparison.interactiveSearch &&
+                  comparePageEmptyEgressDestination(
+                    "interactive",
+                    comparison.interactiveSearch.ids,
+                  );
+                if (!curatedDestination || !("params" in curatedDestination)) return null;
                 return (
                   <div
                     key={comparison.slug}
                     className="inline-flex flex-wrap items-center justify-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5"
                   >
                     <Link
-                      to="/compare/$slug"
-                      params={{ slug: comparison.slug }}
+                      to={curatedDestination.to}
+                      params={curatedDestination.params}
                       className="text-xs text-ink-muted hover:text-ink"
                       onClick={() =>
                         trackEvent(
@@ -326,10 +349,10 @@ function ComparePage() {
                     >
                       {comparison.heading}
                     </Link>
-                    {comparison.interactiveSearch ? (
+                    {interactiveDestination && "search" in interactiveDestination ? (
                       <Link
-                        to="/compare"
-                        search={comparison.interactiveSearch}
+                        to={interactiveDestination.to}
+                        search={interactiveDestination.search}
                         className="text-[10px] text-ink-subtle hover:text-ink"
                         onClick={() =>
                           trackEvent(
@@ -455,14 +478,25 @@ function ComparePage() {
                   className="min-w-[260px] max-w-[320px] border-b border-r border-border bg-surface p-3 text-left align-top"
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <Link
-                      to="/entry/$category/$slug"
-                      params={{ category: e.category, slug: e.slug }}
-                      onClick={() => onOpenDossier(e)}
-                      className="font-display text-sm font-semibold text-ink hover:underline"
-                    >
-                      {e.title}
-                    </Link>
+                    {(() => {
+                      const destination = comparePanelEntryDestination(e.category, e.slug);
+                      if (!destination)
+                        return (
+                          <span className="font-display text-sm font-semibold text-ink">
+                            {e.title}
+                          </span>
+                        );
+                      return (
+                        <Link
+                          to={destination.to}
+                          params={destination.params}
+                          onClick={() => onOpenDossier(e)}
+                          className="font-display text-sm font-semibold text-ink hover:underline"
+                        >
+                          {e.title}
+                        </Link>
+                      );
+                    })()}
                     <button
                       type="button"
                       onClick={() => removeItem(e)}
@@ -473,14 +507,20 @@ function ComparePage() {
                     </button>
                   </div>
                   <p className="mt-1 line-clamp-2 text-xs text-ink-muted">{e.description}</p>
-                  <Link
-                    to="/entry/$category/$slug"
-                    params={{ category: e.category, slug: e.slug }}
-                    onClick={() => onOpenDossier(e)}
-                    className="mt-2 inline-flex items-center gap-1 text-[11px] text-ink-muted hover:text-ink"
-                  >
-                    Open dossier <ArrowRight className="h-3 w-3" />
-                  </Link>
+                  {(() => {
+                    const destination = comparePanelEntryDestination(e.category, e.slug);
+                    if (!destination) return null;
+                    return (
+                      <Link
+                        to={destination.to}
+                        params={destination.params}
+                        onClick={() => onOpenDossier(e)}
+                        className="mt-2 inline-flex items-center gap-1 text-[11px] text-ink-muted hover:text-ink"
+                      >
+                        Open dossier <ArrowRight className="h-3 w-3" />
+                      </Link>
+                    );
+                  })()}
                 </th>
               ))}
               {items.length < 4 && (
@@ -644,10 +684,12 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
 
   if (action.kind === "link") {
     if (action.id === "dossier") {
+      const destination = comparePanelEntryDestination(entry.category, entry.slug);
+      if (!destination) return null;
       return (
         <Link
-          to="/entry/$category/$slug"
-          params={{ category: entry.category, slug: entry.slug }}
+          to={destination.to}
+          params={destination.params}
           onClick={() => {
             if (action.analyticsEvent) {
               trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
@@ -662,9 +704,11 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
     }
 
     if (action.id === "claim") {
+      const destination = claimCtaDestination("claim");
+      if (!destination) return null;
       return (
         <Link
-          to="/claim"
+          to={destination.to}
           onClick={() => {
             trackEvent(
               claimCtaAnalyticsEvent(),

--- a/apps/web/src/routes/mcp-security-report.tsx
+++ b/apps/web/src/routes/mcp-security-report.tsx
@@ -28,9 +28,10 @@ import {
   mcpSecurityReportDistRowAnalyticsEvent,
   mcpSecurityReportEgressAnalyticsData,
   mcpSecurityReportEgressAnalyticsEvent,
+  mcpSecurityReportRouteDestination,
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
-  mcpSecurityReportStatBrowseSearch,
+  mcpSecurityReportStatDestination,
   type McpSecurityReportEgressDestination,
 } from "@/lib/mcp-security-report-page-cta-events";
 
@@ -243,42 +244,53 @@ function McpSecurityReportPage() {
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
-        <DataStat
-          icon={Boxes}
-          label="MCP servers"
-          value={TOTAL}
-          hint="analyzed"
-          to="/browse"
-          search={mcpSecurityReportStatBrowseSearch("total")}
-          onNavigate={() => trackStat("total")}
-        />
-        <DataStat
-          icon={ShieldCheck}
-          label="Safety notes"
-          value={NOTES.safety}
-          hint={`${pctOf(NOTES.safety, TOTAL)}% of total`}
-          to="/browse"
-          search={mcpSecurityReportStatBrowseSearch("safety-notes")}
-          onNavigate={() => trackStat("safety-notes")}
-        />
-        <DataStat
-          icon={Eye}
-          label="Privacy notes"
-          value={NOTES.privacy}
-          hint={`${pctOf(NOTES.privacy, TOTAL)}% of total`}
-          to="/browse"
-          search={mcpSecurityReportStatBrowseSearch("privacy-notes")}
-          onNavigate={() => trackStat("privacy-notes")}
-        />
-        <DataStat
-          icon={PackageCheck}
-          label="Verified package"
-          value={SUPPLY.packageVerified}
-          hint={`${pctOf(SUPPLY.packageVerified, TOTAL)}% of total`}
-          to="/browse"
-          search={mcpSecurityReportStatBrowseSearch("verified-package")}
-          onNavigate={() => trackStat("verified-package")}
-        />
+        {(
+          [
+            {
+              icon: Boxes,
+              label: "MCP servers",
+              value: TOTAL,
+              hint: "analyzed",
+              statId: "total" as const,
+            },
+            {
+              icon: ShieldCheck,
+              label: "Safety notes",
+              value: NOTES.safety,
+              hint: `${pctOf(NOTES.safety, TOTAL)}% of total`,
+              statId: "safety-notes" as const,
+            },
+            {
+              icon: Eye,
+              label: "Privacy notes",
+              value: NOTES.privacy,
+              hint: `${pctOf(NOTES.privacy, TOTAL)}% of total`,
+              statId: "privacy-notes" as const,
+            },
+            {
+              icon: PackageCheck,
+              label: "Verified package",
+              value: SUPPLY.packageVerified,
+              hint: `${pctOf(SUPPLY.packageVerified, TOTAL)}% of total`,
+              statId: "verified-package" as const,
+            },
+          ] as const
+        ).map((stat) => {
+          const destination = mcpSecurityReportStatDestination(stat.statId);
+          if (!destination) return null;
+          return (
+            <DataStat
+              key={stat.statId}
+              icon={stat.icon}
+              label={stat.label}
+              value={stat.value}
+              hint={stat.hint}
+              to={destination.to}
+              search={destination.search}
+              onNavigate={() => trackStat(stat.statId)}
+            />
+          );
+        })}
       </div>
 
       <DataSection
@@ -354,14 +366,20 @@ function McpSecurityReportPage() {
             <li>Prefer verified packages and checksummed artifacts over unpinned installs.</li>
             <li>
               Read the{" "}
-              <Link
-                to="/guides/$slug"
-                params={{ slug: "threat-model-mcp-servers-before-installation" }}
-                onClick={() => trackMcpSecurityReportEgress("threat-model-guide")}
-                className="text-ink underline-offset-2 hover:underline"
-              >
-                MCP threat-model guide
-              </Link>{" "}
+              {(() => {
+                const destination = mcpSecurityReportRouteDestination("threat-model-guide");
+                if (!destination || !("params" in destination)) return "MCP threat-model guide";
+                return (
+                  <Link
+                    to={destination.to}
+                    params={destination.params}
+                    onClick={() => trackMcpSecurityReportEgress("threat-model-guide")}
+                    className="text-ink underline-offset-2 hover:underline"
+                  >
+                    MCP threat-model guide
+                  </Link>
+                );
+              })()}{" "}
               before a team rollout.
             </li>
           </ul>
@@ -392,27 +410,39 @@ function McpSecurityReportPage() {
             heyclau.de/mcp-security-report
           </a>{" "}
           with the data-as-of date. See also the{" "}
-          <Link
-            to="/state-of-mcp-servers"
-            onClick={() => trackMcpSecurityReportEgress("state-of-mcp-servers")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            State of MCP Servers
-          </Link>{" "}
+          {(() => {
+            const destination = mcpSecurityReportRouteDestination("state-of-mcp-servers");
+            if (!destination || "params" in destination) return "State of MCP Servers";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackMcpSecurityReportEgress("state-of-mcp-servers")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                State of MCP Servers
+              </Link>
+            );
+          })()}{" "}
           report. Browse all{" "}
-          <Link
-            to="/$category"
-            params={{ category: "mcp" }}
-            onClick={() =>
-              trackEvent(
-                mcpSecurityReportCategoryBrowseAnalyticsEvent(),
-                mcpSecurityReportCategoryBrowseAnalyticsData(TOTAL),
-              )
-            }
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            MCP servers
-          </Link>
+          {(() => {
+            const destination = mcpSecurityReportRouteDestination("mcp-category");
+            if (!destination || !("params" in destination)) return "MCP servers";
+            return (
+              <Link
+                to={destination.to}
+                params={destination.params}
+                onClick={() =>
+                  trackEvent(
+                    mcpSecurityReportCategoryBrowseAnalyticsEvent(),
+                    mcpSecurityReportCategoryBrowseAnalyticsData(TOTAL),
+                  )
+                }
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                MCP servers
+              </Link>
+            );
+          })()}
           .
         </p>
       </section>

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -25,6 +25,7 @@ import {
   stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportEgressRouteDestination,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   stateReportStatDestination,
@@ -196,35 +197,53 @@ function StateOfAgentSkillsPage() {
             heyclau.de/state-of-agent-skills
           </a>{" "}
           with the data-as-of date. See also the{" "}
-          <Link
-            to="/state-of-claude-code-hooks"
-            onClick={() => trackStateReportEgress("claude-code-hooks")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            State of Claude Code Hooks
-          </Link>{" "}
+          {(() => {
+            const destination = stateReportEgressRouteDestination("claude-code-hooks");
+            if (!destination) return "State of Claude Code Hooks";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("claude-code-hooks")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                State of Claude Code Hooks
+              </Link>
+            );
+          })()}{" "}
           and the broader{" "}
-          <Link
-            to="/state-of-claude-tooling"
-            onClick={() => trackStateReportEgress("claude-tooling")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            State of Claude Tooling
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("claude-tooling");
+            if (!destination) return "State of Claude Tooling";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("claude-tooling")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                State of Claude Tooling
+              </Link>
+            );
+          })()}
           . Browse all{" "}
-          <Link
-            to="/$category"
-            params={{ category: "skills" }}
-            onClick={() =>
-              trackEvent(
-                stateReportCategoryBrowseAnalyticsEvent(),
-                stateReportCategoryBrowseAnalyticsData(REPORT_ID, "skills", MODEL.total, 0, 1),
-              )
-            }
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            skills
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("category", "skills");
+            if (!destination || !("params" in destination)) return "skills";
+            return (
+              <Link
+                to={destination.to}
+                params={destination.params}
+                onClick={() =>
+                  trackEvent(
+                    stateReportCategoryBrowseAnalyticsEvent(),
+                    stateReportCategoryBrowseAnalyticsData(REPORT_ID, "skills", MODEL.total, 0, 1),
+                  )
+                }
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                skills
+              </Link>
+            );
+          })()}
           .
         </p>
       </section>

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -25,6 +25,7 @@ import {
   stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportEgressRouteDestination,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   stateReportStatDestination,
@@ -196,35 +197,53 @@ function StateOfAiAgentsPage() {
             heyclau.de/state-of-ai-agents
           </a>{" "}
           with the data-as-of date. See also the{" "}
-          <Link
-            to="/state-of-agent-skills"
-            onClick={() => trackStateReportEgress("agent-skills")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            State of Agent Skills
-          </Link>{" "}
+          {(() => {
+            const destination = stateReportEgressRouteDestination("agent-skills");
+            if (!destination) return "State of Agent Skills";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("agent-skills")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                State of Agent Skills
+              </Link>
+            );
+          })()}{" "}
           and the broader{" "}
-          <Link
-            to="/state-of-claude-tooling"
-            onClick={() => trackStateReportEgress("claude-tooling")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            State of Claude Tooling
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("claude-tooling");
+            if (!destination) return "State of Claude Tooling";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("claude-tooling")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                State of Claude Tooling
+              </Link>
+            );
+          })()}
           . Browse all{" "}
-          <Link
-            to="/$category"
-            params={{ category: "agents" }}
-            onClick={() =>
-              trackEvent(
-                stateReportCategoryBrowseAnalyticsEvent(),
-                stateReportCategoryBrowseAnalyticsData(REPORT_ID, "agents", MODEL.total, 0, 1),
-              )
-            }
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            agents
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("category", "agents");
+            if (!destination || !("params" in destination)) return "agents";
+            return (
+              <Link
+                to={destination.to}
+                params={destination.params}
+                onClick={() =>
+                  trackEvent(
+                    stateReportCategoryBrowseAnalyticsEvent(),
+                    stateReportCategoryBrowseAnalyticsData(REPORT_ID, "agents", MODEL.total, 0, 1),
+                  )
+                }
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                agents
+              </Link>
+            );
+          })()}
           .
         </p>
       </section>

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -25,6 +25,7 @@ import {
   stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportEgressRouteDestination,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   stateReportStatDestination,
@@ -197,27 +198,39 @@ function StateOfClaudeCodeHooksPage() {
             heyclau.de/state-of-claude-code-hooks
           </a>{" "}
           with the data-as-of date. See also the broader{" "}
-          <Link
-            to="/state-of-claude-tooling"
-            onClick={() => trackStateReportEgress("claude-tooling")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            State of Claude Tooling
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("claude-tooling");
+            if (!destination) return "State of Claude Tooling";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("claude-tooling")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                State of Claude Tooling
+              </Link>
+            );
+          })()}
           . Browse all{" "}
-          <Link
-            to="/$category"
-            params={{ category: "hooks" }}
-            onClick={() =>
-              trackEvent(
-                stateReportCategoryBrowseAnalyticsEvent(),
-                stateReportCategoryBrowseAnalyticsData(REPORT_ID, "hooks", MODEL.total, 0, 1),
-              )
-            }
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            hooks
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("category", "hooks");
+            if (!destination || !("params" in destination)) return "hooks";
+            return (
+              <Link
+                to={destination.to}
+                params={destination.params}
+                onClick={() =>
+                  trackEvent(
+                    stateReportCategoryBrowseAnalyticsEvent(),
+                    stateReportCategoryBrowseAnalyticsData(REPORT_ID, "hooks", MODEL.total, 0, 1),
+                  )
+                }
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                hooks
+              </Link>
+            );
+          })()}
           .
         </p>
       </section>

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -23,6 +23,7 @@ import { NewsletterInline } from "@/components/newsletter-inline";
 import { ReportDownloads } from "@/components/report-downloads";
 import { trackEvent } from "@/lib/analytics";
 import {
+  insightsPageEntryDestination,
   stateReportEntryAnalyticsData,
   stateReportEntryAnalyticsEvent,
 } from "@/lib/insights-page-entry-cta-events";
@@ -35,6 +36,7 @@ import {
   stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportEgressRouteDestination,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   stateReportStatDestination,
@@ -315,13 +317,19 @@ function StateOfClaudeToolingPage() {
           <h2 className="h-display-2 text-ink text-balance">Trust-level distribution</h2>
           <p className="mt-2 text-sm text-ink-muted">
             Every entry carries a trust signal you can verify yourself.{" "}
-            <Link
-              to="/quality"
-              onClick={() => trackStateReportEgress("quality")}
-              className="text-ink underline-offset-2 hover:underline"
-            >
-              See how we score.
-            </Link>
+            {(() => {
+              const destination = stateReportEgressRouteDestination("quality");
+              if (!destination) return "See how we score.";
+              return (
+                <Link
+                  to={destination.to}
+                  onClick={() => trackStateReportEgress("quality")}
+                  className="text-ink underline-offset-2 hover:underline"
+                >
+                  See how we score.
+                </Link>
+              );
+            })()}
           </p>
           <div className="mt-4">
             <DistTable
@@ -400,25 +408,35 @@ function StateOfClaudeToolingPage() {
               key={`${e.category}/${e.slug}`}
               className="flex items-center justify-between gap-3 border-b border-border px-5 py-3 last:border-0"
             >
-              <Link
-                to="/entry/$category/$slug"
-                params={{ category: e.category, slug: e.slug }}
-                onClick={() =>
-                  trackEvent(
-                    stateReportEntryAnalyticsEvent(),
-                    stateReportEntryAnalyticsData(
-                      e.category,
-                      e.slug,
-                      "claude-tooling",
-                      rowIndex,
-                      RECENT_ADDITIONS.length,
-                    ),
-                  )
+              {(() => {
+                const destination = insightsPageEntryDestination(e.category, e.slug);
+                if (!destination) {
+                  return (
+                    <span className="min-w-0 truncate text-sm font-medium text-ink">{e.title}</span>
+                  );
                 }
-                className="min-w-0 truncate text-sm font-medium text-ink hover:underline"
-              >
-                {e.title}
-              </Link>
+                return (
+                  <Link
+                    to={destination.to}
+                    params={destination.params}
+                    onClick={() =>
+                      trackEvent(
+                        stateReportEntryAnalyticsEvent(),
+                        stateReportEntryAnalyticsData(
+                          e.category,
+                          e.slug,
+                          "claude-tooling",
+                          rowIndex,
+                          RECENT_ADDITIONS.length,
+                        ),
+                      )
+                    }
+                    className="min-w-0 truncate text-sm font-medium text-ink hover:underline"
+                  >
+                    {e.title}
+                  </Link>
+                );
+              })()}
               <div className="flex shrink-0 items-center gap-3">
                 <span className="rounded-md border border-border bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-ink-subtle">
                   {e.category}
@@ -450,21 +468,33 @@ function StateOfClaudeToolingPage() {
             heyclau.de/state-of-claude-tooling
           </a>{" "}
           and reference the data-as-of date. Browse the underlying catalog on the{" "}
-          <Link
-            to="/browse"
-            onClick={() => trackStateReportEgress("browse")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            directory
-          </Link>{" "}
+          {(() => {
+            const destination = stateReportEgressRouteDestination("browse");
+            if (!destination) return "directory";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("browse")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                directory
+              </Link>
+            );
+          })()}{" "}
           or review the{" "}
-          <Link
-            to="/quality"
-            onClick={() => trackStateReportEgress("quality")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            quality methodology
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("quality");
+            if (!destination) return "quality methodology";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("quality")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                quality methodology
+              </Link>
+            );
+          })()}
           .
         </p>
       </section>

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/data-report-drilldown-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
+  insightsPageEntryDestination,
   stateReportEntryAnalyticsData,
   stateReportEntryAnalyticsEvent,
 } from "@/lib/insights-page-entry-cta-events";
@@ -40,6 +41,7 @@ import {
   stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportEgressRouteDestination,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   stateReportStatDestination,
@@ -329,13 +331,19 @@ function StateOfMcpServersPage() {
           <h2 className="h-display-2 text-ink text-balance">Trust-level distribution</h2>
           <p className="mt-2 text-sm text-ink-muted">
             Every server carries a trust signal you can verify.{" "}
-            <Link
-              to="/quality"
-              onClick={() => trackStateReportEgress("quality")}
-              className="text-ink underline-offset-2 hover:underline"
-            >
-              See how we score.
-            </Link>
+            {(() => {
+              const destination = stateReportEgressRouteDestination("quality");
+              if (!destination) return "See how we score.";
+              return (
+                <Link
+                  to={destination.to}
+                  onClick={() => trackStateReportEgress("quality")}
+                  className="text-ink underline-offset-2 hover:underline"
+                >
+                  See how we score.
+                </Link>
+              );
+            })()}
           </p>
           <div className="mt-4">
             <DistTable
@@ -403,25 +411,34 @@ function StateOfMcpServersPage() {
               key={`${e.category}/${e.slug}`}
               className="flex items-center justify-between gap-3 border-b border-border px-5 py-3 last:border-0"
             >
-              <Link
-                to="/entry/$category/$slug"
-                params={{ category: e.category, slug: e.slug }}
-                onClick={() =>
-                  trackEvent(
-                    stateReportEntryAnalyticsEvent(),
-                    stateReportEntryAnalyticsData(
-                      e.category,
-                      e.slug,
-                      "mcp-servers",
-                      rowIndex,
-                      RECENT.length,
-                    ),
-                  )
-                }
-                className="min-w-0 truncate text-sm font-medium text-ink hover:underline"
-              >
-                {e.title}
-              </Link>
+              {(() => {
+                const destination = insightsPageEntryDestination(e.category, e.slug);
+                if (!destination)
+                  return (
+                    <span className="min-w-0 truncate text-sm font-medium text-ink">{e.title}</span>
+                  );
+                return (
+                  <Link
+                    to={destination.to}
+                    params={destination.params}
+                    onClick={() =>
+                      trackEvent(
+                        stateReportEntryAnalyticsEvent(),
+                        stateReportEntryAnalyticsData(
+                          e.category,
+                          e.slug,
+                          "mcp-servers",
+                          rowIndex,
+                          RECENT.length,
+                        ),
+                      )
+                    }
+                    className="min-w-0 truncate text-sm font-medium text-ink hover:underline"
+                  >
+                    {e.title}
+                  </Link>
+                );
+              })()}
               <span className="shrink-0 font-mono text-xs text-ink-subtle">
                 {String(e.dateAdded).slice(0, 10)}
               </span>
@@ -449,35 +466,53 @@ function StateOfMcpServersPage() {
             heyclau.de/state-of-mcp-servers
           </a>{" "}
           with the data-as-of date. See also the{" "}
-          <Link
-            to="/mcp-security-report"
-            onClick={() => trackStateReportEgress("mcp-security-report")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            MCP Security &amp; Privacy Report
-          </Link>{" "}
+          {(() => {
+            const destination = stateReportEgressRouteDestination("mcp-security-report");
+            if (!destination) return "MCP Security & Privacy Report";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("mcp-security-report")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                MCP Security &amp; Privacy Report
+              </Link>
+            );
+          })()}{" "}
           and the broader{" "}
-          <Link
-            to="/state-of-claude-tooling"
-            onClick={() => trackStateReportEgress("claude-tooling")}
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            State of Claude Tooling
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("claude-tooling");
+            if (!destination) return "State of Claude Tooling";
+            return (
+              <Link
+                to={destination.to}
+                onClick={() => trackStateReportEgress("claude-tooling")}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                State of Claude Tooling
+              </Link>
+            );
+          })()}
           . Browse all{" "}
-          <Link
-            to="/$category"
-            params={{ category: "mcp" }}
-            onClick={() =>
-              trackEvent(
-                stateReportCategoryBrowseAnalyticsEvent(),
-                stateReportCategoryBrowseAnalyticsData(REPORT_ID, "mcp", TOTAL, 0, 1),
-              )
-            }
-            className="text-ink underline-offset-2 hover:underline"
-          >
-            MCP servers
-          </Link>
+          {(() => {
+            const destination = stateReportEgressRouteDestination("category", "mcp");
+            if (!destination || !("params" in destination)) return "MCP servers";
+            return (
+              <Link
+                to={destination.to}
+                params={destination.params}
+                onClick={() =>
+                  trackEvent(
+                    stateReportCategoryBrowseAnalyticsEvent(),
+                    stateReportCategoryBrowseAnalyticsData(REPORT_ID, "mcp", TOTAL, 0, 1),
+                  )
+                }
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                MCP servers
+              </Link>
+            );
+          })()}
           .
         </p>
       </section>

--- a/tests/compare-curated-egress-cta-events-lib.test.ts
+++ b/tests/compare-curated-egress-cta-events-lib.test.ts
@@ -4,6 +4,7 @@ import {
   COMPARE_CURATED_PAGE_SURFACE,
   compareCuratedEgressAnalyticsData,
   compareCuratedEgressAnalyticsEvent,
+  compareCuratedEgressDestination,
   compareCuratedNotFoundEgressAnalyticsData,
   compareCuratedNotFoundEgressAnalyticsEvent,
 } from "@/lib/compare-curated-egress-cta-events-lib";
@@ -25,5 +26,17 @@ describe("compare curated egress cta events lib", () => {
     expect(compareCuratedNotFoundEgressAnalyticsData()).toEqual({
       surface: COMPARE_CURATED_NOTFOUND_SURFACE,
     });
+  });
+
+  it("maps compare curated egress destinations", () => {
+    expect(compareCuratedEgressDestination("interactive", "a,b")).toEqual({
+      to: "/compare",
+      search: { ids: "a,b" },
+    });
+    expect(compareCuratedEgressDestination("interactive", "")).toBeNull();
+    expect(compareCuratedEgressDestination("not-found")).toEqual({
+      to: "/compare",
+    });
+    expect(compareCuratedEgressDestination("unknown")).toBeNull();
   });
 });

--- a/tests/compare-page-empty-egress-cta-events-lib.test.ts
+++ b/tests/compare-page-empty-egress-cta-events-lib.test.ts
@@ -3,6 +3,7 @@ import {
   COMPARE_PAGE_EMPTY_SURFACE,
   comparePageEmptyEgressAnalyticsData,
   comparePageEmptyEgressAnalyticsEvent,
+  comparePageEmptyEgressDestination,
 } from "@/lib/compare-page-empty-egress-cta-events-lib";
 
 describe("compare page empty egress cta events lib", () => {
@@ -30,5 +31,26 @@ describe("compare page empty egress cta events lib", () => {
       surface: COMPARE_PAGE_EMPTY_SURFACE,
       linkKind: "browse-directory",
     });
+  });
+
+  it("maps compare page empty egress destinations", () => {
+    expect(comparePageEmptyEgressDestination("browse-directory")).toEqual({
+      to: "/browse",
+    });
+    expect(
+      comparePageEmptyEgressDestination("curated-page", "top-mcp"),
+    ).toEqual({
+      to: "/compare/$slug",
+      params: { slug: "top-mcp" },
+    });
+    expect(comparePageEmptyEgressDestination("curated-page", "")).toBeNull();
+    expect(
+      comparePageEmptyEgressDestination("interactive", "mcp/a,mcp/b"),
+    ).toEqual({
+      to: "/compare",
+      search: { ids: "mcp/a,mcp/b" },
+    });
+    expect(comparePageEmptyEgressDestination("interactive", "  ")).toBeNull();
+    expect(comparePageEmptyEgressDestination("unknown")).toBeNull();
   });
 });

--- a/tests/compare-panel-entry-cta-events-lib.test.ts
+++ b/tests/compare-panel-entry-cta-events-lib.test.ts
@@ -18,6 +18,7 @@ import {
   compareRolloutReadinessEntryAnalyticsEvent,
   compareScenarioRankingEntryAnalyticsData,
   compareScenarioRankingEntryAnalyticsEvent,
+  comparePanelEntryDestination,
   parseComparePanelEntryRef,
 } from "@/lib/compare-panel-entry-cta-events-lib";
 
@@ -162,6 +163,12 @@ describe("compare panel entry cta events lib", () => {
       slug: "browser",
     });
     expect(parseComparePanelEntryRef("invalid")).toBeNull();
+    expect(comparePanelEntryDestination("mcp", "browser")).toEqual({
+      to: "/entry/$category/$slug",
+      params: { category: "mcp", slug: "browser" },
+    });
+    expect(comparePanelEntryDestination("", "browser")).toBeNull();
+    expect(comparePanelEntryDestination("mcp", "")).toBeNull();
     expect(comparePageEvidenceGapsSurface()).toBe("compare-page-evidence-gaps");
     expect(compareDrawerEvidenceGapsSurface()).toBe(
       "compare-drawer-evidence-gaps",

--- a/tests/conversion-cta-events-lib.test.ts
+++ b/tests/conversion-cta-events-lib.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   claimCtaAnalyticsData,
   claimCtaAnalyticsEvent,
+  claimCtaDestination,
   newsletterSubscribeAnalyticsData,
   newsletterSubscribeAnalyticsEvent,
   sanitizeNewsletterSource,
@@ -27,6 +28,11 @@ describe("conversion cta events lib", () => {
       surface: "compare-page",
       entry: "mcp/browser",
     });
+  });
+
+  it("maps claim CTA destinations", () => {
+    expect(claimCtaDestination("claim")).toEqual({ to: "/claim" });
+    expect(claimCtaDestination("unknown")).toBeNull();
   });
 
   it("builds newsletter subscribe analytics without email or PII", () => {

--- a/tests/insights-page-entry-cta-events-lib.test.ts
+++ b/tests/insights-page-entry-cta-events-lib.test.ts
@@ -7,6 +7,7 @@ import {
   VALIDATORS_RECENT_REVIEWED_SURFACE,
   contributorProfileEntryAnalyticsData,
   contributorProfileEntryAnalyticsEvent,
+  insightsPageEntryDestination,
   qualityQueueEntryAnalyticsData,
   qualityQueueEntryAnalyticsEvent,
   stateReportEntryAnalyticsData,
@@ -99,5 +100,14 @@ describe("insights page entry cta events lib", () => {
       rowIndex: 0,
       rowCount: 10,
     });
+  });
+
+  it("maps insights page entry destinations", () => {
+    expect(insightsPageEntryDestination("mcp", "browser")).toEqual({
+      to: "/entry/$category/$slug",
+      params: { category: "mcp", slug: "browser" },
+    });
+    expect(insightsPageEntryDestination("", "browser")).toBeNull();
+    expect(insightsPageEntryDestination("mcp", "")).toBeNull();
   });
 });

--- a/tests/mcp-security-report-page-cta-events-lib.test.ts
+++ b/tests/mcp-security-report-page-cta-events-lib.test.ts
@@ -12,6 +12,8 @@ import {
   mcpSecurityReportStatAnalyticsData,
   mcpSecurityReportStatAnalyticsEvent,
   mcpSecurityReportStatBrowseSearch,
+  mcpSecurityReportStatDestination,
+  mcpSecurityReportRouteDestination,
 } from "@/lib/mcp-security-report-page-cta-events-lib";
 
 describe("mcp security report page cta events lib", () => {
@@ -76,5 +78,29 @@ describe("mcp security report page cta events lib", () => {
       category: "mcp",
       signal: "trusted-package",
     });
+  });
+
+  it("maps mcp security report destinations", () => {
+    expect(mcpSecurityReportStatDestination("total")).toEqual({
+      to: "/browse",
+      search: { category: "mcp" },
+    });
+    expect(mcpSecurityReportStatDestination("safety-notes")).toEqual({
+      to: "/browse",
+      search: { category: "mcp", signal: "safety-notes" },
+    });
+    expect(mcpSecurityReportStatDestination("unknown")).toBeNull();
+    expect(mcpSecurityReportRouteDestination("threat-model-guide")).toEqual({
+      to: "/guides/$slug",
+      params: { slug: "threat-model-mcp-servers-before-installation" },
+    });
+    expect(mcpSecurityReportRouteDestination("state-of-mcp-servers")).toEqual({
+      to: "/state-of-mcp-servers",
+    });
+    expect(mcpSecurityReportRouteDestination("mcp-category")).toEqual({
+      to: "/$category",
+      params: { category: "mcp" },
+    });
+    expect(mcpSecurityReportRouteDestination("unknown")).toBeNull();
   });
 });

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -8,6 +8,7 @@ import {
   stateReportDistRowAnalyticsEvent,
   stateReportEgressAnalyticsData,
   stateReportEgressAnalyticsEvent,
+  stateReportEgressRouteDestination,
   stateReportStatAnalyticsData,
   stateReportStatAnalyticsEvent,
   stateReportStatDestination,
@@ -197,5 +198,38 @@ describe("state report page cta events lib", () => {
     expect(stateReportStatDestination("agent-skills", "unknown")).toBeNull();
 
     expect(stateReportStatDestination("unknown-report", "total")).toBeNull();
+  });
+
+  it("maps state report egress route destinations", () => {
+    expect(stateReportEgressRouteDestination("browse")).toEqual({
+      to: "/browse",
+    });
+    expect(stateReportEgressRouteDestination("quality")).toEqual({
+      to: "/quality",
+    });
+    expect(stateReportEgressRouteDestination("mcp-security-report")).toEqual({
+      to: "/mcp-security-report",
+    });
+    expect(stateReportEgressRouteDestination("claude-tooling")).toEqual({
+      to: "/state-of-claude-tooling",
+    });
+    expect(stateReportEgressRouteDestination("mcp-servers")).toEqual({
+      to: "/state-of-mcp-servers",
+    });
+    expect(stateReportEgressRouteDestination("claude-code-hooks")).toEqual({
+      to: "/state-of-claude-code-hooks",
+    });
+    expect(stateReportEgressRouteDestination("agent-skills")).toEqual({
+      to: "/state-of-agent-skills",
+    });
+    expect(stateReportEgressRouteDestination("ai-agents")).toEqual({
+      to: "/state-of-ai-agents",
+    });
+    expect(stateReportEgressRouteDestination("category", "mcp")).toEqual({
+      to: "/$category",
+      params: { category: "mcp" },
+    });
+    expect(stateReportEgressRouteDestination("category", "")).toBeNull();
+    expect(stateReportEgressRouteDestination("unknown")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Add covered destination helpers for compare empty/curated/panel entry and claim CTAs
- Add MCP security stat/route destinations and shared state-report egress + insights entry destinations
- Wire compare index/detail, MCP security report, and all public state reports through those helpers
- Extend Vitest coverage for every destination arm including empty/unknown → null

## Test plan
- [x] vitest for compare/conversion/mcp-security/state-report/insights cta-events-lib suites
- [x] prettier + trunk check --upstream origin/main
- [ ] CI: codecov patch/project, validate-ci/web, required-pr-gate

Refs #550

Made with [Cursor](https://cursor.com)