### PR TITLE
feat(web): add install-risk and notes badges to hub highlights

### DIFF
--- a/apps/web/src/components/hub-highlights.tsx
+++ b/apps/web/src/components/hub-highlights.tsx
@@ -8,7 +8,7 @@ import {
   BadgeCheck,
   type LucideIcon,
 } from "lucide-react";
-import { TrustBadge, SourceBadge } from "@/components/badges";
+import { TrustBadge, SourceBadge, InstallRiskBadge, NotesPresenceChips } from "@/components/badges";
 import type { Highlight, HighlightKind, HubStat } from "@/lib/hub-highlights";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -125,6 +125,8 @@ export function HubHighlights({
                       )
                     }
                   />
+                  <InstallRiskBadge entry={h.entry} size="xs" asLink surface="hub-highlights" />
+                  <NotesPresenceChips entry={h.entry} asLink surface="hub-highlights" />
                 </div>
               </div>
             </li>

--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -16,6 +16,7 @@ export type InstallRiskBadgeSurface =
   | "compare-tray"
   | "trending-list"
   | "trending-podium"
+  | "hub-highlights"
   | "browse-card"
   | "browse-grid"
   | "browse-row"

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -16,6 +16,7 @@ export type NotesPresenceSurface =
   | "compare-tray"
   | "trending-list"
   | "trending-podium"
+  | "hub-highlights"
   | "browse-card"
   | "browse-grid"
   | "browse-row"

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -42,6 +42,10 @@ describe("install risk badge cta events lib", () => {
       surface: "trending-podium",
       risk: "high",
     });
+    expect(installRiskBadgeAnalyticsData("review", "hub-highlights")).toEqual({
+      surface: "hub-highlights",
+      risk: "review",
+    });
     expect(installRiskBadgeAnalyticsData("low", "contributor-profile")).toEqual(
       {
         surface: "contributor-profile",

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -63,6 +63,13 @@ describe("notes presence cta events lib", () => {
       present: true,
     });
     expect(
+      notesPresenceAnalyticsData("safety", true, "hub-highlights"),
+    ).toEqual({
+      surface: "hub-highlights",
+      noteKind: "safety",
+      present: true,
+    });
+    expect(
       notesPresenceAnalyticsData("privacy", true, "contributor-profile"),
     ).toEqual({
       surface: "contributor-profile",


### PR DESCRIPTION
## Summary
- Render `InstallRiskBadge` + `NotesPresenceChips` (`asLink`) on hub highlight cards alongside Trust/Source
- Extend privacy-light surfaces with `hub-highlights` for existing install-risk / notes-presence click events

## Test plan
- [x] prettier + vitest on install-risk / notes-presence libs
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate
- [ ] Open a category/tag hub with Highlights and click install-risk / notes chips

Refs #550