### PR TITLE
feat(web): map Source-backed Stats to browse signal filter

### DIFF
--- a/apps/web/src/lib/home-page-cta-events-lib.ts
+++ b/apps/web/src/lib/home-page-cta-events-lib.ts
@@ -209,7 +209,7 @@ export function homeTrustStatDestination(statId: string): HomeTrustStatDestinati
     case "trusted":
       return { to: "/browse", search: { trust: "trusted" } };
     case "source-backed":
-      return { to: "/browse", search: { source: "source-backed" } };
+      return { to: "/browse", search: { signal: "source-backed" } };
     case "reviewed":
       return { to: "/browse", search: { signal: "reviewed" } };
     case "live-signals":

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -130,7 +130,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { source: "source-backed" },
+            search: { signal: "source-backed" },
             destination: "browse",
           };
         case "reviewed":
@@ -146,7 +146,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "mcp", source: "source-backed" },
+            search: { category: "mcp", signal: "source-backed" },
             destination: "browse",
           };
         case "total":
@@ -190,7 +190,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "agents", source: "source-backed" },
+            search: { category: "agents", signal: "source-backed" },
             destination: "browse",
           };
         case "total":

--- a/apps/web/src/lib/validators-tools-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-tools-cta-events-lib.ts
@@ -43,7 +43,7 @@ export function validatorsSummaryStatAnalyticsData(
 
 export type ValidatorsSummaryStatDestination = {
   to: "/browse" | "/quality";
-  search?: { source?: string };
+  search?: { source?: string; signal?: string };
   destination: "browse" | "quality";
 };
 

--- a/apps/web/src/lib/validators-tools-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-tools-cta-events-lib.ts
@@ -59,7 +59,7 @@ export function validatorsSummaryStatDestination(
     case "source-backed":
       return {
         to: "/browse",
-        search: { source: "source-backed" },
+        search: { signal: "source-backed" },
         destination: "browse",
       };
     case "needs-attention":

--- a/tests/home-page-cta-events-lib.test.ts
+++ b/tests/home-page-cta-events-lib.test.ts
@@ -151,7 +151,7 @@ describe("home page cta events lib", () => {
     });
     expect(homeTrustStatDestination("source-backed")).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
     });
     expect(homeTrustStatDestination("reviewed")).toEqual({
       to: "/browse",

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -96,7 +96,7 @@ describe("state report page cta events lib", () => {
       stateReportStatDestination("claude-tooling", "source-backed"),
     ).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("claude-tooling", "reviewed")).toEqual({
@@ -122,7 +122,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("mcp-servers", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "mcp", source: "source-backed" },
+      search: { category: "mcp", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("mcp-servers", "unknown")).toBeNull();
@@ -165,7 +165,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("ai-agents", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "agents", source: "source-backed" },
+      search: { category: "agents", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("ai-agents", "ready")).toEqual({

--- a/tests/validators-tools-cta-events-lib.test.ts
+++ b/tests/validators-tools-cta-events-lib.test.ts
@@ -52,7 +52,7 @@ describe("validators tools cta events lib", () => {
     });
     expect(validatorsSummaryStatDestination("source-backed")).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
       destination: "browse",
     });
     expect(validatorsSummaryStatDestination("needs-attention")).toEqual({


### PR DESCRIPTION
## Summary
- Remap headline **Source-backed** Stats from browse `source=source-backed` (exact provenance enum) to `signal=source-backed` (trust-signal filter)
- Aligns state reports, home trust strip, and validators summary with quality/hubs/contributor destinations
- Lib-only destination change — DistTable provenance rows still use exact `source:` buckets

## Test plan
- [x] prettier + vitest on state-report / home / validators-tools CTA libs
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [ ] CI: validate-web, coverage, codecov/patch, required-pr-gate
- [ ] Click Source-backed Stats on home, state reports, and validators → browse signal filter

Refs #550