### PR TITLE
feat(web): map skills skill-type DistTable to capability-pack tag hub

### DIFF
--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -41,6 +41,10 @@ const DISCLOSURE_SIGNAL_BY_LABEL: Record<string, string> = {
   "Privacy only": "privacy-notes",
 };
 
+const SKILL_TYPE_TAG_BY_LABEL: Record<string, string> = {
+  "Capability pack": "capability-pack",
+};
+
 const SUPPLY_SIGNAL_BY_LABEL: Record<string, string> = {
   "Verified package": "trusted-package",
   "Checksummed download": "checksums",
@@ -77,6 +81,10 @@ export function notesSignalFromLabel(label: string): string | undefined {
 
 export function disclosureSignalFromLabel(label: string): string | undefined {
   return DISCLOSURE_SIGNAL_BY_LABEL[label];
+}
+
+export function skillTypeTagFromLabel(label: string): string | undefined {
+  return SKILL_TYPE_TAG_BY_LABEL[label];
 }
 
 export function supplyChainSignalFromLabel(label: string): string | undefined {
@@ -189,6 +197,25 @@ export function withDisclosureDrilldown(rows: DistRow[], category: string): Dist
       ...row,
       rowKey: signal,
       drilldown: browseDrilldown({ category, signal }),
+    };
+  });
+}
+
+/** Map skill-type buckets to tag hubs (General stays category browse). */
+export function withSkillTypeDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => {
+    const tag = skillTypeTagFromLabel(row.label);
+    if (!tag) {
+      return {
+        ...row,
+        rowKey: row.rowKey ?? row.label,
+        drilldown: browseDrilldown({ category }),
+      };
+    }
+    return {
+      ...row,
+      rowKey: tag,
+      drilldown: tagDrilldown(tag),
     };
   });
 }
@@ -332,8 +359,9 @@ export function withReportDimensionDrilldown(
       return withTagDrilldown(rows);
     case "disclosure":
       return withDisclosureDrilldown(rows, category);
-    case "prerequisites":
     case "skill-type":
+      return withSkillTypeDrilldown(rows, category);
+    case "prerequisites":
     case "maturity":
     case "verification":
     case "hook-events":

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -6,6 +6,7 @@ import {
   installMethodKeyFromLabel,
   notesSignalFromLabel,
   disclosureSignalFromLabel,
+  skillTypeTagFromLabel,
   platformFromLabel,
   sourceStatusFromLabel,
   supplyChainSignalFromLabel,
@@ -14,6 +15,7 @@ import {
   trustLevelFromLabel,
   withCategoryHubDrilldown,
   withDisclosureDrilldown,
+  withSkillTypeDrilldown,
   withDocsCoverageDrilldown,
   withHostingDrilldown,
   withInstallMethodDrilldown,
@@ -53,6 +55,8 @@ describe("data report drilldown lib", () => {
     expect(disclosureSignalFromLabel("Safety only")).toBe("safety-notes");
     expect(disclosureSignalFromLabel("Privacy only")).toBe("privacy-notes");
     expect(disclosureSignalFromLabel("Neither documented")).toBeUndefined();
+    expect(skillTypeTagFromLabel("Capability pack")).toBe("capability-pack");
+    expect(skillTypeTagFromLabel("General")).toBeUndefined();
   });
 
   it("attaches browse, tag, and category drilldowns with privacy-light keys", () => {
@@ -565,10 +569,29 @@ describe("data report drilldown lib", () => {
     expect(
       withReportDimensionDrilldown(
         "skill-type",
-        [{ label: "x", count: 1, pct: 100 }],
+        [{ label: "Capability pack", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "tag", tag: "capability-pack" });
+    expect(
+      withReportDimensionDrilldown(
+        "skill-type",
+        [{ label: "General", count: 1, pct: 100 }],
         "skills",
       )[0]?.drilldown,
     ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withSkillTypeDrilldown(
+        [{ label: "Capability pack", count: 12, pct: 60 }],
+        "skills",
+      )[0],
+    ).toEqual({
+      label: "Capability pack",
+      count: 12,
+      pct: 60,
+      rowKey: "capability-pack",
+      drilldown: { kind: "tag", tag: "capability-pack" },
+    });
     expect(
       withReportDimensionDrilldown(
         "maturity",


### PR DESCRIPTION
## Summary
- Map agent-skills **skill-type** DistTable rows through `withSkillTypeDrilldown`: **Capability pack** → `/tags/capability-pack`, **General** → `/browse?category=skills`
- Privacy-light drilldown only (tag slug / category); no titles or URLs in analytics payloads

## Test plan
- [x] `pnpm exec prettier` on touched files
- [x] `pnpm exec vitest run tests/data-report-drilldown-lib.test.ts`
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550