### PR TITLE
test(submissions): cover source-evidence close threshold and formatting

### DIFF
--- a/tests/submission-gate-source-evidence-formatting.test.ts
+++ b/tests/submission-gate-source-evidence-formatting.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sourceEvidenceCloseDecision,
+  sourceEvidenceSummary,
+  sourceEvidenceToDecisionEvidence,
+  type SourceEvidenceReport,
+} from "../apps/submission-gate/src/source-evidence";
+
+function report(urls: SourceEvidenceReport["urls"]): SourceEvidenceReport {
+  return { status: "failed", hash: "source-hash", warnings: [], urls };
+}
+
+const deadRepo = {
+  field: "repoUrl",
+  url: "https://github.com/example/missing",
+  status: "hard_failure" as const,
+  role: "canonical" as const,
+  blocking: true,
+  outcome: "http_hard_failure",
+  httpStatus: 404,
+  finalUrl: "https://github.com/example/missing",
+};
+
+const deadSource = {
+  field: "sourceUrl",
+  url: "https://example.com/missing",
+  status: "hard_failure" as const,
+  role: "canonical" as const,
+  blocking: true,
+  outcome: "http_hard_failure",
+  httpStatus: 410,
+  finalUrl: "https://example.com/missing",
+};
+
+describe("submission-gate sourceEvidenceCloseDecision hard-close threshold", () => {
+  it("closes when two or more authoritative sources all hard-failed", () => {
+    const decision = sourceEvidenceCloseDecision(
+      report([deadRepo, deadSource]),
+    );
+    expect(decision).toMatchObject({
+      verdict: "close",
+      close: true,
+      reasonCode: "source_hard_failure",
+    });
+    expect(decision?.summary).toContain(
+      "Close this PR and resubmit with reachable, authoritative source URLs.",
+    );
+  });
+
+  it("stays manual when there is only a single authoritative source, even if it hard-failed", () => {
+    const decision = sourceEvidenceCloseDecision(report([deadRepo]));
+    expect(decision).toMatchObject({
+      verdict: "manual",
+      close: false,
+      reasonCode: "source_hard_failure",
+    });
+  });
+});
+
+describe("submission-gate sourceEvidenceSummary formatting", () => {
+  it("reports that no source URLs were declared when the list is empty", () => {
+    expect(sourceEvidenceSummary(report([]))).toBe(
+      "No source URLs were declared.",
+    );
+  });
+
+  it("prefers the HTTP status over the outcome and flags non-blocking warnings", () => {
+    const passedWithStatus = { ...deadRepo, status: "passed" as const };
+    const noStatusItem = {
+      ...deadRepo,
+      httpStatus: undefined,
+      blocking: false,
+    };
+    const summary = sourceEvidenceSummary(
+      report([passedWithStatus, noStatusItem]),
+    );
+    expect(summary).toContain("HTTP 404");
+    expect(summary).toContain("http_hard_failure");
+    expect(summary).toContain("(non-blocking source-inconclusive warning)");
+  });
+});
+
+describe("submission-gate sourceEvidenceToDecisionEvidence behavior text", () => {
+  it("describes the failure by HTTP status when one was recorded", () => {
+    const evidence = sourceEvidenceToDecisionEvidence(report([deadRepo]));
+    expect(evidence).toEqual([
+      expect.objectContaining({
+        behavior: "repoUrl returned HTTP 404",
+        httpStatus: "404",
+      }),
+    ]);
+  });
+
+  it("describes the failure generically when there is no HTTP status", () => {
+    const noStatusItem = { ...deadRepo, httpStatus: undefined };
+    const evidence = sourceEvidenceToDecisionEvidence(report([noStatusItem]));
+    expect(evidence).toEqual([
+      expect.objectContaining({
+        behavior: "repoUrl is not a valid reachable source URL",
+        httpStatus: undefined,
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
`apps/submission-gate/src/source-evidence.ts` had a few untested branches distinct from the sibling `submission-gate-source-evidence-decisions.test.ts` file (which covers the null-evidence and single-authoritative-source-among-many cases):

- the actual `close` verdict when two or more authoritative canonical sources all hard-fail
- the `manual` fallback when there's exactly one authoritative source (a lone authoritative source is never enough on its own to auto-close, regardless of outcome)
- `sourceEvidenceSummary` / `sourceEvidenceToDecisionEvidence`'s HTTP-status vs. generic-outcome formatting branches

## Test plan
- `pnpm exec vitest run tests/submission-gate-source-evidence-formatting.test.ts` -- 6 tests pass
- `pnpm exec prettier --check tests/submission-gate-source-evidence-formatting.test.ts` -- clean
- Scoped coverage on `apps/submission-gate/src/source-evidence.ts` improves branch coverage 89.4% -> 90.6%
