### PR TITLE
fix(web): return 409 on lost-update race in admin listing-leads status PATCH

### DIFF
--- a/apps/web/src/routes/api/admin/listing-leads.ts
+++ b/apps/web/src/routes/api/admin/listing-leads.ts
@@ -132,10 +132,26 @@ export const PATCH = createApiHandler(
       return apiError("invalid_transition", 400, { requestId });
     }
 
-    await db
-      .prepare("UPDATE listing_leads SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?")
-      .bind(nextStatus, id)
+    // Compare-and-swap on the status we read: the UPDATE only matches if the
+    // row's status hasn't changed since the SELECT above. If another concurrent
+    // request already transitioned it, no row matches (meta.changes === 0) and
+    // we return 409 instead of silently reporting success for a write that a
+    // lost-update race dropped.
+    const update = await db
+      .prepare(
+        "UPDATE listing_leads SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?",
+      )
+      .bind(nextStatus, id, current.status)
       .run();
+
+    if (Number(update.meta?.changes ?? 0) === 0) {
+      logApiWarn(request, "admin.listing_leads.status_conflict", {
+        id,
+        expected: current.status,
+        to: nextStatus,
+      });
+      return apiError("status_conflict", 409, { requestId });
+    }
 
     logApiInfo(request, "admin.listing_leads.status_updated", {
       id,

--- a/tests/admin-listing-leads-conflict.test.ts
+++ b/tests/admin-listing-leads-conflict.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSiteDbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({ getSiteDb: getSiteDbMock }));
+vi.mock("@/lib/admin-auth", () => ({ isLeadsAdminAuthorized: () => true }));
+
+function patchRequest(body: Record<string, unknown>) {
+  return new Request("https://heyclau.de/api/admin/listing-leads", {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      origin: "https://heyclau.de",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// Minimal D1 stub: the SELECT resolves to `current`; the conditional UPDATE
+// reports `updateChanges` rows affected (1 = applied, 0 = the row's status
+// changed between read and write, i.e. a lost-update race).
+function dbStub({
+  current,
+  updateChanges,
+}: {
+  current: { id: number; status: string } | null;
+  updateChanges: number;
+}) {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return {
+            first: async () => current,
+            run: async () => ({
+              success: true,
+              meta: { changes: updateChanges },
+            }),
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("admin listing-leads PATCH lost-update conflict", () => {
+  beforeEach(() => {
+    getSiteDbMock.mockReset();
+  });
+
+  it("returns 409 when the lead's status changed between read and the conditional write", async () => {
+    getSiteDbMock.mockReturnValue(
+      dbStub({ current: { id: 1, status: "new" }, updateChanges: 0 }),
+    );
+    const { PATCH } = await import("@/routes/api/admin/listing-leads");
+
+    const response = await PATCH(patchRequest({ id: 1, action: "review" }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "status_conflict" },
+    });
+  });
+
+  it("returns 200 with the next status when the conditional write applies", async () => {
+    getSiteDbMock.mockReturnValue(
+      dbStub({ current: { id: 1, status: "new" }, updateChanges: 1 }),
+    );
+    const { PATCH } = await import("@/routes/api/admin/listing-leads");
+
+    const response = await PATCH(patchRequest({ id: 1, action: "review" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      id: 1,
+      status: "pending_review",
+    });
+  });
+
+  it("still returns 404 when the lead does not exist", async () => {
+    getSiteDbMock.mockReturnValue(dbStub({ current: null, updateChanges: 0 }));
+    const { PATCH } = await import("@/routes/api/admin/listing-leads");
+
+    const response = await PATCH(patchRequest({ id: 999, action: "review" }));
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5267.

The admin listing-leads status PATCH had a **lost-update race**: it read the lead's `status`, computed the next status, then wrote `UPDATE … WHERE id = ?` with **no check on the status it read and no `meta.changes` check** — so two concurrent transitions could both report success while one silently clobbered the other.

**Fix (compare-and-swap):** the UPDATE is now conditioned on the read status (`… WHERE id = ? AND status = ?` bound to `current.status`). If `meta.changes === 0` (the row's status changed between read and write), the route returns **409 `status_conflict`** instead of a silent false success, and logs the conflict rather than a successful transition.

## Files

- `apps/web/src/routes/api/admin/listing-leads.ts` — conditional UPDATE + `meta.changes === 0` → 409 (mirrors the `meta.changes` check `updateAdminJobState` already does).
- `tests/admin-listing-leads-conflict.test.ts` — race regression + happy-path + not-found tests (route handler invoked with a stubbed D1 via the existing `vi.mock("@/lib/db")` pattern).

## Invariants / evidence (no visual impact)

- **409 on conflict:** SELECT returns `{status:"new"}`, the conditional UPDATE reports `changes:0` (status changed since read) → response is **409 `status_conflict`**; the audit log emits `admin.listing_leads.status_conflict` (a conflict), **not** a `status_updated` success event.
- **200 on success:** `changes:1` → `200 { ok:true, status:"pending_review" }` and the normal `status_updated` log.
- **404 unchanged** when the lead doesn't exist. The `not_found` / `invalid_transition` / auth paths are untouched.

## Validation

```
pnpm exec vitest run tests/admin-listing-leads-conflict.test.ts \
  tests/listing-leads-csv-lib.test.ts tests/admin-auth.test.ts     # 11 passed
pnpm --filter web type-check                                       # clean
pnpm exec prettier --check <changed files>                        # clean
```
