### PR TITLE
fix(registry): read weekly brief note signals from trustSignals fallback

### DIFF
--- a/packages/registry/src/weekly-brief-lib.js
+++ b/packages/registry/src/weekly-brief-lib.js
@@ -213,8 +213,13 @@ export function itemFromEntry(entry, reasons, siteUrl) {
     dateAdded: isoDate(entry.dateAdded),
     reasons,
     sourceUrls: sourceUrls(entry).slice(0, 4),
-    safetyNotesCount: list(entry.safetyNotes).length,
-    privacyNotesCount: list(entry.privacyNotes).length,
+    // Fall back to the `trustSignals.has*` booleans: the production directory
+    // index drops the raw arrays, so counting them alone reports 0 in every
+    // real brief. Keeps the exact count when the fuller entry shape has it.
+    safetyNotesCount:
+      list(entry.safetyNotes).length || (hasSafetyNotes(entry) ? 1 : 0),
+    privacyNotesCount:
+      list(entry.privacyNotes).length || (hasPrivacyNotes(entry) ? 1 : 0),
     downloadTrust: entry.downloadTrust || null,
     packageVerified: entry.packageVerified === true,
   };
@@ -225,15 +230,15 @@ export function newEntryReasons(entry) {
   const date = isoDate(entry.dateAdded);
   if (date) reasons.push(`added ${date}`);
   if (hasSource(entry)) reasons.push("source-backed");
-  if (list(entry.safetyNotes).length) reasons.push("has safety notes");
-  if (list(entry.privacyNotes).length) reasons.push("has privacy notes");
+  if (hasSafetyNotes(entry)) reasons.push("has safety notes");
+  if (hasPrivacyNotes(entry)) reasons.push("has privacy notes");
   return reasons.length ? reasons : ["new registry entry"];
 }
 
 export function sourceBackedReasons(entry) {
   const reasons = ["source-backed"];
-  if (list(entry.safetyNotes).length) reasons.push("safety notes present");
-  if (list(entry.privacyNotes).length) reasons.push("privacy notes present");
+  if (hasSafetyNotes(entry)) reasons.push("safety notes present");
+  if (hasPrivacyNotes(entry)) reasons.push("privacy notes present");
   if (entry.claimStatus === "verified") reasons.push("verified claim");
   if (entry.reviewedBy) reasons.push("reviewed metadata");
   return reasons;

--- a/tests/weekly-brief-lib.test.ts
+++ b/tests/weekly-brief-lib.test.ts
@@ -776,3 +776,47 @@ describe("public wrapper re-exports", () => {
     );
   });
 });
+
+describe("safety/privacy signals against the production directory index", () => {
+  // The production directory index drops the raw safetyNotes/privacyNotes
+  // arrays and keeps only the trustSignals.has* booleans, so reading the raw
+  // arrays alone reported 0 notes in every real Weekly Brief email.
+  const prodShaped = entry({
+    trustSignals: { hasSafetyNotes: true, hasPrivacyNotes: true },
+  });
+
+  it("counts notes from trustSignals when the raw arrays are absent", () => {
+    const item = itemFromEntry(prodShaped, SITE_URL);
+    expect(item.safetyNotesCount).toBeGreaterThan(0);
+    expect(item.privacyNotesCount).toBeGreaterThan(0);
+  });
+
+  it("keeps the exact count when the fuller entry shape has the arrays", () => {
+    const item = itemFromEntry(
+      entry({ safetyNotes: ["s1", "s2"], privacyNotes: ["p1"] }),
+      SITE_URL,
+    );
+    expect(item.safetyNotesCount).toBe(2);
+    expect(item.privacyNotesCount).toBe(1);
+  });
+
+  it("still reports zero when the entry has no notes at all", () => {
+    const item = itemFromEntry(entry(), SITE_URL);
+    expect(item.safetyNotesCount).toBe(0);
+    expect(item.privacyNotesCount).toBe(0);
+  });
+
+  it("surfaces note reasons for production-shaped entries", () => {
+    expect(newEntryReasons(prodShaped)).toEqual(
+      expect.arrayContaining(["has safety notes", "has privacy notes"]),
+    );
+    expect(sourceBackedReasons(prodShaped)).toEqual(
+      expect.arrayContaining(["safety notes present", "privacy notes present"]),
+    );
+  });
+
+  it("omits note reasons when the entry has no notes", () => {
+    expect(sourceBackedReasons(entry())).not.toContain("safety notes present");
+    expect(newEntryReasons(entry())).not.toContain("has safety notes");
+  });
+});


### PR DESCRIPTION
## Summary
`itemFromEntry()`, `newEntryReasons()`, and `sourceBackedReasons()` read `entry.safetyNotes`/`entry.privacyNotes` directly, but `buildDirectoryEntries()` never emits those arrays — the production directory index the brief runs against keeps only the `trustSignals.has*` booleans. So `safetyNotesCount`/`privacyNotesCount` were `0` in every real Weekly Brief email and the safety/privacy badges could never render, despite the module's own comment warning about exactly this trap.

- All three functions now use the module's existing `hasSafetyNotes()`/`hasPrivacyNotes()` helpers, which already read both shapes
- Counts keep the exact array length when the fuller entry shape provides it, and fall back to a presence count of `1` when only `trustSignals` is available
- `trustScore()` and `buildDirectoryEntries()` are untouched (both already correct per the issue)

Closes #5253

## Test plan
Verified against both entry shapes:

| entry shape | safety/privacy counts | before |
|---|---|---|
| production (`trustSignals` only) | `1 / 1` | `0 / 0` (bug) |
| full (`["s1","s2"]` / `["p1"]`) | `2 / 1` | `2 / 1` (unchanged) |
| no notes | `0 / 0` | `0 / 0` (unchanged) |

- [x] Regression tests use the production-shaped (trustSignals-only) fixture, matching how the bug actually manifests
- [x] Both other input shapes locked in so neither regresses
- [x] Reason text (`has safety notes`, `safety notes present`) now appears for production-shaped entries, and is still omitted when an entry genuinely has no notes
- [x] All brief-related suites pass (350 tests across 7 files)
- [x] No visual impact — data-layer fix; badge rendering in `brief-email-lib.ts` is unchanged
- [ ] CI: validate-web, coverage, codecov/patch
