### PR TITLE
feat(web): map skills verification and hooks complexity DistTable drilldowns

### DIFF
--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -41,6 +41,11 @@ const DISCLOSURE_SIGNAL_BY_LABEL: Record<string, string> = {
   "Privacy only": "privacy-notes",
 };
 
+const VERIFICATION_SIGNAL_BY_LABEL: Record<string, string> = {
+  Validated: "reviewed",
+  Production: "reviewed",
+};
+
 const SUPPLY_SIGNAL_BY_LABEL: Record<string, string> = {
   "Verified package": "trusted-package",
   "Checksummed download": "checksums",
@@ -77,6 +82,10 @@ export function notesSignalFromLabel(label: string): string | undefined {
 
 export function disclosureSignalFromLabel(label: string): string | undefined {
   return DISCLOSURE_SIGNAL_BY_LABEL[label];
+}
+
+export function verificationSignalFromLabel(label: string): string | undefined {
+  return VERIFICATION_SIGNAL_BY_LABEL[label];
 }
 
 export function supplyChainSignalFromLabel(label: string): string | undefined {
@@ -178,6 +187,25 @@ export function withNotesSignalDrilldown(rows: DistRow[], category?: string): Di
 export function withDisclosureDrilldown(rows: DistRow[], category: string): DistRow[] {
   return rows.map((row) => {
     const signal = disclosureSignalFromLabel(row.label);
+    if (!signal) {
+      return {
+        ...row,
+        rowKey: row.rowKey ?? row.label,
+        drilldown: browseDrilldown({ category }),
+      };
+    }
+    return {
+      ...row,
+      rowKey: signal,
+      drilldown: browseDrilldown({ category, signal }),
+    };
+  });
+}
+
+/** Map skill verification buckets to reviewed browse signal (Draft stays category-only). */
+export function withVerificationDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => {
+    const signal = verificationSignalFromLabel(row.label);
     if (!signal) {
       return {
         ...row,
@@ -332,10 +360,12 @@ export function withReportDimensionDrilldown(
       return withTagDrilldown(rows);
     case "disclosure":
       return withDisclosureDrilldown(rows, category);
+    case "verification":
+      return withVerificationDrilldown(rows, category);
+    case "complexity":
     case "prerequisites":
     case "skill-type":
     case "maturity":
-    case "verification":
     case "hook-events":
       return withCategoryBrowseDrilldown(rows, category);
     default:

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -6,6 +6,7 @@ import {
   installMethodKeyFromLabel,
   notesSignalFromLabel,
   disclosureSignalFromLabel,
+  verificationSignalFromLabel,
   platformFromLabel,
   sourceStatusFromLabel,
   supplyChainSignalFromLabel,
@@ -14,6 +15,7 @@ import {
   trustLevelFromLabel,
   withCategoryHubDrilldown,
   withDisclosureDrilldown,
+  withVerificationDrilldown,
   withDocsCoverageDrilldown,
   withHostingDrilldown,
   withInstallMethodDrilldown,
@@ -53,6 +55,9 @@ describe("data report drilldown lib", () => {
     expect(disclosureSignalFromLabel("Safety only")).toBe("safety-notes");
     expect(disclosureSignalFromLabel("Privacy only")).toBe("privacy-notes");
     expect(disclosureSignalFromLabel("Neither documented")).toBeUndefined();
+    expect(verificationSignalFromLabel("Validated")).toBe("reviewed");
+    expect(verificationSignalFromLabel("Production")).toBe("reviewed");
+    expect(verificationSignalFromLabel("Draft")).toBeUndefined();
   });
 
   it("attaches browse, tag, and category drilldowns with privacy-light keys", () => {
@@ -579,10 +584,36 @@ describe("data report drilldown lib", () => {
     expect(
       withReportDimensionDrilldown(
         "verification",
-        [{ label: "x", count: 1, pct: 100 }],
+        [{ label: "Validated", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({
+      kind: "browse",
+      search: { category: "skills", signal: "reviewed" },
+    });
+    expect(
+      withReportDimensionDrilldown(
+        "verification",
+        [{ label: "Draft", count: 1, pct: 100 }],
         "skills",
       )[0]?.drilldown,
     ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withVerificationDrilldown(
+        [{ label: "Production", count: 2, pct: 40 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({
+      kind: "browse",
+      search: { category: "skills", signal: "reviewed" },
+    });
+    expect(
+      withReportDimensionDrilldown(
+        "complexity",
+        [{ label: "Simple (score 1–2)", count: 1, pct: 100 }],
+        "hooks",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "hooks" } });
     expect(
       withReportDimensionDrilldown(
         "hook-events",


### PR DESCRIPTION
## Summary
- Map skills verification DistTable Validated/Production rows to browse `signal=reviewed` (Draft stays category-only)
- Enable hooks complexity DistTable browse drilldown (was display-only)

## Test plan
- [ ] Open /state-of-agent-skills verification DistTable and click Validated / Production / Draft
- [ ] Open /state-of-claude-code-hooks complexity DistTable and click a row
- [ ] Confirm browse destinations and privacy-light dist-row analytics

Refs #550

Made with [Cursor](https://cursor.com)