### PR TITLE
feat(web): map skills verification and hooks complexity DistTable drilldowns

### DIFF
--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -41,6 +41,11 @@ const DISCLOSURE_SIGNAL_BY_LABEL: Record<string, string> = {
   "Privacy only": "privacy-notes",
 };
 
+const VERIFICATION_SIGNAL_BY_LABEL: Record<string, string> = {
+  Validated: "reviewed",
+  Production: "reviewed",
+};
+
 const SKILL_TYPE_TAG_BY_LABEL: Record<string, string> = {
   "Capability pack": "capability-pack",
 };
@@ -81,6 +86,10 @@ export function notesSignalFromLabel(label: string): string | undefined {
 
 export function disclosureSignalFromLabel(label: string): string | undefined {
   return DISCLOSURE_SIGNAL_BY_LABEL[label];
+}
+
+export function verificationSignalFromLabel(label: string): string | undefined {
+  return VERIFICATION_SIGNAL_BY_LABEL[label];
 }
 
 export function skillTypeTagFromLabel(label: string): string | undefined {
@@ -216,6 +225,25 @@ export function withSkillTypeDrilldown(rows: DistRow[], category: string): DistR
       ...row,
       rowKey: tag,
       drilldown: tagDrilldown(tag),
+    };
+  });
+}
+
+/** Map skill verification buckets to reviewed browse signal (Draft stays category-only). */
+export function withVerificationDrilldown(rows: DistRow[], category: string): DistRow[] {
+  return rows.map((row) => {
+    const signal = verificationSignalFromLabel(row.label);
+    if (!signal) {
+      return {
+        ...row,
+        rowKey: row.rowKey ?? row.label,
+        drilldown: browseDrilldown({ category }),
+      };
+    }
+    return {
+      ...row,
+      rowKey: signal,
+      drilldown: browseDrilldown({ category, signal }),
     };
   });
 }
@@ -361,9 +389,11 @@ export function withReportDimensionDrilldown(
       return withDisclosureDrilldown(rows, category);
     case "skill-type":
       return withSkillTypeDrilldown(rows, category);
+    case "verification":
+      return withVerificationDrilldown(rows, category);
+    case "complexity":
     case "prerequisites":
     case "maturity":
-    case "verification":
     case "hook-events":
       return withCategoryBrowseDrilldown(rows, category);
     default:

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -7,6 +7,7 @@ import {
   notesSignalFromLabel,
   disclosureSignalFromLabel,
   skillTypeTagFromLabel,
+  verificationSignalFromLabel,
   platformFromLabel,
   sourceStatusFromLabel,
   supplyChainSignalFromLabel,
@@ -16,6 +17,7 @@ import {
   withCategoryHubDrilldown,
   withDisclosureDrilldown,
   withSkillTypeDrilldown,
+  withVerificationDrilldown,
   withDocsCoverageDrilldown,
   withHostingDrilldown,
   withInstallMethodDrilldown,
@@ -57,6 +59,9 @@ describe("data report drilldown lib", () => {
     expect(disclosureSignalFromLabel("Neither documented")).toBeUndefined();
     expect(skillTypeTagFromLabel("Capability pack")).toBe("capability-pack");
     expect(skillTypeTagFromLabel("General")).toBeUndefined();
+    expect(verificationSignalFromLabel("Validated")).toBe("reviewed");
+    expect(verificationSignalFromLabel("Production")).toBe("reviewed");
+    expect(verificationSignalFromLabel("Draft")).toBeUndefined();
   });
 
   it("attaches browse, tag, and category drilldowns with privacy-light keys", () => {
@@ -602,10 +607,36 @@ describe("data report drilldown lib", () => {
     expect(
       withReportDimensionDrilldown(
         "verification",
-        [{ label: "x", count: 1, pct: 100 }],
+        [{ label: "Validated", count: 1, pct: 100 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({
+      kind: "browse",
+      search: { category: "skills", signal: "reviewed" },
+    });
+    expect(
+      withReportDimensionDrilldown(
+        "verification",
+        [{ label: "Draft", count: 1, pct: 100 }],
         "skills",
       )[0]?.drilldown,
     ).toEqual({ kind: "browse", search: { category: "skills" } });
+    expect(
+      withVerificationDrilldown(
+        [{ label: "Production", count: 2, pct: 40 }],
+        "skills",
+      )[0]?.drilldown,
+    ).toEqual({
+      kind: "browse",
+      search: { category: "skills", signal: "reviewed" },
+    });
+    expect(
+      withReportDimensionDrilldown(
+        "complexity",
+        [{ label: "Simple (score 1–2)", count: 1, pct: 100 }],
+        "hooks",
+      )[0]?.drilldown,
+    ).toEqual({ kind: "browse", search: { category: "hooks" } });
     expect(
       withReportDimensionDrilldown(
         "hook-events",


### PR DESCRIPTION
## Summary
- Map skills **verification** DistTable: Validated / Production → browse `signal=reviewed`; Draft stays category-only
- Enable hooks **complexity** DistTable browse drilldown (was display-only)
- Re-lands closed #5298 on current main (after skill-type #5307)

## Test plan
- [x] prettier + vitest on `data-report-drilldown-lib`
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate
- [ ] Open /state-of-agent-skills verification DistTable and click Validated / Production / Draft
- [ ] Open /state-of-claude-code-hooks complexity DistTable and click a row

Refs #550