### PR TITLE
fix(web): include submittedBy in saved-search alert matching

### DIFF
--- a/apps/web/src/lib/saved-search-alerts-lib.ts
+++ b/apps/web/src/lib/saved-search-alerts-lib.ts
@@ -43,6 +43,7 @@ export interface SavedSearchAlertEntry {
   description?: string;
   cardDescription?: string;
   author?: string;
+  submittedBy?: string;
   tags?: string[];
   keywords?: string[];
   platforms?: Array<Platform | string>;
@@ -93,6 +94,7 @@ function normalizedEntryText(entry: SavedSearchAlertEntry) {
     entry.description,
     entry.cardDescription,
     entry.author,
+    entry.submittedBy,
     entry.trust,
     entry.source,
     ...(entry.platforms ?? []),

--- a/tests/saved-search-alerts-lib.test.ts
+++ b/tests/saved-search-alerts-lib.test.ts
@@ -91,6 +91,19 @@ describe("savedSearchQueryMatchesEntry", () => {
     expect(savedSearchQueryMatchesEntry(entry, "mcp")).toBe(true);
   });
 
+  it("matches on submittedBy so alerts mirror the live /browse haystack", () => {
+    // `normalizedSearchText` in data/search.ts includes `submittedBy`, so a
+    // saved search that matches only via the submitter must fire alerts too.
+    const submitted: SavedSearchAlertEntry = {
+      category: "mcp",
+      slug: "acme-server",
+      title: "Unrelated Title",
+      submittedBy: "acme-corp",
+    };
+    expect(savedSearchQueryMatchesEntry(submitted, "acme-corp")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(submitted, "other-corp")).toBe(false);
+  });
+
   it("uses the shared alias map for saved-search query expansion", () => {
     const automationEntry: SavedSearchAlertEntry = {
       ...entry,


### PR DESCRIPTION
## Summary
The live `/browse` haystack (`normalizedSearchText` in `data/search.ts`) includes `entry.submittedBy`, but the saved-search alert haystack (`normalizedEntryText`) omitted it and `SavedSearchAlertEntry` did not even declare the field. A saved search matching only via a submitter (e.g. `q: "acme-corp"`) surfaced the entry live on `/browse` but never fired an in-app alert for its add/update events.

- Declare `submittedBy` on `SavedSearchAlertEntry`
- Include `entry.submittedBy` in `normalizedEntryText`, in the same position as the live haystack so the two field sets now match exactly

The runtime objects already carry `submittedBy` (full `Entry` records via `loadEventEntries` -> `buildEntry`), so this only widens the declared/matched surface — no caller changes.

Closes #5274

## Test plan
- [x] Confirmed the drift first: an entry matchable only by `submittedBy` did not match before the change, and does after
- [x] **Mutation-tested the regression test**: removing `entry.submittedBy` from the haystack makes the new test fail, so it genuinely guards the field rather than passing incidentally
- [x] Negative case included (a different submitter still does not match)
- [x] Existing saved-search alert suites pass unchanged (28 tests across both files)
- [x] `tsc --noEmit` clean
- [x] No visual impact — matching-logic only
- [ ] CI: validate-web, coverage, codecov/patch
