### PR TITLE
feat(web): map DistTable notes Both to safety-notes browse signal

### DIFF
--- a/apps/web/src/lib/data-report-drilldown-lib.ts
+++ b/apps/web/src/lib/data-report-drilldown-lib.ts
@@ -33,6 +33,8 @@ const PLATFORM_BY_LABEL = Object.fromEntries(
 const NOTES_SIGNAL_BY_LABEL: Record<string, string> = {
   "Safety notes": "safety-notes",
   "Privacy notes": "privacy-notes",
+  // Same proxy as disclosure "Safety & privacy" — browse entries with safety notes.
+  Both: "safety-notes",
 };
 
 const DISCLOSURE_SIGNAL_BY_LABEL: Record<string, string> = {

--- a/tests/data-report-drilldown-lib.test.ts
+++ b/tests/data-report-drilldown-lib.test.ts
@@ -52,7 +52,7 @@ describe("data report drilldown lib", () => {
     expect(platformFromLabel("Unknown")).toBeUndefined();
     expect(notesSignalFromLabel("Safety notes")).toBe("safety-notes");
     expect(notesSignalFromLabel("Privacy notes")).toBe("privacy-notes");
-    expect(notesSignalFromLabel("Both")).toBeUndefined();
+    expect(notesSignalFromLabel("Both")).toBe("safety-notes");
     expect(disclosureSignalFromLabel("Safety & privacy")).toBe("safety-notes");
     expect(disclosureSignalFromLabel("Safety only")).toBe("safety-notes");
     expect(disclosureSignalFromLabel("Privacy only")).toBe("privacy-notes");
@@ -190,7 +190,15 @@ describe("data report drilldown lib", () => {
     ]);
     expect(
       withNotesSignalDrilldown([{ label: "Both", count: 1, pct: 10 }]),
-    ).toEqual([{ label: "Both", count: 1, pct: 10 }]);
+    ).toEqual([
+      {
+        label: "Both",
+        count: 1,
+        pct: 10,
+        rowKey: "safety-notes",
+        drilldown: { kind: "browse", search: { signal: "safety-notes" } },
+      },
+    ]);
     expect(
       withNotesSignalDrilldown(
         [{ label: "Both", count: 1, pct: 10, rowKey: "both" }],
@@ -201,8 +209,11 @@ describe("data report drilldown lib", () => {
         label: "Both",
         count: 1,
         pct: 10,
-        rowKey: "both",
-        drilldown: { kind: "browse", search: { category: "mcp" } },
+        rowKey: "safety-notes",
+        drilldown: {
+          kind: "browse",
+          search: { category: "mcp", signal: "safety-notes" },
+        },
       },
     ]);
     expect(
@@ -212,8 +223,11 @@ describe("data report drilldown lib", () => {
         label: "Both",
         count: 1,
         pct: 10,
-        rowKey: "Both",
-        drilldown: { kind: "browse", search: { category: "mcp" } },
+        rowKey: "safety-notes",
+        drilldown: {
+          kind: "browse",
+          search: { category: "mcp", signal: "safety-notes" },
+        },
       },
     ]);
     expect(


### PR DESCRIPTION
## Summary
- Map DistTable notes label **Both** → browse `signal=safety-notes` (same proxy as disclosure “Safety & privacy”)
- Tooling notes DistTable: Both becomes a link (was display-only); MCP security: Both gains signal filter (was category-only)

## Test plan
- [x] prettier + vitest on `data-report-drilldown-lib`
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate
- [ ] Open /state-of-claude-tooling notes DistTable and click Both
- [ ] Open /mcp-security-report notes DistTable and click Both

Refs #550