### PR TITLE
feat(web): map agent-skills validated headline to reviewed browse signal

### DIFF
--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -211,8 +211,13 @@ export function stateReportStatDestination(
             search: { category: "skills", signal: "trusted-package" },
             destination: "browse",
           };
-        case "total":
         case "validated":
+          return {
+            to: "/browse",
+            search: { category: "skills", signal: "reviewed" },
+            destination: "browse",
+          };
+        case "total":
         case "packs":
           return {
             to: "/browse",

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -182,7 +182,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("agent-skills", "validated")).toEqual({
       to: "/browse",
-      search: { category: "skills" },
+      search: { category: "skills", signal: "reviewed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("agent-skills", "packs")).toEqual({


### PR DESCRIPTION
## Summary
- Map agent-skills `Validated or production` DataStat to browse `signal=reviewed` (was category-only)
- Aligns headline destination with verification DistTable review filter

## Test plan
- [ ] Open /state-of-agent-skills and click Validated or production
- [ ] Confirm browse opens with category=skills and signal=reviewed

Refs #550

Made with [Cursor](https://cursor.com)