### PR TITLE
refactor(web): extract shared entry trust-signal predicates for compare libs

### DIFF
--- a/apps/web/src/lib/compare-deployment-risk-map-lib.ts
+++ b/apps/web/src/lib/compare-deployment-risk-map-lib.ts
@@ -1,4 +1,12 @@
 import type { Entry } from "@/types/registry";
+import {
+  hasInstallPayloadSignal as hasInstall,
+  hasPackageSignal as hasPackage,
+  hasPrivacySignal as hasPrivacy,
+  hasReviewedSignal as hasReviewed,
+  hasSafetySignal as hasSafety,
+  hasSourceSignal as hasSource,
+} from "@/lib/entry-signal-predicates-lib";
 
 export type DeploymentRiskPresetId = "balanced" | "security" | "speed";
 export type DeploymentRiskBand = "low" | "medium" | "high";
@@ -35,32 +43,6 @@ export type CompareDeploymentRiskMapState = {
   lowRiskCount: number;
   highRiskCount: number;
 };
-
-function hasSource(entry: Entry): boolean {
-  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
-}
-
-function hasReviewed(entry: Entry): boolean {
-  return Boolean(entry.reviewed || entry.reviewedBy);
-}
-
-function hasSafety(entry: Entry): boolean {
-  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
-}
-
-function hasPrivacy(entry: Entry): boolean {
-  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
-}
-
-function hasPackage(entry: Entry): boolean {
-  return entry.packageVerified === true || Boolean(entry.downloadSha256);
-}
-
-function hasInstall(entry: Entry): boolean {
-  return Boolean(
-    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
-  );
-}
 
 function entryRef(entry: Entry): string {
   return `${entry.category}/${entry.slug}`;

--- a/apps/web/src/lib/compare-evidence-gaps-lib.ts
+++ b/apps/web/src/lib/compare-evidence-gaps-lib.ts
@@ -6,6 +6,14 @@
  */
 
 import type { Entry } from "@/types/registry";
+import {
+  hasInstallPayloadSignal as hasInstallPayload,
+  hasPackageSignal as hasPackage,
+  hasPrivacySignal as hasPrivacy,
+  hasReviewedSignal as hasReviewed,
+  hasSafetySignal as hasSafety,
+  hasSourceSignal as hasSource,
+} from "@/lib/entry-signal-predicates-lib";
 
 export type CompareEvidenceGapId =
   | "source"
@@ -41,34 +49,6 @@ export type CompareEvidenceGapsState = {
   entries: CompareEntryEvidenceCell[];
   highSeverityCount: number;
 };
-
-function hasSafety(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">): boolean {
-  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
-}
-
-function hasPrivacy(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">): boolean {
-  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
-}
-
-function hasInstallPayload(
-  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
-): boolean {
-  return Boolean(
-    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
-  );
-}
-
-function hasSource(entry: Pick<Entry, "source" | "sourceUrl">): boolean {
-  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
-}
-
-function hasReviewed(entry: Pick<Entry, "reviewed" | "reviewedBy">): boolean {
-  return Boolean(entry.reviewed || entry.reviewedBy);
-}
-
-function hasPackage(entry: Pick<Entry, "packageVerified" | "downloadSha256">): boolean {
-  return entry.packageVerified === true || Boolean(entry.downloadSha256);
-}
 
 const GAP_LABELS: Record<CompareEvidenceGapId, string> = {
   source: "Source provenance",

--- a/apps/web/src/lib/compare-mitigation-priority-lib.ts
+++ b/apps/web/src/lib/compare-mitigation-priority-lib.ts
@@ -1,4 +1,12 @@
 import type { Entry } from "@/types/registry";
+import {
+  hasInstallPayloadSignal as hasInstall,
+  hasPackageSignal as hasPackage,
+  hasPrivacySignal as hasPrivacy,
+  hasReviewedSignal as hasReviewed,
+  hasSafetySignal as hasSafety,
+  hasSourceSignal as hasSource,
+} from "@/lib/entry-signal-predicates-lib";
 
 export type MitigationPriorityPresetId = "balanced" | "security-first" | "rollout-first";
 export type MitigationPriorityTier = "urgent" | "watch" | "optional";
@@ -45,32 +53,6 @@ const SIGNAL_LABELS: Record<MitigationSignalId, string> = {
   package: "Package integrity",
   install: "Install payload",
 };
-
-function hasSource(entry: Entry): boolean {
-  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
-}
-
-function hasReviewed(entry: Entry): boolean {
-  return Boolean(entry.reviewed || entry.reviewedBy);
-}
-
-function hasSafety(entry: Entry): boolean {
-  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
-}
-
-function hasPrivacy(entry: Entry): boolean {
-  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
-}
-
-function hasPackage(entry: Entry): boolean {
-  return entry.packageVerified === true || Boolean(entry.downloadSha256);
-}
-
-function hasInstall(entry: Entry): boolean {
-  return Boolean(
-    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
-  );
-}
 
 function entryRef(entry: Entry): string {
   return `${entry.category}/${entry.slug}`;

--- a/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
+++ b/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
@@ -1,4 +1,12 @@
 import type { Entry } from "@/types/registry";
+import {
+  hasInstallPayloadSignal as hasInstall,
+  hasPackageSignal as hasPackage,
+  hasPrivacySignal as hasPrivacy,
+  hasReviewedSignal as hasReviewed,
+  hasSafetySignal as hasSafety,
+  hasSourceSignal as hasSource,
+} from "@/lib/entry-signal-predicates-lib";
 
 export type OperationalFitPresetId = "team-default" | "security-hardening" | "rapid-adoption";
 export type OperationalFitTone = "strong" | "mixed" | "weak";
@@ -43,32 +51,6 @@ export type CompareOperationalFitHeatmapState = {
   bestEntryRef: string | null;
   weakEntryRefs: string[];
 };
-
-function hasSource(entry: Entry): boolean {
-  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
-}
-
-function hasReviewed(entry: Entry): boolean {
-  return Boolean(entry.reviewed || entry.reviewedBy);
-}
-
-function hasSafety(entry: Entry): boolean {
-  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
-}
-
-function hasPrivacy(entry: Entry): boolean {
-  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
-}
-
-function hasPackage(entry: Entry): boolean {
-  return entry.packageVerified === true || Boolean(entry.downloadSha256);
-}
-
-function hasInstall(entry: Entry): boolean {
-  return Boolean(
-    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
-  );
-}
 
 function entryRef(entry: Entry): string {
   return `${entry.category}/${entry.slug}`;

--- a/apps/web/src/lib/compare-rollout-readiness-lib.ts
+++ b/apps/web/src/lib/compare-rollout-readiness-lib.ts
@@ -1,4 +1,12 @@
 import type { Entry } from "@/types/registry";
+import {
+  hasInstallPayloadSignal as hasInstall,
+  hasPackageSignal as hasPackage,
+  hasPrivacySignal as hasPrivacy,
+  hasReviewedSignal as hasReviewed,
+  hasSafetySignal as hasSafety,
+  hasSourceSignal as hasSource,
+} from "@/lib/entry-signal-predicates-lib";
 
 export type RolloutPresetId = "prototype" | "team" | "production";
 export type RolloutChecklistTone = "complete" | "warning" | "blocked";
@@ -48,32 +56,6 @@ const PRESET_HEADING: Record<RolloutPresetId, string> = {
 
 function entryRef(entry: Entry): string {
   return `${entry.category}/${entry.slug}`;
-}
-
-function hasSafety(entry: Entry): boolean {
-  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
-}
-
-function hasPrivacy(entry: Entry): boolean {
-  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
-}
-
-function hasPackage(entry: Entry): boolean {
-  return entry.packageVerified === true || Boolean(entry.downloadSha256);
-}
-
-function hasInstall(entry: Entry): boolean {
-  return Boolean(
-    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
-  );
-}
-
-function hasSource(entry: Entry): boolean {
-  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
-}
-
-function hasReviewed(entry: Entry): boolean {
-  return Boolean(entry.reviewed || entry.reviewedBy);
 }
 
 function signalMap(entry: Entry): SignalMap {

--- a/apps/web/src/lib/entry-signal-predicates-lib.ts
+++ b/apps/web/src/lib/entry-signal-predicates-lib.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure entry trust-signal predicates.
+ *
+ * Canonical presence checks for the trust evidence surfaced across browse,
+ * compare, and entry-detail decision helpers. Each predicate accepts the
+ * narrowest `Entry` slice it needs so callers can pass partial fixtures, and
+ * the results are derived purely from the entry metadata passed in.
+ */
+
+import type { Entry } from "@/types/registry";
+
+export function hasSafetySignal(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+export function hasPrivacySignal(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+export function hasSourceSignal(entry: Pick<Entry, "source" | "sourceUrl">): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+export function hasReviewedSignal(entry: Pick<Entry, "reviewed" | "reviewedBy">): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+export function hasPackageSignal(
+  entry: Pick<Entry, "packageVerified" | "downloadSha256">,
+): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+export function hasInstallPayloadSignal(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}


### PR DESCRIPTION
## Summary
- Add `entry-signal-predicates-lib` as the canonical home for the entry trust-signal presence checks (`safety`, `privacy`, `source`, `reviewed`, `package`, `install payload`)
- Dedupe the five compare decision libs that each re-declared the same six predicates locally (30 duplicate definitions removed, net -92 lines)
- Behavior-preserving: call sites are unchanged via import aliases, so the diff is limited to deleting the local copies and importing the shared ones

These predicates were copy-pasted across 21 files; this PR converts the `compare-*` decision family first to keep the change reviewable.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Existing suites for all five libs pass unchanged (80 tests)
- [ ] CI: validate-web, coverage, codecov/patch
