### PR TITLE
feat(web): align headline Stats to browse trust-signal filters

### DIFF
--- a/apps/web/src/lib/home-page-cta-events-lib.ts
+++ b/apps/web/src/lib/home-page-cta-events-lib.ts
@@ -209,7 +209,7 @@ export function homeTrustStatDestination(statId: string): HomeTrustStatDestinati
     case "trusted":
       return { to: "/browse", search: { trust: "trusted" } };
     case "source-backed":
-      return { to: "/browse", search: { source: "source-backed" } };
+      return { to: "/browse", search: { signal: "source-backed" } };
     case "reviewed":
       return { to: "/browse", search: { signal: "reviewed" } };
     case "live-signals":

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -130,11 +130,15 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { source: "source-backed" },
+            search: { signal: "source-backed" },
             destination: "browse",
           };
         case "reviewed":
-          return { to: "/quality", destination: "quality" };
+          return {
+            to: "/browse",
+            search: { signal: "reviewed" },
+            destination: "browse",
+          };
         case "total":
         case "categories":
           return { to: "/browse", destination: "browse" };
@@ -146,7 +150,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "mcp", source: "source-backed" },
+            search: { category: "mcp", signal: "source-backed" },
             destination: "browse",
           };
         case "total":
@@ -190,7 +194,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "agents", source: "source-backed" },
+            search: { category: "agents", signal: "source-backed" },
             destination: "browse",
           };
         case "total":

--- a/apps/web/src/lib/validators-tools-cta-events-lib.ts
+++ b/apps/web/src/lib/validators-tools-cta-events-lib.ts
@@ -43,7 +43,7 @@ export function validatorsSummaryStatAnalyticsData(
 
 export type ValidatorsSummaryStatDestination = {
   to: "/browse" | "/quality";
-  search?: { source?: string };
+  search?: { signal?: string };
   destination: "browse" | "quality";
 };
 
@@ -55,11 +55,15 @@ export function validatorsSummaryStatDestination(
     case "entries":
       return { to: "/browse", destination: "browse" };
     case "safety-coverage":
-      return { to: "/quality", destination: "quality" };
+      return {
+        to: "/browse",
+        search: { signal: "reviewed" },
+        destination: "browse",
+      };
     case "source-backed":
       return {
         to: "/browse",
-        search: { source: "source-backed" },
+        search: { signal: "source-backed" },
         destination: "browse",
       };
     case "needs-attention":

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -495,7 +495,7 @@ function SummaryStat({
   value: React.ReactNode;
   help?: string;
   to?: "/browse" | "/quality";
-  search?: { source?: string };
+  search?: { source?: string; signal?: string };
   statId?: ValidatorsSummaryStatId;
   destination?: "browse" | "quality" | "validators-skill-package" | "validators-mcp-config";
 }) {

--- a/tests/home-page-cta-events-lib.test.ts
+++ b/tests/home-page-cta-events-lib.test.ts
@@ -151,7 +151,7 @@ describe("home page cta events lib", () => {
     });
     expect(homeTrustStatDestination("source-backed")).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
     });
     expect(homeTrustStatDestination("reviewed")).toEqual({
       to: "/browse",

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -96,12 +96,13 @@ describe("state report page cta events lib", () => {
       stateReportStatDestination("claude-tooling", "source-backed"),
     ).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("claude-tooling", "reviewed")).toEqual({
-      to: "/quality",
-      destination: "quality",
+      to: "/browse",
+      search: { signal: "reviewed" },
+      destination: "browse",
     });
     expect(stateReportStatDestination("claude-tooling", "unknown")).toBeNull();
 
@@ -122,7 +123,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("mcp-servers", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "mcp", source: "source-backed" },
+      search: { category: "mcp", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("mcp-servers", "unknown")).toBeNull();
@@ -165,7 +166,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("ai-agents", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "agents", source: "source-backed" },
+      search: { category: "agents", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("ai-agents", "ready")).toEqual({

--- a/tests/validators-tools-cta-events-lib.test.ts
+++ b/tests/validators-tools-cta-events-lib.test.ts
@@ -47,12 +47,13 @@ describe("validators tools cta events lib", () => {
       destination: "browse",
     });
     expect(validatorsSummaryStatDestination("safety-coverage")).toEqual({
-      to: "/quality",
-      destination: "quality",
+      to: "/browse",
+      search: { signal: "reviewed" },
+      destination: "browse",
     });
     expect(validatorsSummaryStatDestination("source-backed")).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
       destination: "browse",
     });
     expect(validatorsSummaryStatDestination("needs-attention")).toEqual({


### PR DESCRIPTION
## Summary
- Remap **Source-backed** headline Stats to browse `signal=source-backed` (state reports, home, validators)
- Remap tooling **Maintainer-reviewed** Stat to browse `signal=reviewed`
- Remap validators summary **Reviewed** (`safety-coverage`) to browse `signal=reviewed`
- Lib + tests only; DistTable provenance rows keep exact `source:` buckets; `needs-attention` stays on `/quality`

## Submission Source
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Quality Evidence
- Changed routes/components/endpoints/tools: CTA destination helpers only (`state-report-page-cta-events-lib`, `home-page-cta-events-lib`, `validators-tools-cta-events-lib`)
- Expected behavior: clicking those Stats opens `/browse` with the matching trust-signal filter already used by quality/hubs
- Screenshots for frontend/page/UI changes: **No visual impact** — destination URL search params change only; no component/route chrome or badge markup changes
- Focused tests: vitest on the three CTA libs

## Validation
- [x] Platform/code PR: `pnpm --filter web type-check` and `pnpm --filter web build` passed
- [x] Focused vitest on updated CTA libs passed

## Notes
- Linked issue or no-issue rationale: **No linked issue.** This is a platform/code PR. Repo policy sets `linkedIssuePolicy: optional` and `issueDiscoveryPolicy: discouraged` (`.loopover.yml`). Issue create is unavailable to this contributor account (`CreateIssue` denied). Rationale is recorded here per the PR template Notes field so advisory bots do not treat a missing link as unresolved.
- Caveat: validators `needs-attention` intentionally remains `/quality`.