### PR TITLE
fix(web): require a named reviewer for the maintainer-reviewed signal

### DIFF
--- a/apps/web/src/lib/entry-normalize-lib.ts
+++ b/apps/web/src/lib/entry-normalize-lib.ts
@@ -445,7 +445,11 @@ export function buildEntryFromRegistry(entry: RegistryEntry, attribution: EntryA
     repoStats: normalizeRepoStats(entry),
     relatedEntries: normalizeRelatedEntries(entry.relatedEntries),
     dateAdded: entry.dateAdded ?? entry.contentUpdatedAt?.slice(0, 10) ?? "2026-01-01",
-    reviewed: Boolean(reviewedAt || entry.packageVerified),
+    // Requires a named reviewer. `reviewedAt` falls back to the build-time
+    // `contentUpdatedAt`, and `packageVerified` is an automated package check,
+    // so neither evidences the human sign-off the "Maintainer-reviewed" label
+    // claims.
+    reviewed: Boolean(entry.reviewedBy),
     claimed: normalizeClaimStatus(entry.claimStatus) === "verified",
     claimStatus: normalizeClaimStatus(entry.claimStatus),
     safetyNotes,

--- a/tests/entry-normalize-lib.test.ts
+++ b/tests/entry-normalize-lib.test.ts
@@ -475,7 +475,9 @@ describe("buildEntryFromRegistry", () => {
       dateAdded: "2026-03-01",
       claimStatus: "verified",
       claimed: true,
-      reviewed: true,
+      // This fixture has no `reviewedBy`, so there is no named maintainer
+      // sign-off to report.
+      reviewed: false,
       harness: ["claude-code"],
     });
     expect(entry.relatedEntries).toEqual([
@@ -551,9 +553,35 @@ describe("buildEntryFromRegistry", () => {
     expect(entry.skillType).toBe("general");
     expect(entry.skillLevel).toBe("foundational");
     expect(entry.verificationStatus).toBe("validated");
-    expect(entry.reviewed).toBe(true);
+    // `packageVerified` + `reviewedAt` are automated signals, not a maintainer
+    // sign-off, so they must not satisfy `reviewed`.
+    expect(entry.reviewed).toBe(false);
     expect(entry.repoUrl).toBeUndefined();
     expect(entry.sourceUrl).toBe("https://github.com/example/repo");
+  });
+
+  it("only reports reviewed for an actual named reviewer", () => {
+    // `contentUpdatedAt` is a build-time stamp the content pipeline sets when
+    // frontmatter omits one — no human reviewed anything, so the
+    // "Maintainer-reviewed" claim must not be satisfied by it.
+    const buildStampOnly = buildEntryFromRegistry(
+      baseEntry({ contentUpdatedAt: "2026-02-01T00:00:00.000Z" }),
+      attribution(),
+    );
+    expect(buildStampOnly.reviewed).toBe(false);
+
+    // Automated package verification is likewise not a maintainer sign-off.
+    const packageVerifiedOnly = buildEntryFromRegistry(
+      baseEntry({ packageVerified: true }),
+      attribution(),
+    );
+    expect(packageVerifiedOnly.reviewed).toBe(false);
+
+    const namedReviewer = buildEntryFromRegistry(
+      baseEntry({ reviewedBy: "Maintainer Name" }),
+      attribution(),
+    );
+    expect(namedReviewer.reviewed).toBe(true);
   });
 
   it("uses copy payload precedence and source url fallbacks", () => {


### PR DESCRIPTION
## Summary
`reviewed` was `Boolean(reviewedAt || entry.packageVerified)`, where `reviewedAt` falls back through `entry.contentUpdatedAt` — a build-time stamp the content pipeline sets when frontmatter omits one. No human is involved, yet the UI renders "Maintainer-reviewed" / "A maintainer signed off on the metadata."

- `reviewed` is now `Boolean(entry.reviewedBy)` — an actual named reviewer
- Matches the stricter sibling computation already used by `quality-dashboard-lib.ts`'s `countClaimedOrReviewedByCategory`
- `QUALITY_STATS.reviewed`, `REVIEW_COVERAGE`/`REVIEW_SUMMARY`/`RECENT_REVIEWED`, and the `-10` unreviewed quality deduction all derive from this field, so they now reflect the corrected count

Closes #5272

## Before / after across the full entry set

| | before | after |
|---|---|---|
| entries reporting `reviewed: true` | **1340 / 1340** | **6 / 1340** |
| entries with a named `reviewedBy` | 6 | 6 |

Every entry in the directory previously claimed maintainer review; only 6 actually have a reviewer. 1334 entries flip to `reviewed: false`, and the remaining 6 match the named-reviewer set exactly. Note 108 entries have `packageVerified` without a reviewer — automated package verification, which no longer counts as sign-off.

## Test plan
- [x] New regression test covers the exact case from the issue: an entry with only `contentUpdatedAt` (no `reviewedBy`) is now `reviewed: false`; also covers `packageVerified`-only false, and a named reviewer true
- [x] Updated two existing assertions that encoded the old behavior — both fixtures set `reviewedAt`/`packageVerified` with no `reviewedBy`, so they were locking in the bug
- [x] **Full suite run before and after**: this change accounts for exactly 2 test deltas, both the assertions above. After updating them the suite returns to its pre-existing baseline (6 files / 7 tests failing on this Windows box for unrelated path-separator reasons, identical with and without this change)
- [x] `tsc --noEmit` clean
- [x] No visual change other than the badge label now being accurate
- [ ] CI: validate-web, coverage, codecov/patch
