### PR TITLE
fix(feed): use newest pubDate for trending feed's lastBuildDate

### DIFF
--- a/apps/web/src/lib/feed-items-lib.ts
+++ b/apps/web/src/lib/feed-items-lib.ts
@@ -11,5 +11,6 @@ export function absolutizeFeedLinks<T extends { link: string }>(items: T[], base
 
 /** The newest item's pubDate, or the epoch ISO string for an empty feed. */
 export function feedLastBuilt(items: Array<{ pubDate: string }>): string {
-  return items.length ? items[0].pubDate : new Date(0).toISOString();
+  if (items.length === 0) return new Date(0).toISOString();
+  return items.reduce((acc, item) => (item.pubDate > acc ? item.pubDate : acc), items[0].pubDate);
 }

--- a/tests/feed-items-lib.test.ts
+++ b/tests/feed-items-lib.test.ts
@@ -34,6 +34,16 @@ describe("feedLastBuilt", () => {
     ).toBe("2026-02-02");
   });
 
+  it("returns the newest item's pubDate when the array is not sorted by date", () => {
+    expect(
+      feedLastBuilt([
+        { pubDate: "2026-01-01" },
+        { pubDate: "2026-02-02" },
+        { pubDate: "2026-01-15" },
+      ]),
+    ).toBe("2026-02-02");
+  });
+
   it("falls back to the epoch ISO string for an empty feed", () => {
     expect(feedLastBuilt([])).toBe(new Date(0).toISOString());
   });

--- a/tests/feeds-trending-items.test.ts
+++ b/tests/feeds-trending-items.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/growth-surfaces", () => ({
 }));
 
 import { trendingItems } from "@/lib/feeds";
+import { feedLastBuilt } from "@/lib/feed-items-lib";
 
 describe("feeds trendingItems branch coverage", () => {
   beforeEach(() => {
@@ -71,5 +72,35 @@ describe("feeds trendingItems branch coverage", () => {
 
     const items = await trendingItems();
     expect(items[0]?.pubDate).toBe(new Date(0).toISOString());
+  });
+
+  it("returns the newest pubDate as lastBuildDate when the highest-scoring item is not the newest", async () => {
+    const oldItem = {
+      category: "mcp",
+      slug: "old-item",
+      title: "Old Item",
+      description: "Old",
+      dateAdded: "2026-01-01T00:00:00.000Z",
+    };
+    const newItem = {
+      category: "mcp",
+      slug: "new-item",
+      title: "New Item",
+      description: "New",
+      dateAdded: "2026-01-02T00:00:00.000Z",
+    };
+
+    // oldItem is first in the trending list (higher score) but has an older date
+    getGrowthSurfaces.mockResolvedValue({
+      communitySignalsAvailable: true,
+      votesAvailable: false,
+      intentEventsAvailable: false,
+      communityTrending: [oldItem, newItem],
+    });
+
+    const items = await trendingItems();
+    // items will be in the order: [oldItem, newItem] (as per communityTrending)
+    const lastBuilt = feedLastBuilt(items);
+    expect(lastBuilt).toBe(newItem.dateAdded); // because newItem has the newer date
   });
 });


### PR DESCRIPTION
# fix(feed): use newest pubDate for trending feed's lastBuildDate

## Summary

The trending feed's lastBuildDate was using the first item's pubDate (which is the highest-scoring item) instead of the newest item's pubDate. This changes the feedLastBuilt helper to compute the maximum pubDate across all items, ensuring the lastBuildDate reflects the most recent item.

Fixes #5275

## Changes

- Updated feedLastBuilt in apps/web/src/lib/feed-items-lib.ts to reduce over pubDate dates to find the newest.
- Added test in tests/feed-items-lib.test.ts to verify feedLastBuilt works with unordered dates.
- Added test in tests/feeds-trending-items.test.ts to verify the trending feed uses the newest item's pubDate when the highest-scoring item is not the newest.

## Testing

Added unit tests for the changed functions. The tests pass locally.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
