### PR TITLE
fix(web): expose aria-pressed on entry signals toggle buttons

### DIFF
--- a/apps/web/src/components/entry-signals-panel.tsx
+++ b/apps/web/src/components/entry-signals-panel.tsx
@@ -276,6 +276,7 @@ function SignalButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-pressed={Boolean(active)}
       data-active={active || undefined}
       className={cn(
         "inline-flex items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 py-1 text-xs font-medium text-ink-muted transition-colors duration-200 ease-out hover:text-ink disabled:cursor-wait disabled:opacity-60",


### PR DESCRIPTION
## Summary
`EntrySignalsPanel`'s `SignalButton` (Upvote / Used / Works / Broken) are genuine toggle buttons, but only exposed state through `data-active`, so screen readers announced no pressed/not-pressed state.

- Add `aria-pressed` to `SignalButton`, matching the pattern already used by `EntryPrerequisiteReadinessPanel`, `EntrySafetySurfacePanel`, `entry-detail-command-center.tsx`, `CompareScenarioRankingPanel`, and `resource-card.tsx`
- Uses `Boolean(active)` because the `active` prop is optional (`active?: boolean`); a toggle must expose the not-pressed state as `aria-pressed="false"` rather than omitting the attribute
- Accessibility-attribute only — `data-active` and all styling are untouched

Closes #5260

## Test plan
- [x] `tsc --noEmit` clean
- [x] Diff is a single added attribute line — no visual or behavioral change (`data-active` and `toneClass` untouched)
- [x] Existing entry-signals suites pass unchanged (26 tests)
- [ ] CI: validate-web, coverage, codecov/patch
