### PR TITLE
feat(web): add resource card trust badge browse analytics

### DIFF
--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -22,6 +22,8 @@ import { recordIntentEvent } from "@/lib/intent-event-client";
 import {
   resourceCardCategoryBrowseAnalyticsData,
   resourceCardCategoryBrowseAnalyticsEvent,
+  resourceCardTrustBrowseAnalyticsData,
+  resourceCardTrustBrowseAnalyticsEvent,
   resourceCardCompareAnalyticsData,
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
@@ -226,7 +228,16 @@ function ResourceCardInner({
           {entry.category}
         </CategoryPill>
         <SourceBadge status={entry.source} asLink surface={analyticsSurface} />
-        <TrustBadge level={entry.trust} />
+        <TrustBadge
+          level={entry.trust}
+          asLink
+          onNavigate={() =>
+            trackEvent(
+              resourceCardTrustBrowseAnalyticsEvent(),
+              resourceCardTrustBrowseAnalyticsData(entry.trust, analyticsSurface),
+            )
+          }
+        />
         <span className="hidden min-w-0 shrink md:inline-flex">
           <LazyEntryAuthorAttribution entry={entry} className="truncate text-xs text-ink-subtle" />
         </span>
@@ -293,7 +304,16 @@ function ResourceCardInner({
             >
               {entry.category}
             </CategoryPill>
-            <TrustBadge level={entry.trust} />
+            <TrustBadge
+              level={entry.trust}
+              asLink
+              onNavigate={() =>
+                trackEvent(
+                  resourceCardTrustBrowseAnalyticsEvent(),
+                  resourceCardTrustBrowseAnalyticsData(entry.trust, analyticsSurface),
+                )
+              }
+            />
             <SourceBadge status={entry.source} asLink surface={analyticsSurface} />
             <InstallRiskBadge entry={entry} size="xs" asLink surface={analyticsSurface} />
           </div>
@@ -374,7 +394,16 @@ function ResourceCardInner({
             >
               {entry.category}
             </CategoryPill>
-            <TrustBadge level={entry.trust} />
+            <TrustBadge
+              level={entry.trust}
+              asLink
+              onNavigate={() =>
+                trackEvent(
+                  resourceCardTrustBrowseAnalyticsEvent(),
+                  resourceCardTrustBrowseAnalyticsData(entry.trust, analyticsSurface),
+                )
+              }
+            />
             <SourceBadge status={entry.source} asLink surface={analyticsSurface} />
             <InstallRiskBadge entry={entry} size="xs" asLink surface={analyticsSurface} />
             {entry.platforms.slice(0, 2).map((p) => (

--- a/apps/web/src/lib/resource-card-cta-events-lib.ts
+++ b/apps/web/src/lib/resource-card-cta-events-lib.ts
@@ -139,17 +139,37 @@ export function resourceCardCategoryBrowseAnalyticsData(
   };
 }
 
-export type ResourceCardBadgeKind = "source" | "install-risk" | "notes" | "platform" | "category";
+export function resourceCardTrustBrowseAnalyticsEvent(): string {
+  return "browse_card_trust_click";
+}
+
+export function resourceCardTrustBrowseAnalyticsData(
+  trust: string,
+  surface: ResourceCardSurface = RESOURCE_CARD_SURFACE,
+) {
+  return {
+    surface,
+    trust,
+  };
+}
+
+export type ResourceCardBadgeKind =
+  | "source"
+  | "install-risk"
+  | "notes"
+  | "platform"
+  | "category"
+  | "trust";
 
 /** Resolve which secondary badge kinds a card variant can expose as browse egress. */
 export function resourceCardBadgeKinds(variant: string): ResourceCardBadgeKind[] {
   switch (variant) {
     case "grid":
-      return ["category", "source", "install-risk", "notes"];
+      return ["category", "trust", "source", "install-risk", "notes"];
     case "row":
-      return ["category", "source", "install-risk", "platform", "notes"];
+      return ["category", "trust", "source", "install-risk", "platform", "notes"];
     case "compact":
-      return ["category", "source"];
+      return ["category", "source", "trust"];
     default:
       return [];
   }

--- a/apps/web/src/lib/resource-card-cta-events.ts
+++ b/apps/web/src/lib/resource-card-cta-events.ts
@@ -6,6 +6,8 @@ export {
   resourceCardBadgeKinds,
   resourceCardCategoryBrowseAnalyticsData,
   resourceCardCategoryBrowseAnalyticsEvent,
+  resourceCardTrustBrowseAnalyticsData,
+  resourceCardTrustBrowseAnalyticsEvent,
   resourceCardCompareAnalyticsData,
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,

--- a/tests/resource-card-cta-events-lib.test.ts
+++ b/tests/resource-card-cta-events-lib.test.ts
@@ -3,6 +3,8 @@ import {
   resourceCardBadgeKinds,
   resourceCardCategoryBrowseAnalyticsData,
   resourceCardCategoryBrowseAnalyticsEvent,
+  resourceCardTrustBrowseAnalyticsData,
+  resourceCardTrustBrowseAnalyticsEvent,
   resourceCardCompareAnalyticsData,
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
@@ -131,20 +133,39 @@ describe("resource card cta events lib", () => {
       surface: "home-recent",
       category: "hooks",
     });
+    expect(resourceCardTrustBrowseAnalyticsEvent()).toBe(
+      "browse_card_trust_click",
+    );
+    expect(resourceCardTrustBrowseAnalyticsData("trusted")).toEqual({
+      surface: "browse-card",
+      trust: "trusted",
+    });
+    expect(
+      resourceCardTrustBrowseAnalyticsData("review", "browse-grid"),
+    ).toEqual({
+      surface: "browse-grid",
+      trust: "review",
+    });
     expect(resourceCardBadgeKinds("grid")).toEqual([
       "category",
+      "trust",
       "source",
       "install-risk",
       "notes",
     ]);
     expect(resourceCardBadgeKinds("row")).toEqual([
       "category",
+      "trust",
       "source",
       "install-risk",
       "platform",
       "notes",
     ]);
-    expect(resourceCardBadgeKinds("compact")).toEqual(["category", "source"]);
+    expect(resourceCardBadgeKinds("compact")).toEqual([
+      "category",
+      "source",
+      "trust",
+    ]);
     expect(resourceCardBadgeKinds("unknown")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Promote ResourceCard TrustBadge to asLink browse egress outside entry Links (compact/grid/row)
- Add `browse_card_trust_click` helpers and include trust in badge-kind maps

## Test plan
- [ ] Browse/home hub cards: click Trust badge on compact, grid, and row variants
- [ ] Confirm browse opens with matching trust filter
- [ ] Confirm analytics payload is privacy-light (surface + trust)
- [ ] Confirm no nested Links (badge sits outside entry title Link)

Refs #550

Made with [Cursor](https://cursor.com)