### PR TITLE
fix(registry): include docs/source/package/repository URLs in relationship source links

### DIFF
--- a/packages/registry/src/relationships-lib.js
+++ b/packages/registry/src/relationships-lib.js
@@ -133,6 +133,15 @@ export function sourceUrls(entry) {
         ? entry.downloadUrl
         : "",
       ...(Array.isArray(entry.retrievalSources) ? entry.retrievalSources : []),
+      // Other first-class, schema-validated source-link fields that
+      // content-builder copies onto every entry. Without these, entries that
+      // share only a docs/source/package/repository link (or the plural
+      // sourceUrls[]) are invisible to relationship candidate-building.
+      entry.docsUrl,
+      entry.sourceUrl,
+      entry.packageUrl,
+      entry.repositoryUrl,
+      ...(Array.isArray(entry.sourceUrls) ? entry.sourceUrls : []),
     ]
       .map(normalizeUrl)
       .filter(Boolean),

--- a/tests/relationships-lib.test.ts
+++ b/tests/relationships-lib.test.ts
@@ -183,6 +183,33 @@ describe("sourceUrls", () => {
       ),
     ).toEqual(["https://docs.example.com/a"]);
   });
+
+  it("includes docsUrl, sourceUrl, packageUrl, repositoryUrl, and plural sourceUrls[]", () => {
+    expect(
+      sourceUrls(
+        entry({
+          docsUrl: "https://docs.example.com/x",
+          sourceUrl: "https://src.example.com/y",
+          packageUrl: "https://pkg.example.com/z",
+          repositoryUrl: "https://repo.example.com/w",
+          sourceUrls: [
+            "https://plural.example.com/v",
+            "https://plural.example.com/v",
+          ],
+        }),
+      ),
+    ).toEqual([
+      "https://docs.example.com/x",
+      "https://src.example.com/y",
+      "https://pkg.example.com/z",
+      "https://repo.example.com/w",
+      "https://plural.example.com/v",
+    ]);
+  });
+
+  it("ignores a non-array sourceUrls value", () => {
+    expect(sourceUrls(entry({ sourceUrls: "not-an-array" }))).toEqual([]);
+  });
 });
 
 describe("sourceDomains", () => {
@@ -767,6 +794,28 @@ describe("buildRegistryRelationGraph", () => {
 
     const twinRow = graph.entries.find((row) => row.key === "tools:twin");
     expect(twinRow?.related.some((r) => r.key === "guides:guide")).toBe(true);
+  });
+
+  it("makes two entries that share only a packageUrl into related candidates", () => {
+    // Category overlap alone tops out at 16 (< 18 threshold), so before
+    // packageUrl was added to sourceUrls() these two never became candidates
+    // and scored null; the shared source URL now contributes 70 points.
+    const left = entry({
+      slug: "left",
+      title: "Left",
+      packageUrl: "https://pkg.example.com/thing",
+    });
+    const right = entry({
+      slug: "right",
+      title: "Right",
+      packageUrl: "https://pkg.example.com/thing",
+    });
+
+    const graph = buildRegistryRelationGraph([left, right]);
+    const leftRow = graph.entries.find((row) => row.key === "skills:left");
+    const match = leftRow?.related.find((r) => r.key === "skills:right");
+    expect(match).toBeDefined();
+    expect(match?.reasons).toContain("shared_source_url");
   });
 
   it("returns an empty entries list for an empty registry", () => {


### PR DESCRIPTION
Closes #5249

## Problem

`relationships-lib.js`'s `sourceUrls()` — whose whole job is gathering an entry's source links for relationship matching — only reads `repoUrl`/`documentationUrl`/`websiteUrl`/`downloadUrl`/`retrievalSources`. But `content-schema-lib.js` validates `docsUrl`, `sourceUrl`, `packageUrl`, `repositoryUrl`, and the plural `sourceUrls[]` as first-class URL fields, and `content-builder-lib.js` copies all of them onto every built entry. `packageUrl`/`sourceUrls[]` are used in real content today (e.g. `content/tools/official-mcp-rust-sdk.mdx`). Because `candidatesFor` in `buildRegistryRelationGraph` buckets candidates off exactly these source URLs, two entries sharing only one of these fields never even became candidates, so they could never score as related.

## Fix

Add `entry.docsUrl`, `entry.sourceUrl`, `entry.packageUrl`, `entry.repositoryUrl`, and `...(entry.sourceUrls ?? [])` to `sourceUrls()`. Purely additive: when these fields are absent they normalize to `""` and are filtered out, so existing behavior driven by the original fields is unchanged.

## Before / after

Two `skills` entries sharing only `packageUrl: https://pkg.example.com/thing`:
- **Before:** category overlap alone scores 16 (< the 18 threshold) → not candidates, `related` empty.
- **After:** the shared source URL contributes 70 → they become candidates and relate (`reasons` includes `shared_source_url`).

## Tests

`tests/relationships-lib.test.ts`:
- `sourceUrls()` now includes the five new fields (and ignores a non-array `sourceUrls`).
- `buildRegistryRelationGraph` relates two entries sharing only a `packageUrl`.
- Existing `repoUrl`/`documentationUrl`/`websiteUrl`/`downloadUrl`/`retrievalSources` cases unchanged.

## Validation

```
pnpm exec vitest run tests/relationships-lib.test.ts        # 56 passed
pnpm exec vitest run tests/artifacts-lib.test.ts tests/registry-artifacts.test.ts tests/quality-lib.test.ts   # consumers green
pnpm exec prettier --check packages/registry/src/relationships-lib.js tests/relationships-lib.test.ts
```

No visual impact; no generated artifacts touched.