### PR TITLE
feat(web): add install-risk and notes badges to trending podium

### DIFF
--- a/apps/web/src/components/trending-podium.tsx
+++ b/apps/web/src/components/trending-podium.tsx
@@ -1,7 +1,13 @@
 import * as React from "react";
 import { Link } from "@tanstack/react-router";
 import { Star, ArrowUpRight, TrendingUp } from "lucide-react";
-import { CategoryPill, TrustBadge, SourceBadge } from "@/components/badges";
+import {
+  CategoryPill,
+  TrustBadge,
+  SourceBadge,
+  InstallRiskBadge,
+  NotesPresenceChips,
+} from "@/components/badges";
 import { formatCompact } from "@/lib/format";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -113,6 +119,8 @@ export function TrendingPodium({ entries }: { entries: TrendingEntry[] }) {
                   )
                 }
               />
+              <InstallRiskBadge entry={e} size="xs" asLink surface="trending-podium" />
+              <NotesPresenceChips entry={e} asLink surface="trending-podium" />
             </div>
             {entryDestination ? (
               <Link

--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -15,6 +15,7 @@ export type InstallRiskBadgeSurface =
   | "peek-panel"
   | "compare-tray"
   | "trending-list"
+  | "trending-podium"
   | "browse-card"
   | "browse-grid"
   | "browse-row"

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -15,6 +15,7 @@ export type NotesPresenceSurface =
   | "peek-panel"
   | "compare-tray"
   | "trending-list"
+  | "trending-podium"
   | "browse-card"
   | "browse-grid"
   | "browse-row"

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -38,6 +38,10 @@ describe("install risk badge cta events lib", () => {
       surface: "trending-list",
       risk: "review",
     });
+    expect(installRiskBadgeAnalyticsData("high", "trending-podium")).toEqual({
+      surface: "trending-podium",
+      risk: "high",
+    });
     expect(installRiskBadgeAnalyticsData("low", "contributor-profile")).toEqual(
       {
         surface: "contributor-profile",

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -56,6 +56,13 @@ describe("notes presence cta events lib", () => {
       },
     );
     expect(
+      notesPresenceAnalyticsData("privacy", true, "trending-podium"),
+    ).toEqual({
+      surface: "trending-podium",
+      noteKind: "privacy",
+      present: true,
+    });
+    expect(
       notesPresenceAnalyticsData("privacy", true, "contributor-profile"),
     ).toEqual({
       surface: "contributor-profile",


### PR DESCRIPTION
## Summary
- Render `InstallRiskBadge` + `NotesPresenceChips` (`asLink`) on the trending podium chip row so top-3 matches the trending list
- Extend privacy-light surfaces with `trending-podium` for existing `install_risk_badge_click` / `notes_presence_chip_click` events

## Test plan
- [x] prettier + vitest on install-risk / notes-presence libs
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate
- [ ] Open /trending and click install-risk / notes chips on podium cards

Refs #550