### PR TITLE
fix(web): persist checkedAt for all admin job state transitions

### DIFF
--- a/apps/web/src/lib/job-admin-lib.ts
+++ b/apps/web/src/lib/job-admin-lib.ts
@@ -479,12 +479,18 @@ export async function updateAdminJobState(
 
   const result = await db
     .prepare(
+      // `checkedAt` records when the source was last verified, so it is
+      // persisted for every action — a job closed for a dead source must keep
+      // the timestamp that justified the closure. `stale_check_count` still
+      // resets only for activate/reactivate, which are the actions that mean
+      // the source is healthy again; close/archive/expire/review keep the
+      // accumulated stale history.
       `UPDATE jobs_listings
       SET
         status = ?,
         expires_at = CASE WHEN ? = 1 THEN ? ELSE expires_at END,
-        source_checked_at = CASE WHEN ? IN ('activate', 'reactivate') THEN ? ELSE source_checked_at END,
-        last_checked_at = CASE WHEN ? IN ('activate', 'reactivate') THEN ? ELSE last_checked_at END,
+        source_checked_at = ?,
+        last_checked_at = ?,
         stale_check_count = CASE WHEN ? IN ('activate', 'reactivate') THEN 0 ELSE stale_check_count END,
         updated_at = CURRENT_TIMESTAMP
       WHERE slug = ?`,
@@ -493,9 +499,7 @@ export async function updateAdminJobState(
       nextStatus,
       hasExpiresAt ? 1 : 0,
       expiresAt,
-      input.action,
       checkedAt,
-      input.action,
       checkedAt,
       input.action,
       input.slug,

--- a/tests/job-admin-lib.test.ts
+++ b/tests/job-admin-lib.test.ts
@@ -797,6 +797,41 @@ describe("updateAdminJobState", () => {
     expect(db.runCalls.at(-1)?.values).toContain(expectedStatus);
   });
 
+  it.each(["close", "archive", "expire", "review"] as const)(
+    "persists checkedAt for action %s",
+    async (action) => {
+      // scripts/check-d1-job-sources.mjs sends checkedAt when it closes a job
+      // for a dead source; that timestamp justifies the closure and was
+      // previously dropped for these four actions.
+      const db = new FakeD1();
+      db.jobRows = [validActiveJobRow({ slug: `${action}-checked` })];
+      await updateAdminJobState(db, {
+        slug: `${action}-checked`,
+        action,
+        checkedAt: VALID_CHECKED_AT,
+      });
+      const call = db.runCalls.at(-1);
+      expect(call?.query).toContain("source_checked_at = ?");
+      expect(call?.query).toContain("last_checked_at = ?");
+      expect(call?.values).toContain(VALID_CHECKED_AT);
+    },
+  );
+
+  it("keeps the stale_check_count reset scoped to activate/reactivate", async () => {
+    // Only activate/reactivate mean the source is healthy again, so closing or
+    // archiving must not wipe the accumulated stale history.
+    const db = new FakeD1();
+    db.jobRows = [validActiveJobRow({ slug: "close-history" })];
+    await updateAdminJobState(db, {
+      slug: "close-history",
+      action: "close",
+      checkedAt: VALID_CHECKED_AT,
+    });
+    expect(db.runCalls.at(-1)?.query).toContain(
+      "stale_check_count = CASE WHEN ? IN ('activate', 'reactivate') THEN 0 ELSE stale_check_count END",
+    );
+  });
+
   it("marks a job stale and increments stale_check_count", async () => {
     const db = new FakeD1();
     db.jobRows = [


### PR DESCRIPTION
## Summary
`updateAdminJobState`'s generic UPDATE branch only wrote `source_checked_at`/`last_checked_at` when the action was `activate`/`reactivate`, so the `checkedAt` value was silently dropped for `close`, `archive`, `expire`, and `review`. `scripts/check-d1-job-sources.mjs` sends `checkedAt` on exactly those calls when it closes a repeatedly-failing job source — so a job closed for a dead source lost the timestamp that justified the closure.

- `source_checked_at`/`last_checked_at` are now written unconditionally (the value already defaults to `now()` when the caller omits it, so no action loses data)
- Removed the now-redundant `CASE WHEN ... IN ('activate','reactivate')` wrappers and their duplicate bind parameters for those two columns

Closes #5266

## Invariant: `stale_check_count` reset stays scoped (deliberate, not an oversight)
The issue asked to confirm this. `stale_check_count = 0` remains gated on `activate`/`reactivate` only, because those are the actions that mean *the source is healthy again*. Resetting it on `close`/`archive`/`expire`/`review` would erase the accumulated stale history that justified closing the job — the opposite of this fix's intent. There is a dedicated test asserting the reset stays scoped.

The `stale` and `revalidate` branches are untouched (already correct per the issue).

## Test plan
- [x] Validation command from the issue passes: `vitest run tests/job-admin-lib.test.ts tests/web-job-admin.test.ts` — 258 tests
- [x] Regression test locks in `checkedAt` persistence for each of the 4 previously-broken actions
- [x] **Mutation-tested**: restoring the original action-scoped SQL makes all 4 new tests fail, so they genuinely guard the fix
- [x] Existing activate/reactivate/stale/revalidate assertions pass unchanged
- [x] `tsc --noEmit` clean
- [x] No visual impact — persistence-layer fix
- [ ] CI: validate-web, coverage, codecov/patch
