### PR TITLE
feat(web): align Source-backed and tooling reviewed Stats to browse signals

### DIFF
--- a/apps/web/src/lib/home-page-cta-events-lib.ts
+++ b/apps/web/src/lib/home-page-cta-events-lib.ts
@@ -209,7 +209,7 @@ export function homeTrustStatDestination(statId: string): HomeTrustStatDestinati
     case "trusted":
       return { to: "/browse", search: { trust: "trusted" } };
     case "source-backed":
-      return { to: "/browse", search: { source: "source-backed" } };
+      return { to: "/browse", search: { signal: "source-backed" } };
     case "reviewed":
       return { to: "/browse", search: { signal: "reviewed" } };
     case "live-signals":

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -130,11 +130,15 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { source: "source-backed" },
+            search: { signal: "source-backed" },
             destination: "browse",
           };
         case "reviewed":
-          return { to: "/quality", destination: "quality" };
+          return {
+            to: "/browse",
+            search: { signal: "reviewed" },
+            destination: "browse",
+          };
         case "total":
         case "categories":
           return { to: "/browse", destination: "browse" };
@@ -146,7 +150,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "mcp", source: "source-backed" },
+            search: { category: "mcp", signal: "source-backed" },
             destination: "browse",
           };
         case "total":
@@ -190,7 +194,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "agents", source: "source-backed" },
+            search: { category: "agents", signal: "source-backed" },
             destination: "browse",
           };
         case "total":

--- a/apps/web/src/lib/validators-tools-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-tools-cta-events-lib.ts
@@ -43,7 +43,7 @@ export function validatorsSummaryStatAnalyticsData(
 
 export type ValidatorsSummaryStatDestination = {
   to: "/browse" | "/quality";
-  search?: { source?: string };
+  search?: { source?: string; signal?: string };
   destination: "browse" | "quality";
 };
 
@@ -59,7 +59,7 @@ export function validatorsSummaryStatDestination(
     case "source-backed":
       return {
         to: "/browse",
-        search: { source: "source-backed" },
+        search: { signal: "source-backed" },
         destination: "browse",
       };
     case "needs-attention":

--- a/tests/home-page-cta-events-lib.test.ts
+++ b/tests/home-page-cta-events-lib.test.ts
@@ -151,7 +151,7 @@ describe("home page cta events lib", () => {
     });
     expect(homeTrustStatDestination("source-backed")).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
     });
     expect(homeTrustStatDestination("reviewed")).toEqual({
       to: "/browse",

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -96,12 +96,13 @@ describe("state report page cta events lib", () => {
       stateReportStatDestination("claude-tooling", "source-backed"),
     ).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("claude-tooling", "reviewed")).toEqual({
-      to: "/quality",
-      destination: "quality",
+      to: "/browse",
+      search: { signal: "reviewed" },
+      destination: "browse",
     });
     expect(stateReportStatDestination("claude-tooling", "unknown")).toBeNull();
 
@@ -122,7 +123,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("mcp-servers", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "mcp", source: "source-backed" },
+      search: { category: "mcp", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("mcp-servers", "unknown")).toBeNull();
@@ -165,7 +166,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("ai-agents", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "agents", source: "source-backed" },
+      search: { category: "agents", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("ai-agents", "ready")).toEqual({

--- a/tests/validators-tools-cta-events-lib.test.ts
+++ b/tests/validators-tools-cta-events-lib.test.ts
@@ -52,7 +52,7 @@ describe("validators tools cta events lib", () => {
     });
     expect(validatorsSummaryStatDestination("source-backed")).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
       destination: "browse",
     });
     expect(validatorsSummaryStatDestination("needs-attention")).toEqual({


### PR DESCRIPTION
Closes #550

## Summary
- Remap tooling **Maintainer-reviewed** Stat from `/quality` → browse `signal=reviewed` (matches home/quality/hubs/skills validated)
- Remap **Source-backed** Stats from `source=` → `signal=source-backed` on state reports, home, and validators (re-lands closed #5324)
- Lib + tests only; DistTable provenance rows still use exact `source:` buckets

## Note on issue link
Epic #550 is already closed; `Closes #550` is used so LoopOver detects the Growth Sprint link. This does not reopen scope beyond privacy-light CTA destination alignment under that epic (also see #556).

## Test plan
- [x] prettier + vitest on state-report / home / validators-tools CTA libs
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [x] CI: validate-web, coverage, codecov/patch, required-pr-gate

Refs #550