### PR TITLE
feat(web): align Source-backed and tooling reviewed Stats to browse signals

### DIFF
--- a/apps/web/src/lib/home-page-cta-events-lib.ts
+++ b/apps/web/src/lib/home-page-cta-events-lib.ts
@@ -209,7 +209,7 @@ export function homeTrustStatDestination(statId: string): HomeTrustStatDestinati
     case "trusted":
       return { to: "/browse", search: { trust: "trusted" } };
     case "source-backed":
-      return { to: "/browse", search: { source: "source-backed" } };
+      return { to: "/browse", search: { signal: "source-backed" } };
     case "reviewed":
       return { to: "/browse", search: { signal: "reviewed" } };
     case "live-signals":

--- a/apps/web/src/lib/state-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/state-report-page-cta-events-lib.ts
@@ -130,11 +130,15 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { source: "source-backed" },
+            search: { signal: "source-backed" },
             destination: "browse",
           };
         case "reviewed":
-          return { to: "/quality", destination: "quality" };
+          return {
+            to: "/browse",
+            search: { signal: "reviewed" },
+            destination: "browse",
+          };
         case "total":
         case "categories":
           return { to: "/browse", destination: "browse" };
@@ -146,7 +150,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "mcp", source: "source-backed" },
+            search: { category: "mcp", signal: "source-backed" },
             destination: "browse",
           };
         case "total":
@@ -190,7 +194,7 @@ export function stateReportStatDestination(
         case "source-backed":
           return {
             to: "/browse",
-            search: { category: "agents", source: "source-backed" },
+            search: { category: "agents", signal: "source-backed" },
             destination: "browse",
           };
         case "total":

--- a/tests/home-page-cta-events-lib.test.ts
+++ b/tests/home-page-cta-events-lib.test.ts
@@ -151,7 +151,7 @@ describe("home page cta events lib", () => {
     });
     expect(homeTrustStatDestination("source-backed")).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
     });
     expect(homeTrustStatDestination("reviewed")).toEqual({
       to: "/browse",

--- a/tests/state-report-page-cta-events-lib.test.ts
+++ b/tests/state-report-page-cta-events-lib.test.ts
@@ -96,12 +96,13 @@ describe("state report page cta events lib", () => {
       stateReportStatDestination("claude-tooling", "source-backed"),
     ).toEqual({
       to: "/browse",
-      search: { source: "source-backed" },
+      search: { signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("claude-tooling", "reviewed")).toEqual({
-      to: "/quality",
-      destination: "quality",
+      to: "/browse",
+      search: { signal: "reviewed" },
+      destination: "browse",
     });
     expect(stateReportStatDestination("claude-tooling", "unknown")).toBeNull();
 
@@ -122,7 +123,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("mcp-servers", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "mcp", source: "source-backed" },
+      search: { category: "mcp", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("mcp-servers", "unknown")).toBeNull();
@@ -165,7 +166,7 @@ describe("state report page cta events lib", () => {
     });
     expect(stateReportStatDestination("ai-agents", "source-backed")).toEqual({
       to: "/browse",
-      search: { category: "agents", source: "source-backed" },
+      search: { category: "agents", signal: "source-backed" },
       destination: "browse",
     });
     expect(stateReportStatDestination("ai-agents", "ready")).toEqual({


### PR DESCRIPTION
## Summary
- Remap state-report **Source-backed** Stats to browse `signal=source-backed`
- Remap tooling **Maintainer-reviewed** Stat to browse `signal=reviewed`
- Remap home **Source-backed** Stat to browse `signal=source-backed`
- Pure destination helpers + tests only (no route/component markup)

## Submission Source
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Quality Evidence
- Changed routes/components/endpoints/tools: `state-report-page-cta-events-lib.ts`, `home-page-cta-events-lib.ts` (+ tests)
- Expected behavior: those Stats open `/browse` with the trust-signal filter already used by quality/hubs
- Screenshots: **No visual impact** — search-param destination change only; no JSX/chrome/badge changes
- Focused tests: vitest on the two CTA libs

## Validation
- [x] `pnpm --filter web type-check`
- [x] `pnpm --filter web build`
- [x] Focused vitest passed

## Notes
- Linked issue or no-issue rationale: **No linked issue.** Platform/code PR. `.loopover.yml` sets `linkedIssuePolicy: optional` and `issueDiscoveryPolicy: discouraged`. This contributor cannot create issues (`CreateIssue` denied). Explicit no-issue rationale recorded per PR template Notes.