### PR TITLE
fix(registry): Date-guard verifiedAt derivation from unquoted dateAdded

### DIFF
--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -461,6 +461,21 @@ const FIRST_CODE_BLOCK_INSTALL_CATEGORIES = new Set([
   "statuslines",
 ]);
 
+/**
+ * Normalize a frontmatter date-like value to YYYY-MM-DD.
+ * Mirrors content-builder-lib's normalizeDateAdded without importing it
+ * (that module already imports inferStructuredFields from here).
+ */
+function normalizeIsoDateField(value) {
+  if (!value) return "";
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString().slice(0, 10);
+  }
+  const normalized = String(value).trim();
+  const isoMatch = normalized.match(/^\d{4}-\d{2}-\d{2}/);
+  return isoMatch?.[0] ?? normalized;
+}
+
 export function inferStructuredFields(data, body, category) {
   const codeBlocks = extractCodeBlocks(body);
   const firstCodeBlock = codeBlocks[0];
@@ -574,9 +589,9 @@ export function inferStructuredFields(data, body, category) {
   const verifiedAt =
     category === "skills"
       ? data.verifiedAt
-        ? String(data.verifiedAt).trim()
+        ? normalizeIsoDateField(data.verifiedAt)
         : data.dateAdded
-          ? String(data.dateAdded).trim()
+          ? normalizeIsoDateField(data.dateAdded)
           : ""
       : "";
   const retrievalSources = Array.isArray(data.retrievalSources)

--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -26,6 +26,7 @@ import {
   stripCodeBlocks,
   validateEntry,
 } from "../packages/registry/src/content-schema-lib.js";
+import { parseSafeFrontmatter } from "../packages/registry/src/frontmatter-lib.js";
 
 const CATEGORIES = [
   "agents",
@@ -1066,6 +1067,40 @@ describe("inferStructuredFields carries explicit optional fields", () => {
     );
     expect(inferred.verifiedAt).toBe("2026-01-02");
     expect(inferred.testedPlatforms).toEqual(["Claude", "Codex"]);
+  });
+
+  it("Date-guards unquoted YAML dateAdded when deriving verifiedAt", () => {
+    const source = [
+      "---",
+      "title: Demo skill",
+      "slug: demo-skill",
+      "description: Demo",
+      "dateAdded: 2025-09-18",
+      "---",
+      "Body.",
+    ].join("\n");
+    const { data } = parseSafeFrontmatter(source);
+    expect(data.dateAdded).toBeInstanceOf(Date);
+
+    const before = String(data.dateAdded).trim();
+    expect(before).not.toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    const inferred = inferStructuredFields(data, "Body.", "skills");
+    expect(inferred.verifiedAt).toBe("2025-09-18");
+    expect(inferred.verifiedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("keeps quoted-string dateAdded verifiedAt fallback unchanged", () => {
+    const inferred = inferStructuredFields(
+      {
+        title: "T",
+        slug: "demo",
+        dateAdded: "2025-09-18",
+      },
+      "Body.",
+      "skills",
+    );
+    expect(inferred.verifiedAt).toBe("2025-09-18");
   });
 
   it("drops copySnippet/usageSnippet from an agents entry's recommended gaps", () => {


### PR DESCRIPTION
Closes #5252

## Summary
- Date-guard `inferStructuredFields` skills `verifiedAt` fallback the same way `normalizeDateAdded` does (local helper; no circular import)
- Unquoted YAML `dateAdded` from gray-matter now yields ISO `YYYY-MM-DD` instead of `Date.toString()`
- Quoted-string `dateAdded` / explicit `verifiedAt` behavior unchanged

## Submission Source
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Quality Evidence
- Changed: `packages/registry/src/content-schema-lib.js`, `tests/content-schema-lib.test.ts`
- Before: unquoted `dateAdded: 2025-09-18` → `String(date)` like `Wed Sep 17 2025...`
- After: same frontmatter → `verifiedAt: 2025-09-18`
- Screenshots: **No visual impact** (registry inference only)

## Validation
- [x] `pnpm exec vitest run tests/content-schema-lib.test.ts` (393 passed)