### PR TITLE
fix(registry): recognize www.github.com in repo and profile URL parsers

### DIFF
--- a/packages/mcp/src/public-url-lib.js
+++ b/packages/mcp/src/public-url-lib.js
@@ -34,11 +34,12 @@ export function isPublicHttpsUrl(value) {
 export function isPublicGitHubProfileUrl(value) {
   const url = parseUrl(value);
   if (!url) return false;
+  const hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
   return (
     url.protocol === "https:" &&
     url.username === "" &&
     url.password === "" &&
-    url.hostname === "github.com" &&
+    hostname === "github.com" &&
     url.pathname.split("/").filter(Boolean).length === 1
   );
 }

--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -143,11 +143,12 @@ export function isPublicGitHubProfileUrl(value) {
   const url = parseUrl(value);
   if (!url) return false;
   const segments = url.pathname.split("/").filter(Boolean);
+  const hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
   return (
     url.protocol === "https:" &&
     url.username === "" &&
     url.password === "" &&
-    url.hostname === "github.com" &&
+    hostname === "github.com" &&
     segments.length === 1 &&
     !RESERVED_OWNERS.has(segments[0].toLowerCase())
   );

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -296,7 +296,8 @@ function hostname(value) {
 function githubRepoFromUrl(value) {
   try {
     const url = new URL(normalizeText(value));
-    if (!isPublicHttpsUrl(value) || url.hostname !== "github.com") {
+    const hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
+    if (!isPublicHttpsUrl(value) || hostname !== "github.com") {
       return "";
     }
     const [owner, repo] = url.pathname.split("/").filter(Boolean);

--- a/tests/mcp-public-url-lib.test.ts
+++ b/tests/mcp-public-url-lib.test.ts
@@ -132,6 +132,8 @@ describe("isPublicGitHubProfileUrl", () => {
     ["https://github.com/user_name", true],
     ["https://github.com/a", true],
     ["https://GITHUB.COM/octocat", true],
+    ["https://www.github.com/octocat", true],
+    ["https://WWW.GitHub.com/octocat", true],
   ])("accepts single-segment profile URL %s", (url) => {
     expect(isPublicGitHubProfileUrl(url)).toBe(true);
   });
@@ -143,7 +145,6 @@ describe("isPublicGitHubProfileUrl", () => {
     ["https://github.com/octocat/repo/issues", false],
     ["https://github.com/", false],
     ["https://github.com", false],
-    ["https://www.github.com/octocat", false],
     ["https://gist.github.com/octocat", false],
     ["https://raw.githubusercontent.com/user/repo/main/file", false],
   ])("rejects non-profile GitHub URL %s", (url) => {

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -124,6 +124,18 @@ describe("public URL userinfo helpers", () => {
     );
   });
 
+  it("accepts www.github.com profile URLs like bare github.com", () => {
+    expect(isPublicGitHubProfileUrl("https://www.github.com/octocat")).toBe(
+      true,
+    );
+    expect(isPublicGitHubProfileUrl("https://WWW.GitHub.com/octocat")).toBe(
+      true,
+    );
+    expect(
+      isPublicGitHubProfileUrl("https://www.github.com/octocat/repo"),
+    ).toBe(false);
+  });
+
   it("rejects non-http(s) URLs even on a GitHub host", () => {
     // A GitHub hostname over ftp/ws is not a public GitHub web URL; the protocol
     // guard matches the sibling public-URL validators.

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -478,3 +478,53 @@ describe("tierFromFlags risk-tier boundaries", () => {
     );
   });
 });
+
+describe("www.github.com source URL normalization", () => {
+  it("registers www.github.com repo URLs as GitHub sources like bare github.com", () => {
+    const bare = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 901,
+        title: "content(mcp): add bare github source",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Bare Source MCP",
+            slug: "bare-source-mcp",
+            repoUrl: "https://github.com/example/www-parity-mcp",
+          }),
+          "content/mcp/bare-source-mcp.mdx",
+        ),
+      ],
+    });
+    const www = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 902,
+        title: "content(mcp): add www github source",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Www Source MCP",
+            slug: "www-source-mcp",
+            repoUrl: "https://www.github.com/example/www-parity-mcp",
+          }),
+          "content/mcp/www-source-mcp.mdx",
+        ),
+      ],
+    });
+
+    expect(bare.trustSignals).toEqual(
+      expect.arrayContaining(["GitHub source: example/www-parity-mcp"]),
+    );
+    expect(www.trustSignals).toEqual(
+      expect.arrayContaining(["GitHub source: example/www-parity-mcp"]),
+    );
+  });
+});


### PR DESCRIPTION
Closes #5220

## Summary
- Strip leading `www.` (case-insensitive) in `githubRepoFromUrl` and `isPublicGitHubProfileUrl` to match `isPublicGitHubHostUrl`
- Mirror the same profile-host fix in the self-contained MCP `public-url-lib`
- `https://www.github.com/owner/repo` now registers as a GitHub source trust signal like bare `github.com`

## URL forms covered by tests
- Profiles: `https://github.com/octocat`, `https://www.github.com/octocat`, `https://WWW.GitHub.com/octocat`
- Repos (via submission risk): `https://github.com/example/www-parity-mcp`, `https://www.github.com/example/www-parity-mcp`
- Still rejected: gist/raw hosts, credentialed URLs, multi-segment paths

## Submission Source
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves

## Quality Evidence
- Changed: `submission-risk.js`, `source-url-lib.js`, `mcp/public-url-lib.js` + focused tests
- Screenshots: **No visual impact**

## Validation
- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts tests/registry-source-url.test.ts tests/source-url-lib.test.ts tests/mcp-public-url-lib.test.ts` (404 passed)
- [x] `pnpm --filter web type-check`