### PR TITLE
fix(registry): reject malformed/credential-embedded job apply/source URLs

### DIFF
--- a/packages/registry/src/commercial-lib.js
+++ b/packages/registry/src/commercial-lib.js
@@ -193,6 +193,18 @@ export function hasHttpsUrl(value) {
   return /^https:\/\//i.test(textValue(value));
 }
 
+// A REQUIRED public https URL for job apply/source fields: it must be present
+// AND survive the same strict validation lead URLs already get. Unlike
+// isPublicHttpsUrl (which returns true for an empty string, i.e. "optionally
+// absent"), an empty value here is a failure because these job fields are
+// required. This closes the gap where hasHttpsUrl's `/^https:\/\//` prefix test
+// accepted malformed or credential-embedded URLs (e.g.
+// `https://user:pass@evil.com/apply`) onto the public jobs board.
+function isRequiredPublicHttpsUrl(value) {
+  const text = textValue(value);
+  return text !== "" && isPublicHttpsUrl(text);
+}
+
 export function validateJobPublicationQuality(job = {}) {
   const tier = normalizeCommercialTier(job.tier);
   const status = textValue(job.status).toLowerCase();
@@ -264,7 +276,7 @@ export function validateJobPublicationQuality(job = {}) {
   if (!employmentType) {
     errors.push("paid active jobs require an employment type");
   }
-  if (!hasHttpsUrl(sourceUrl)) {
+  if (!isRequiredPublicHttpsUrl(sourceUrl)) {
     errors.push("paid active jobs require an HTTPS source or apply URL");
   }
   if (!postedAt) {
@@ -315,10 +327,10 @@ export function validateJobPublicExposure(job = {}, options = {}) {
       `active jobs require a ${JOB_PUBLIC_EXPOSURE_RULES.summaryMinLength}+ character reviewed summary`,
     );
   }
-  if (!hasHttpsUrl(applyUrl)) {
+  if (!isRequiredPublicHttpsUrl(applyUrl)) {
     errors.push("active jobs require an HTTPS employer apply URL");
   }
-  if (!hasHttpsUrl(sourceUrl)) {
+  if (!isRequiredPublicHttpsUrl(sourceUrl)) {
     errors.push("active jobs require an HTTPS source URL");
   }
   if (!checkedAt && !hasLiveSourceTruth) {

--- a/tests/commercial-lib.test.ts
+++ b/tests/commercial-lib.test.ts
@@ -334,6 +334,20 @@ describe("validateJobPublicationQuality", () => {
     expect(result.errors.join("\n")).toContain("expiresAt");
     expect(result.errors.join("\n")).toContain("source verification");
   });
+
+  it("rejects a credential-embedded apply/source URL on a paid active job", () => {
+    // sourceUrl falls back to applyUrl, so a credential-embedded applyUrl is
+    // what the source-or-apply HTTPS gate sees.
+    const result = validateJobPublicationQuality(
+      paidActiveJob({ applyUrl: "https://user:pass@evil.com/apply" }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      "paid active jobs require an HTTPS source or apply URL",
+    );
+    // A clean https applyUrl (the default fixture) does not trip the gate.
+    expect(validateJobPublicationQuality(paidActiveJob()).ok).toBe(true);
+  });
 });
 
 describe("validateJobPublicExposure", () => {
@@ -371,6 +385,46 @@ describe("validateJobPublicExposure", () => {
       last_checked_at: "2026-05-20",
     });
     expect(result.ok).toBe(true);
+  });
+
+  it("rejects credential-embedded and malformed apply/source URLs", () => {
+    const base = {
+      status: "active",
+      summary: "S".repeat(JOB_PUBLIC_EXPOSURE_RULES.summaryMinLength),
+      responsibilities: ["r1", "r2"],
+      requirements: ["q1", "q2"],
+      sourceCheckedAt: "2026-05-20",
+      source: "manual",
+    };
+
+    // Both forms below satisfy the old `/^https:\/\//` prefix test but are
+    // rejected by the stricter public-https validator.
+    for (const bad of ["https://user:pass@evil.com/apply", "https://"]) {
+      const result = validateJobPublicExposure({
+        ...base,
+        applyUrl: bad,
+        sourceUrl: bad,
+      });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          "active jobs require an HTTPS employer apply URL",
+          "active jobs require an HTTPS source URL",
+        ]),
+      );
+    }
+
+    // Legitimate https apply/source URLs still pass the URL check.
+    const good = validateJobPublicExposure({
+      ...base,
+      applyUrl: "https://jobs.example/apply",
+      sourceUrl: "https://jobs.example/source",
+    });
+    expect(good.errors).not.toContain(
+      "active jobs require an HTTPS employer apply URL",
+    );
+    expect(good.errors).not.toContain(
+      "active jobs require an HTTPS source URL",
+    );
   });
 
   it("allows live source truth to replace a missing verification date", () => {


### PR DESCRIPTION
Closes #5247

## Problem

`commercial-lib.js`'s `hasHttpsUrl` is a naive `/^https:\/\//i` prefix test, so it accepts malformed and credential-embedded URLs (e.g. `https://user:pass@evil.com/apply`, or a bare `https://` with no host). It gates `applyUrl`/`sourceUrl` in `validateJobPublicationQuality` and `validateJobPublicExposure` — the filters that decide which "active" jobs reach the public jobs board — so a malicious/malformed apply URL could pass. The same file already imports the stricter `isPublicHttpsUrl` (used for lead validation), which correctly rejects these.

## Fix

Route the three job apply/source-URL gates through a small `isRequiredPublicHttpsUrl` helper that applies the same strict validation lead URLs already get.

Important detail: `isPublicHttpsUrl` returns `true` for an empty string (optional-absent semantics), but these job fields are **required** — a missing URL must stay an error. So the helper requires the value to be non-empty **and** pass `isPublicHttpsUrl`, matching the existing `isPublicLeadHttpsUrl` guard pattern. `hasHttpsUrl` itself and its exported behavior/tests are left untouched.

## URL forms covered by the new tests

| Input | Old `hasHttpsUrl` | New gate | Expected |
|---|---|---|---|
| `https://jobs.example/apply` | pass | pass | ✅ still accepted |
| `https://user:pass@evil.com/apply` | **pass** | reject | ❌ now rejected |
| `https://` (no host) | **pass** | reject | ❌ now rejected |
| `http://insecure` | reject | reject | ❌ (unchanged) |
| `""` (missing) | reject | reject | ❌ required (unchanged) |

## Tests

`tests/commercial-lib.test.ts`:
- `validateJobPublicExposure` rejects credential-embedded and bare-`https://` apply/source URLs, and still accepts legitimate https.
- `validateJobPublicationQuality` rejects a credential-embedded apply URL (which its source-or-apply gate falls back to) while the clean fixture still passes.

## Validation

```
pnpm exec vitest run tests/commercial-lib.test.ts        # 50 passed
pnpm exec vitest run tests/job-admin-lib.test.ts tests/jobs-lib.test.ts tests/jobs-api.test.ts tests/public-jobs-filter-lib.test.ts tests/web-job-admin.test.ts tests/commercial-intake.test.ts tests/job-source-label.test.ts   # consumers green
pnpm exec prettier --check packages/registry/src/commercial-lib.js tests/commercial-lib.test.ts
```

No visual impact; no generated artifacts touched.