### PR TITLE
test(web): cover empty-input and row-filter branches in claude-tooling-stats-lib

### DIFF
--- a/tests/claude-tooling-stats-lib.test.ts
+++ b/tests/claude-tooling-stats-lib.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildClaudeToolingReport } from "@/lib/claude-tooling-stats-lib";
 import { buildClaudeToolingReport as buildFromWrapper } from "@/lib/claude-tooling-stats";
 import { ENTRIES } from "@/data/entries";
+import { TRUST_LABEL } from "@/types/registry";
 
 describe("claude-tooling-stats-lib", () => {
   it("builds a deterministic report model with key dimensions", () => {
@@ -25,6 +26,58 @@ describe("claude-tooling-stats-lib", () => {
   it("keeps wrapper re-export aligned", () => {
     expect(buildFromWrapper(ENTRIES, "2026-07-16")).toEqual(
       buildClaudeToolingReport(ENTRIES, "2026-07-16"),
+    );
+  });
+
+  it("drops every empty dimension when there are no entries", () => {
+    const report = buildClaudeToolingReport([], "2026-07-16");
+    expect(report.total).toBe(0);
+    expect(report.stats.find((stat) => stat.key === "total")?.value).toBe(0);
+    // Categories/trust/source/platform/install/notes rows are all empty -> filtered out.
+    expect(report.dimensions).toEqual([]);
+  });
+
+  it("keeps only the category row present in a single-category subset", () => {
+    const anchorCategory = ENTRIES[0].category;
+    const subset = ENTRIES.filter((entry) => entry.category === anchorCategory);
+    const report = buildClaudeToolingReport(subset, "2026-07-16");
+    const categories = report.dimensions.find(
+      (dimension) => dimension.key === "categories",
+    );
+    expect(categories?.rows).toHaveLength(1);
+    expect(categories?.rows[0].count).toBe(subset.length);
+  });
+
+  it("keeps only the trust rows that actually occur in the input", () => {
+    const anchorTrust = ENTRIES[0].trust;
+    const subset = ENTRIES.filter((entry) => entry.trust === anchorTrust);
+    const report = buildClaudeToolingReport(subset, "2026-07-16");
+    const trust = report.dimensions.find(
+      (dimension) => dimension.key === "trust",
+    );
+    expect(trust?.rows).toHaveLength(1);
+    expect(trust?.rows[0]).toMatchObject({
+      label: TRUST_LABEL[anchorTrust],
+      count: subset.length,
+    });
+  });
+
+  it("keeps platform and notes-coverage rows internally consistent", () => {
+    const report = buildClaudeToolingReport(ENTRIES, "2026-07-16");
+    const platforms = report.dimensions.find(
+      (dimension) => dimension.key === "platforms",
+    );
+    expect(platforms?.rows.length).toBeGreaterThan(0);
+    expect(platforms?.rows.every((row) => row.count > 0)).toBe(true);
+
+    const notes = report.dimensions.find(
+      (dimension) => dimension.key === "notes-coverage",
+    );
+    const noteCount = (label: string) =>
+      notes?.rows.find((row) => row.label === label)?.count ?? 0;
+    // "Both" can never exceed either individual coverage count.
+    expect(noteCount("Both")).toBeLessThanOrEqual(
+      Math.min(noteCount("Safety notes"), noteCount("Privacy notes")),
     );
   });
 });


### PR DESCRIPTION
## What

Adds branch-coverage tests for `buildClaudeToolingReport` in `apps/web/src/lib/claude-tooling-stats-lib.ts`. The existing suite only exercised the full `ENTRIES` dataset, so the input-shape and row-filtering branches were untested.

## New cases

- **Empty input** — no entries → `total` is 0, the `total` stat is 0, and every dimension (categories, trust, source, platforms, install-methods, notes-coverage) is dropped by the trailing `.filter((dimension) => dimension.rows.length > 0)`.
- **Category-row filtering** — a single-category subset keeps exactly the one occurring category row.
- **Trust-row filtering** — a single-trust subset keeps exactly the one occurring trust row, dropping the absent trust levels via `.filter((row) => row.count > 0)`.
- **Platform / notes-coverage consistency** — platform rows all have `count > 0`, and the `Both` notes count never exceeds `min(Safety, Privacy)`.

## Validation

```
pnpm exec vitest run tests/claude-tooling-stats-lib.test.ts   # 6 passed
pnpm exec prettier --check tests/claude-tooling-stats-lib.test.ts
```

Test-only change; no source or generated artifacts touched.