### PR TITLE
test(web): cover empty-input and row-filter branches in mcp-servers-stats-lib

### DIFF
--- a/tests/mcp-servers-stats-lib.test.ts
+++ b/tests/mcp-servers-stats-lib.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { buildMcpServersReport } from "@/lib/mcp-servers-stats-lib";
 import { buildMcpServersReport as buildFromWrapper } from "@/lib/mcp-servers-stats";
 import { ENTRIES } from "@/data/entries";
+import { TRUST_LABEL } from "@/types/registry";
+
+const MCP = ENTRIES.filter((entry) => entry.category === "mcp");
 
 describe("mcp-servers-stats-lib", () => {
   it("builds a deterministic MCP servers report model", () => {
@@ -26,5 +29,61 @@ describe("mcp-servers-stats-lib", () => {
     expect(buildFromWrapper(ENTRIES, "2026-07-16")).toEqual(
       buildMcpServersReport(ENTRIES, "2026-07-16"),
     );
+  });
+
+  it("drops every empty dimension when there are no MCP entries", () => {
+    const report = buildMcpServersReport([], "2026-07-16");
+    expect(report.total).toBe(0);
+    expect(report.stats.every((stat) => stat.value === 0)).toBe(true);
+    expect(
+      report.stats.every(
+        (stat) => stat.hint === "0%" || stat.hint === "registry",
+      ),
+    ).toBe(true);
+    // Trust/source/transport/hosting/install rows are all empty -> filtered out.
+    expect(report.dimensions).toEqual([]);
+  });
+
+  it("ignores non-MCP entries entirely", () => {
+    const nonMcp = ENTRIES.filter((entry) => entry.category !== "mcp").slice(
+      0,
+      8,
+    );
+    expect(nonMcp.length).toBeGreaterThan(0);
+    const report = buildMcpServersReport(nonMcp, "2026-07-16");
+    expect(report.total).toBe(0);
+    expect(report.dimensions).toEqual([]);
+  });
+
+  it("keeps only the trust rows that actually occur in the input", () => {
+    const anchorTrust = MCP[0].trust;
+    const subset = MCP.filter((entry) => entry.trust === anchorTrust);
+    const report = buildMcpServersReport(subset, "2026-07-16");
+    const trust = report.dimensions.find(
+      (dimension) => dimension.key === "trust",
+    );
+    expect(trust?.rows).toHaveLength(1);
+    expect(trust?.rows[0]).toMatchObject({
+      label: TRUST_LABEL[anchorTrust],
+      count: subset.length,
+    });
+  });
+
+  it("counts hosting and source-backed stats consistently with the entries", () => {
+    const report = buildMcpServersReport(MCP, "2026-07-16");
+    const stat = (key: string) =>
+      report.stats.find((entry) => entry.key === key)?.value ?? -1;
+    expect(stat("total")).toBe(MCP.length);
+    expect(stat("remote") + stat("local")).toBeLessThanOrEqual(MCP.length);
+    expect(stat("source-backed")).toBe(
+      MCP.filter(
+        (entry) =>
+          entry.source === "source-backed" || entry.source === "first-party",
+      ).length,
+    );
+    // Every surviving dimension carries at least one row.
+    expect(
+      report.dimensions.every((dimension) => dimension.rows.length > 0),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Adds branch-coverage tests for `buildMcpServersReport` in `apps/web/src/lib/mcp-servers-stats-lib.ts`. The existing suite only exercised the full `ENTRIES` dataset, leaving the input-shape branches untested.

## New cases

- **Empty input** — no MCP entries → `total` is 0, every stat value is 0, and all dimensions are dropped by the trailing `.filter((dimension) => dimension.rows.length > 0)`.
- **Non-MCP entries ignored** — the internal `category === "mcp"` filter yields an empty report.
- **Trust-row filtering** — a single-trust subset keeps exactly the one occurring trust row (the `.filter((row) => row.count > 0)` drops the absent trust levels).
- **Hosting / source-backed counting** — asserts `remote + local <= total` and that the `source-backed` stat matches a recomputed `source-backed | first-party` count, and that every surviving dimension carries at least one row.

## Validation

```
pnpm exec vitest run tests/mcp-servers-stats-lib.test.ts   # 6 passed
pnpm exec prettier --check tests/mcp-servers-stats-lib.test.ts
```

Test-only change; no source or generated artifacts touched.