### PR TITLE
fix(web): escape delimiters in saved-search hash and signature

### DIFF
--- a/apps/web/src/lib/saved-search-hash-lib.ts
+++ b/apps/web/src/lib/saved-search-hash-lib.ts
@@ -4,13 +4,26 @@
 import type { SavedSearch } from "@/lib/recents";
 
 /**
+ * Escape the `|` field delimiter (and the `\` escape character itself) so no
+ * field's content can shift across a boundary and forge another search's hash
+ * input. Fields containing neither character are returned unchanged, so
+ * existing delimiter-free searches keep their current hash.
+ */
+function escapeField(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("|", "\\|");
+}
+
+/**
  * Stable base36 hash of a saved search's identifying fields (query plus the
  * category / trust / source / platform filters). Used to key saved-search alert
- * segments: equal searches hash equally; different searches (almost) always
- * differ. Deterministic — no ordering or clock dependence.
+ * segments: equal searches hash equally, and differing searches hash
+ * differently because each field is delimiter-escaped before joining.
+ * Deterministic — no ordering or clock dependence.
  */
 export function hashSearch(s: SavedSearch): string {
-  const raw = `${s.q}|${s.category ?? ""}|${s.trust ?? ""}|${s.source ?? ""}|${s.platform ?? ""}`;
+  const raw = [s.q, s.category ?? "", s.trust ?? "", s.source ?? "", s.platform ?? ""]
+    .map(escapeField)
+    .join("|");
   let h = 0;
   for (let i = 0; i < raw.length; i++) h = (h * 31 + raw.charCodeAt(i)) | 0;
   return Math.abs(h).toString(36);

--- a/apps/web/src/lib/saved-search-signature-lib.ts
+++ b/apps/web/src/lib/saved-search-signature-lib.ts
@@ -5,9 +5,21 @@
 import type { SavedSearchAlertSearch } from "@/lib/saved-search-alerts";
 
 /**
+ * Escape the `\t` / `\n` delimiters (and the `\` escape character itself) so a
+ * field's content cannot shift across a field or entry boundary and forge
+ * another list's signature. Fields containing none of these characters are
+ * returned unchanged, so existing delimiter-free signatures stay identical.
+ */
+function escapeField(value: string | undefined): string {
+  return (value ?? "").replaceAll("\\", "\\\\").replaceAll("\t", "\\t").replaceAll("\n", "\\n");
+}
+
+/**
  * Stable, tab/newline-delimited signature of the alert-relevant fields of each
  * saved search. Used as a memo/effect key so the watch provider only refetches
- * when a search's alert configuration actually changes.
+ * when a search's alert configuration actually changes. Each field is
+ * delimiter-escaped first, so content cannot shift across a boundary and make
+ * two different configurations share a signature.
  */
 export function savedSearchSignature(searches: SavedSearchAlertSearch[]): string {
   return searches
@@ -22,7 +34,9 @@ export function savedSearchSignature(searches: SavedSearchAlertSearch[]): string
         search.platform,
         search.alerts?.enabled ? "1" : "0",
         search.alerts?.channels?.join(",") ?? "",
-      ].join("\t"),
+      ]
+        .map(escapeField)
+        .join("\t"),
     )
     .join("\n");
 }

--- a/tests/saved-search-hash-lib.test.ts
+++ b/tests/saved-search-hash-lib.test.ts
@@ -42,3 +42,27 @@ describe("hashSearch", () => {
     );
   });
 });
+
+describe("hashSearch delimiter escaping", () => {
+  it("does not collide when content shifts across a field boundary", () => {
+    // Regression: both inputs previously joined to "foo|bar|baz|||" and hashed
+    // to the same value, so two unrelated saved searches shared one alert segment.
+    expect(hashSearch(search({ q: "foo", category: "bar|baz" }))).not.toBe(
+      hashSearch(search({ q: "foo|bar", category: "baz" })),
+    );
+  });
+
+  it("does not collide when a field contains the escape character", () => {
+    expect(hashSearch(search({ q: "a\\", category: "b" }))).not.toBe(
+      hashSearch(search({ q: "a", category: "\b" })),
+    );
+  });
+
+  it("keeps hashes stable for searches without delimiter characters", () => {
+    // Escaping is a no-op for delimiter-free fields, so existing alert
+    // segments keep their key.
+    expect(
+      hashSearch(search({ q: "browser", category: "mcp", trust: "verified" })),
+    ).toBe("7l9kg2");
+  });
+});

--- a/tests/saved-search-signature-lib.test.ts
+++ b/tests/saved-search-signature-lib.test.ts
@@ -46,3 +46,27 @@ describe("savedSearchSignature", () => {
     );
   });
 });
+
+describe("savedSearchSignature delimiter escaping", () => {
+  it("does not collide when a tab shifts across a field boundary", () => {
+    // Regression: a tab inside `label` previously merged into the next field,
+    // making two different alert configurations produce one signature.
+    expect(savedSearchSignature([search({ label: "x\ty", q: "z" })])).not.toBe(
+      savedSearchSignature([search({ label: "x", q: "y\tz" })]),
+    );
+  });
+
+  it("does not collide when a newline shifts across an entry boundary", () => {
+    expect(savedSearchSignature([search({ label: "a\nb" })])).not.toBe(
+      savedSearchSignature([search({ label: "a" }), search({ label: "b" })]),
+    );
+  });
+
+  it("keeps signatures stable for delimiter-free fields", () => {
+    expect(
+      savedSearchSignature([
+        search({ id: "1", label: "L", q: "Q", category: "mcp" }),
+      ]),
+    ).toBe("1\tL\tQ\tmcp\t\t\t\t0\t");
+  });
+});


### PR DESCRIPTION
## Summary
`hashSearch` joined fields with a raw `|`, so content shifted across a field boundary produced byte-identical hash input. Verified before the fix: `{q:"foo", category:"bar|baz"}` and `{q:"foo|bar", category:"baz"}` both hashed to `8hrv9c`. Because `hashSearch` keys the newsletter alert segment (`saved-search:${hashSearch(s)}`), a collision lets one user's saved-search alert segment be shared with an unrelated search. `savedSearchSignature` had the identical bug with its `	`/`
` delimiters.

- Escape the delimiter and the escape character itself in each field before joining (`\` -> `\`, `|` -> `\|`; and `	`/`
` for the signature)
- Chose escaping over `JSON.stringify` specifically to satisfy the "don't invalidate existing alert segments" criterion — escaping is a no-op for delimiter-free fields, so existing hashes are preserved
- Contained to the two functions; no consumer changes

Closes #5273

## Test plan
- [x] Reproduced both documented collisions before the fix (`8hrv9c` twice; signature strings byte-identical)
- [x] After the fix both pairs differ (`6t1ugu` vs `kpmusw`; signatures differ)
- [x] **Existing hashes preserved**: `{q:"browser", category:"mcp", trust:"verified"}` still hashes to `7l9kg2`, unchanged from before — existing alert segments keep their key
- [x] Regression tests lock in both collisions plus an escape-character case and the stability invariant (17 tests pass)
- [x] `tsc --noEmit` clean
- [x] No visual impact — pure hashing/serialization change
- [ ] CI: validate-web, coverage, codecov/patch
