### PR TITLE
refactor(web): dedupe entryRef to reuse entry-identity helper

### DIFF
--- a/apps/web/src/lib/browse-adoption-queue-lib.ts
+++ b/apps/web/src/lib/browse-adoption-queue-lib.ts
@@ -1,4 +1,5 @@
 import type { Entry } from "@/types/registry";
+import { entryRef } from "@/lib/entry-identity";
 
 export type BrowseAdoptionPresetId = "balanced" | "security-first" | "fast-pilot";
 export type BrowseAdoptionTier = "ready" | "caution" | "hold";
@@ -65,10 +66,6 @@ function hasInstall(entry: Entry): boolean {
   return Boolean(
     entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
   );
-}
-
-function entryRef(entry: Entry): string {
-  return `${entry.category}/${entry.slug}`;
 }
 
 function headingForPreset(preset: BrowseAdoptionPresetId): string {

--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -1,4 +1,5 @@
 import type { Entry } from "@/types/registry";
+import { entryRef } from "@/lib/entry-identity";
 
 export type BrowseConfidencePresetId = "balanced" | "strict" | "pilot";
 export type BrowseConfidenceBand = "high" | "medium" | "low";
@@ -65,10 +66,6 @@ function hasInstall(entry: Entry): boolean {
   return Boolean(
     entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
   );
-}
-
-function entryRef(entry: Entry): string {
-  return `${entry.category}/${entry.slug}`;
 }
 
 function headingForPreset(preset: BrowseConfidencePresetId): string {

--- a/apps/web/src/lib/browse-freshness-distribution-lib.ts
+++ b/apps/web/src/lib/browse-freshness-distribution-lib.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Entry } from "@/types/registry";
+import { entryRef } from "@/lib/entry-identity";
 
 export type FreshnessBucketId = "fresh" | "recent" | "aging" | "stale";
 
@@ -85,10 +86,6 @@ function medianOf(values: number[]): number {
     return Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
   }
   return sorted[mid]!;
-}
-
-function entryRef(entry: Entry): string {
-  return `${entry.category}/${entry.slug}`;
 }
 
 function summarize(

--- a/apps/web/src/lib/browse-rollout-signals-lib.ts
+++ b/apps/web/src/lib/browse-rollout-signals-lib.ts
@@ -1,4 +1,5 @@
 import type { Entry } from "@/types/registry";
+import { entryRef } from "@/lib/entry-identity";
 
 export type BrowseRolloutSignalId =
   | "source"
@@ -94,10 +95,6 @@ function rowMessage(id: BrowseRolloutSignalId, tone: BrowseRolloutSignalTone): s
   if (tone === "good") return `${signalLabel(id)} is broadly covered in current results.`;
   if (tone === "watch") return `${signalLabel(id)} is mixed and needs spot-checking.`;
   return `${signalLabel(id)} is sparse; verify before rollout decisions.`;
-}
-
-function entryRef(entry: Entry): string {
-  return `${entry.category}/${entry.slug}`;
 }
 
 function requiredMissingLabels(signals: Record<BrowseRolloutSignalId, boolean>): string[] {

--- a/apps/web/src/lib/entry-compare-benchmark-lib.ts
+++ b/apps/web/src/lib/entry-compare-benchmark-lib.ts
@@ -1,4 +1,5 @@
 import type { Entry } from "@/types/registry";
+import { entryRef } from "@/lib/entry-identity";
 import { sameEntry } from "@/lib/entry-identity";
 
 export type CompareBenchmarkPresetId = "balanced" | "security" | "rollout";
@@ -61,10 +62,6 @@ function hasInstall(entry: Entry): boolean {
   return Boolean(
     entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
   );
-}
-
-function entryRef(entry: Entry): string {
-  return `${entry.category}/${entry.slug}`;
 }
 
 function headingForPreset(preset: CompareBenchmarkPresetId): string {


### PR DESCRIPTION
## Summary
- `entryRef` is already exported from `@/lib/entry-identity`, but five browse/entry libs each re-declared an identical local copy
- Replace those local copies with the shared import (net -15 lines); `EntryIdentity` is structurally satisfied by `Entry`, so call sites are unchanged
- Behavior-preserving: no call-site or output changes

## Test plan
- [x] `tsc --noEmit` clean
- [x] Existing suites for all five libs plus `entry-identity` pass unchanged (86 tests)
- [ ] CI: validate-web, coverage, codecov/patch
