### PR TITLE
fix(web): escape delimiters in saved-search hash and signature

### DIFF
--- a/apps/web/src/lib/saved-search-hash-lib.ts
+++ b/apps/web/src/lib/saved-search-hash-lib.ts
@@ -4,13 +4,24 @@
 import type { SavedSearch } from "@/lib/recents";
 
 /**
+ * Escape the `|` field delimiter (and the `\` escape character itself) so no
+ * field's content can shift across a boundary and forge another search's hash
+ * input. Fields containing neither character are returned unchanged, so
+ * existing delimiter-free searches keep their current hash.
+ */
+function escapeField(value: string | undefined): string {
+  return (value ?? "").replaceAll("\\", "\\\\").replaceAll("|", "\\|");
+}
+
+/**
  * Stable base36 hash of a saved search's identifying fields (query plus the
  * category / trust / source / platform filters). Used to key saved-search alert
- * segments: equal searches hash equally; different searches (almost) always
- * differ. Deterministic — no ordering or clock dependence.
+ * segments: equal searches hash equally, and differing searches hash
+ * differently because each field is delimiter-escaped before joining.
+ * Deterministic — no ordering or clock dependence.
  */
 export function hashSearch(s: SavedSearch): string {
-  const raw = `${s.q}|${s.category ?? ""}|${s.trust ?? ""}|${s.source ?? ""}|${s.platform ?? ""}`;
+  const raw = [s.q, s.category, s.trust, s.source, s.platform].map(escapeField).join("|");
   let h = 0;
   for (let i = 0; i < raw.length; i++) h = (h * 31 + raw.charCodeAt(i)) | 0;
   return Math.abs(h).toString(36);

--- a/apps/web/src/lib/saved-search-signature-lib.ts
+++ b/apps/web/src/lib/saved-search-signature-lib.ts
@@ -5,9 +5,21 @@
 import type { SavedSearchAlertSearch } from "@/lib/saved-search-alerts";
 
 /**
+ * Escape the `\t` / `\n` delimiters (and the `\` escape character itself) so a
+ * field's content cannot shift across a field or entry boundary and forge
+ * another list's signature. Fields containing none of these characters are
+ * returned unchanged, so existing delimiter-free signatures stay identical.
+ */
+function escapeField(value: string | undefined): string {
+  return (value ?? "").replaceAll("\\", "\\\\").replaceAll("\t", "\\t").replaceAll("\n", "\\n");
+}
+
+/**
  * Stable, tab/newline-delimited signature of the alert-relevant fields of each
  * saved search. Used as a memo/effect key so the watch provider only refetches
- * when a search's alert configuration actually changes.
+ * when a search's alert configuration actually changes. Each field is
+ * delimiter-escaped first, so content cannot shift across a boundary and make
+ * two different configurations share a signature.
  */
 export function savedSearchSignature(searches: SavedSearchAlertSearch[]): string {
   return searches
@@ -22,7 +34,9 @@ export function savedSearchSignature(searches: SavedSearchAlertSearch[]): string
         search.platform,
         search.alerts?.enabled ? "1" : "0",
         search.alerts?.channels?.join(",") ?? "",
-      ].join("\t"),
+      ]
+        .map(escapeField)
+        .join("\t"),
     )
     .join("\n");
 }

--- a/tests/saved-search-hash-lib.test.ts
+++ b/tests/saved-search-hash-lib.test.ts
@@ -42,3 +42,37 @@ describe("hashSearch", () => {
     );
   });
 });
+
+describe("hashSearch delimiter escaping", () => {
+  it("does not collide when content shifts across a field boundary", () => {
+    // Regression: both inputs previously joined to "foo|bar|baz|||" and hashed
+    // to the same value, so two unrelated saved searches shared one alert segment.
+    expect(hashSearch(search({ q: "foo", category: "bar|baz" }))).not.toBe(
+      hashSearch(search({ q: "foo|bar", category: "baz" })),
+    );
+  });
+
+  it("does not collide when a field contains the escape character", () => {
+    // Built from the char code so the fixture is unambiguously one literal
+    // backslash. Escaping only `|` is not enough: a raw backslash can forge
+    // the `\|` produced by an escaped pipe, so these two searches both
+    // serialize to "\||\|||" unless the backslash is escaped too.
+    const BACKSLASH = String.fromCharCode(92);
+    const pipeThenBackslash = search({ q: "|", category: BACKSLASH });
+    const backslashThenPipe = search({ q: BACKSLASH, trust: "|" });
+
+    expect(pipeThenBackslash.category).toHaveLength(1);
+    expect(backslashThenPipe.q).toHaveLength(1);
+    expect(hashSearch(pipeThenBackslash)).not.toBe(
+      hashSearch(backslashThenPipe),
+    );
+  });
+
+  it("keeps hashes stable for searches without delimiter characters", () => {
+    // Escaping is a no-op for delimiter-free fields, so existing alert
+    // segments keep their key.
+    expect(
+      hashSearch(search({ q: "browser", category: "mcp", trust: "verified" })),
+    ).toBe("7l9kg2");
+  });
+});

--- a/tests/saved-search-signature-lib.test.ts
+++ b/tests/saved-search-signature-lib.test.ts
@@ -46,3 +46,27 @@ describe("savedSearchSignature", () => {
     );
   });
 });
+
+describe("savedSearchSignature delimiter escaping", () => {
+  it("does not collide when a tab shifts across a field boundary", () => {
+    // Regression: a tab inside `label` previously merged into the next field,
+    // making two different alert configurations produce one signature.
+    expect(savedSearchSignature([search({ label: "x\ty", q: "z" })])).not.toBe(
+      savedSearchSignature([search({ label: "x", q: "y\tz" })]),
+    );
+  });
+
+  it("does not collide when a newline shifts across an entry boundary", () => {
+    expect(savedSearchSignature([search({ label: "a\nb" })])).not.toBe(
+      savedSearchSignature([search({ label: "a" }), search({ label: "b" })]),
+    );
+  });
+
+  it("keeps signatures stable for delimiter-free fields", () => {
+    expect(
+      savedSearchSignature([
+        search({ id: "1", label: "L", q: "Q", category: "mcp" }),
+      ]),
+    ).toBe("1\tL\tQ\tmcp\t\t\t\t0\t");
+  });
+});


### PR DESCRIPTION
## Summary
Supersedes #5319, which was closed after review correctly caught that its escape-character test did not test what it claimed. Both review nits are addressed and the fix itself is unchanged.

`hashSearch` joined fields with a raw `|`, so content shifted across a field boundary produced identical hash input: `{q:"foo", category:"bar|baz"}` and `{q:"foo|bar", category:"baz"}` both hashed to `8hrv9c`. That hash keys the newsletter alert segment, so colliding searches shared an alert segment. `savedSearchSignature` had the same bug with `	`/`
`.

- Escape the delimiter and the escape character itself in each field before joining
- Chose escaping over `JSON.stringify` to satisfy the "don't invalidate existing alert segments" criterion — it is a no-op for delimiter-free fields
- Contained to the two functions; no consumer changes

**Review feedback addressed**
- *Escape-character test didn't exercise the `\` path*: correct, and worse than reported — the old fixture pair differed under either implementation, so it could never have caught a regression. Rewritten using a pair that genuinely collides without backslash escaping (`{q:"|", category:"\\"}` vs `{q:"\\", trust:"|"}`, which both serialize to `\||\|||` when only `|` is escaped). Fixture chars are built via `String.fromCharCode(92)` so the literal is unambiguous.
- *`escapeField` signature mismatch between the two files*: both now take `string | undefined` and handle the nullish case internally, which also removed the duplicated `?? ""` at the hash call sites.

Closes #5273

## Test plan
- [x] Both documented collisions reproduced before the fix, resolved after
- [x] **Mutation-tested the new escape-character assertion**: removing only the backslash-escaping step makes it fail, and restoring it makes it pass — so it now actually guards the property (the previous version passed against that mutant)
- [x] Existing hashes preserved: `{q:"browser", category:"mcp", trust:"verified"}` still hashes to `7l9kg2`
- [x] 17 tests pass across both suites; `tsc --noEmit` clean
- [x] No visual impact — pure hashing/serialization change
- [ ] CI: validate-web, coverage, codecov/patch
