### PR TITLE
docs(skill): require verifying against synced upstream before closing/filing

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -74,6 +74,15 @@ partial work open. Given this repo starts with a near-empty gittensor backlog, m
 little or nothing to sweep here until the backlog this skill builds has had time to accumulate
 real activity — that's expected, not a sign the check is broken.
 
+**Verify against synced upstream, not a stale local checkout.** Before treating any local grep/read
+as evidence that an issue's described work does or doesn't exist, confirm the code you're reading
+matches the default branch's current tip — fetch and fast-forward the checkout (or use a disposable
+worktree off `origin/main` if the primary checkout is dirty or has unpushed work on another branch)
+before doing any verification. A checkout that's merely *clean* isn't the same as *current* — a
+stale-but-clean checkout silently produced false "already done"/"not done" conclusions in the sibling
+loopover/metagraphed repos' gardening runs on 2026-07-17/18, causing duplicate issues to be filed for
+already-shipped work. Confirm sync every run; never assume a previous run's freshness carried over.
+
 Also check issue #550 (the growth-sprint umbrella) and any other checklist-style tracker each run:
 sync stale checkboxes against real child-issue state, same as the sibling repos' Pass 1. Do not
 add new child issues to #550's shallow analytics-wiring pattern (see above) even if asked to "keep


### PR DESCRIPTION
## Summary
- A local checkout that's merely clean isn't the same as current — the gardening automation was verifying "does this issue's described work already exist" against whatever the local checkout happened to have, with no check that it matched `origin/main`'s current tip.
- Confirmed 2026-07-17/18: a stale-but-clean checkout produced false "already done"/"not done" conclusions in sibling loopover/metagraphed gardening runs, causing duplicate issues to be filed for already-shipped work.
- Adds an explicit rule to Pass 1: fetch + fast-forward (or a disposable worktree off `origin/main` if the checkout is dirty/has unpushed work) before any verification grep, every run.

## Test plan
- [x] `npx prettier --check .claude/skills/contributor-pipeline-gardening/SKILL.md` passes
- Doc-only change, no code/schema/CI-relevant paths touched