### PR TITLE
feat(web): add install-risk and notes badges on validators rows

### DIFF
--- a/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/install-risk-badge-cta-events-lib.ts
@@ -33,7 +33,9 @@ export type InstallRiskBadgeSurface =
   | "platform-category"
   | "detail-related"
   | "detail-guides"
-  | "contributor-profile";
+  | "contributor-profile"
+  | "validators-attention"
+  | "validators-recent-reviewed";
 
 export function installRiskBadgeAnalyticsEvent(): string {
   return "install_risk_badge_click";

--- a/apps/web/src/lib/notes-presence-cta-events-lib.ts
+++ b/apps/web/src/lib/notes-presence-cta-events-lib.ts
@@ -33,7 +33,9 @@ export type NotesPresenceSurface =
   | "platform-category"
   | "detail-related"
   | "detail-guides"
-  | "contributor-profile";
+  | "contributor-profile"
+  | "validators-attention"
+  | "validators-recent-reviewed";
 
 export type NotesPresenceKind = "safety" | "privacy";
 

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -10,7 +10,13 @@ import {
   REVIEW_SUMMARY,
   type Expertise,
 } from "@/data/validators";
-import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
+import {
+  CategoryPill,
+  SourceBadge,
+  TrustBadge,
+  InstallRiskBadge,
+  NotesPresenceChips,
+} from "@/components/badges";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
@@ -305,6 +311,13 @@ function ValidatorsPage() {
                               )
                             }
                           />
+                          <InstallRiskBadge
+                            entry={entry}
+                            size="xs"
+                            asLink
+                            surface="validators-attention"
+                          />
+                          <NotesPresenceChips entry={entry} asLink surface="validators-attention" />
                         </div>
                         {(() => {
                           const destination = insightsPageEntryDestination(
@@ -392,6 +405,13 @@ function ValidatorsPage() {
                         )
                       }
                     />
+                    <InstallRiskBadge
+                      entry={entry}
+                      size="xs"
+                      asLink
+                      surface="validators-recent-reviewed"
+                    />
+                    <NotesPresenceChips entry={entry} asLink surface="validators-recent-reviewed" />
                   </div>
                   {(() => {
                     const destination = insightsPageEntryDestination(entry.category, entry.slug);

--- a/tests/install-risk-badge-cta-events-lib.test.ts
+++ b/tests/install-risk-badge-cta-events-lib.test.ts
@@ -52,6 +52,18 @@ describe("install risk badge cta events lib", () => {
         risk: "low",
       },
     );
+    expect(
+      installRiskBadgeAnalyticsData("review", "validators-attention"),
+    ).toEqual({
+      surface: "validators-attention",
+      risk: "review",
+    });
+    expect(
+      installRiskBadgeAnalyticsData("high", "validators-recent-reviewed"),
+    ).toEqual({
+      surface: "validators-recent-reviewed",
+      risk: "high",
+    });
     expect(installRiskBadgeAnalyticsData("high", "browse-grid")).toEqual({
       surface: "browse-grid",
       risk: "high",

--- a/tests/notes-presence-cta-events-lib.test.ts
+++ b/tests/notes-presence-cta-events-lib.test.ts
@@ -76,6 +76,24 @@ describe("notes presence cta events lib", () => {
       noteKind: "privacy",
       present: true,
     });
+    expect(
+      notesPresenceAnalyticsData("safety", true, "validators-attention"),
+    ).toEqual({
+      surface: "validators-attention",
+      noteKind: "safety",
+      present: true,
+    });
+    expect(
+      notesPresenceAnalyticsData(
+        "privacy",
+        false,
+        "validators-recent-reviewed",
+      ),
+    ).toEqual({
+      surface: "validators-recent-reviewed",
+      noteKind: "privacy",
+      present: false,
+    });
     expect(notesPresenceAnalyticsData("privacy", true, "browse-grid")).toEqual({
       surface: "browse-grid",
       noteKind: "privacy",


### PR DESCRIPTION
## Summary
- Render `InstallRiskBadge` + `NotesPresenceChips` (`asLink`) on validators attention queue and recent-reviewed rows
- Extend privacy-light surfaces with `validators-attention` and `validators-recent-reviewed`

## Test plan
- [x] prettier + vitest on install-risk / notes-presence libs
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate
- [ ] Open /validators and click install-risk / notes chips in attention + recent-reviewed rows

Refs #550