### PR TITLE
fix(web): stop nesting npm-version anchor inside integration card link

### DIFF
--- a/apps/web/src/components/integration-card.tsx
+++ b/apps/web/src/components/integration-card.tsx
@@ -114,8 +114,6 @@ export function IntegrationCard({
               fallbackVersion={integration.version}
               fallbackUpdatedAt={integration.updatedAt}
               showDownloads={false}
-              asLink
-              analyticsSurface="integration-card"
             />
           ) : (
             <>


### PR DESCRIPTION
## Summary
`integration-card.tsx` wraps the whole card in `<Link to="/integrations/$slug">`, but rendered `LiveVersionBadge` with `asLink`, whose link path emits its own `<a href="https://www.npmjs.com/...">` — an anchor nested inside an anchor. That is invalid HTML and makes clicking the npm-version chip behave unpredictably.

- Drop `asLink` and `analyticsSurface` from the `LiveVersionBadge` call in `integration-card.tsx`
- Without `asLink` the badge renders a plain `<span>`, so no nested anchor remains
- `analyticsSurface` is only meaningful on the link path, so it is removed with it
- Matches the convention already followed by `resource-card.tsx`, `trending-podium.tsx`, `hub-highlights.tsx`, `category-ranking-table.tsx`, and `hero-status-row.tsx`

Closes #5258

## Test plan
- [x] `tsc --noEmit` clean
- [x] Confirmed via source that the non-`asLink` path renders `<span>` (`live-version-badge.tsx`), so the card contains a single anchor
- [x] Existing CTA-event suites pass unchanged (integration-card, live-version, ecosystem-page — 8 tests)
- [x] No visual or styling change: only the link wrapper and its analytics prop are removed
- [ ] CI: validate-web, coverage, codecov/patch
