### PR TITLE
feat(web): route skills Capability packs Stat to capability-pack tag hub

### DIFF
--- a/apps/web/src/components/data-report.tsx
+++ b/apps/web/src/components/data-report.tsx
@@ -45,14 +45,16 @@ export function DataStat({
   hint,
   to,
   search,
+  params,
   onNavigate,
 }: {
   icon: React.ElementType;
   label: string;
   value: number;
   hint: string;
-  to?: "/browse" | "/quality";
+  to?: "/browse" | "/quality" | "/tags/$tag";
   search?: DistBrowseSearch;
+  params?: { tag: string };
   onNavigate?: () => void;
 }) {
   const body = (
@@ -76,6 +78,7 @@ export function DataStat({
       <Link
         to={to}
         search={to === "/browse" ? search : undefined}
+        params={to === "/tags/$tag" ? params : undefined}
         onClick={onNavigate}
         className="block bg-surface p-5 transition-colors duration-200 ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60"
       >

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -94,7 +94,7 @@ export function stateReportStatAnalyticsEvent(): string {
 export function stateReportStatAnalyticsData(
   reportId: StateReportId,
   statKey: string,
-  destination: "browse" | "quality",
+  destination: "browse" | "quality" | "tag",
 ) {
   return {
     reportId,
@@ -103,21 +103,31 @@ export function stateReportStatAnalyticsData(
   };
 }
 
-/** Browse/quality destination for a state-report headline stat. */
+/** Browse/quality/tag destination for a state-report headline stat. */
 export type StateReportStatBrowseSearch = {
   category?: string;
   source?: string;
   signal?: string;
 };
 
-export type StateReportStatDestination = {
-  to: "/browse" | "/quality";
-  search?: StateReportStatBrowseSearch;
-  destination: "browse" | "quality";
-};
+export type StateReportStatDestination =
+  | {
+      to: "/browse";
+      search?: StateReportStatBrowseSearch;
+      destination: "browse";
+    }
+  | {
+      to: "/quality";
+      destination: "quality";
+    }
+  | {
+      to: "/tags/$tag";
+      params: { tag: string };
+      destination: "tag";
+    };
 
 /**
- * Map a state-report headline stat to browse/quality egress.
+ * Map a state-report headline stat to browse/quality/tag egress.
  * Covers all five public state reports (tooling, mcp, hooks, agents, skills).
  */
 export function stateReportStatDestination(
@@ -218,11 +228,16 @@ export function stateReportStatDestination(
             destination: "browse",
           };
         case "total":
-        case "packs":
           return {
             to: "/browse",
             search: { category: "skills" },
             destination: "browse",
+          };
+        case "packs":
+          return {
+            to: "/tags/$tag",
+            params: { tag: "capability-pack" },
+            destination: "tag",
           };
         default:
           return null;

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -140,7 +140,8 @@ function StateOfAgentSkillsPage() {
               value={stat.value}
               hint={statHint(stat)}
               to={destination?.to}
-              search={destination?.search}
+              search={destination && "search" in destination ? destination.search : undefined}
+              params={destination && "params" in destination ? destination.params : undefined}
               onNavigate={() => trackStat(stat.key)}
             />
           );

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -140,7 +140,8 @@ function StateOfAiAgentsPage() {
               value={stat.value}
               hint={statHint(stat)}
               to={destination?.to}
-              search={destination?.search}
+              search={destination && "search" in destination ? destination.search : undefined}
+              params={destination && "params" in destination ? destination.params : undefined}
               onNavigate={() => trackStat(stat.key)}
             />
           );

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -140,7 +140,8 @@ function StateOfClaudeCodeHooksPage() {
               value={stat.value}
               hint={statHint(stat)}
               to={destination?.to}
-              search={destination?.search}
+              search={destination && "search" in destination ? destination.search : undefined}
+              params={destination && "params" in destination ? destination.params : undefined}
               onNavigate={() => trackStat(stat.key)}
             />
           );

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -283,7 +283,8 @@ function StateOfClaudeToolingPage() {
               value={stat.value}
               hint={stat.hint}
               to={destination?.to}
-              search={destination?.search}
+              search={destination && "search" in destination ? destination.search : undefined}
+              params={destination && "params" in destination ? destination.params : undefined}
               onNavigate={() => trackStat(stat.key)}
             />
           );

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -295,7 +295,8 @@ function StateOfMcpServersPage() {
               value={stat.value}
               hint={stat.hint}
               to={destination?.to}
-              search={destination?.search}
+              search={destination && "search" in destination ? destination.search : undefined}
+              params={destination && "params" in destination ? destination.params : undefined}
               onNavigate={() => trackStat(stat.key)}
             />
           );

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -186,9 +186,9 @@ describe("state report page cta events lib", () => {
       destination: "browse",
     });
     expect(stateReportStatDestination("agent-skills", "packs")).toEqual({
-      to: "/browse",
-      search: { category: "skills" },
-      destination: "browse",
+      to: "/tags/$tag",
+      params: { tag: "capability-pack" },
+      destination: "tag",
     });
     expect(stateReportStatDestination("agent-skills", "packaged")).toEqual({
       to: "/browse",


### PR DESCRIPTION
## Summary
- Point agent-skills headline **Capability packs** DataStat to `/tags/capability-pack` (aligned with skill-type DistTable)
- Extend `DataStat` / `stateReportStatDestination` to support tag-hub destinations (`destination: "tag"`)

## Test plan
- [x] prettier + vitest on `state-report-page-cta-events-lib`
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate
- [ ] Open /state-of-agent-skills and click Capability packs Stat → tag hub

Refs #550