### PR TITLE
fix(registry): keep valid non-GitHub repoUrl instead of discarding to null

### DIFF
--- a/packages/registry/src/content-builder-lib.js
+++ b/packages/registry/src/content-builder-lib.js
@@ -23,6 +23,7 @@ import {
 } from "./content-schema.js";
 import { buildBrandAssetMetadata } from "./brand-assets.js";
 import { parseGitHubRepoUrl } from "./source-repo.js";
+import { isPublicHttpUrl } from "./source-url.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
 
 export const DEFAULT_DIRECTORY_REPO_URL =
@@ -411,7 +412,13 @@ export function buildContentEntryFromMdx(params) {
     codeBlocks,
     filePath: path.relative(repoRoot, filePath).replaceAll(path.sep, "/"),
     githubUrl: buildGitHubUrl(filePath, repoRoot),
-    repoUrl: githubRepo?.url ?? null,
+    // GitHub repos get the canonical owner/repo-derived URL; any other public
+    // http(s) repo (GitLab, sourcehut, self-hosted) keeps its validated raw URL
+    // instead of being discarded to null. isPublicHttpUrl mirrors the schema's
+    // own repoUrl validator, and the `repoUrl &&` guard keeps an absent repo
+    // null (isPublicHttpUrl treats an empty string as valid-optional).
+    repoUrl:
+      githubRepo?.url ?? (repoUrl && isPublicHttpUrl(repoUrl) ? repoUrl : null),
     githubStars: null,
     githubForks: null,
     repoUpdatedAt: null,

--- a/tests/content-builder-lib.test.ts
+++ b/tests/content-builder-lib.test.ts
@@ -299,6 +299,34 @@ describe("buildContentEntryFromMdx", () => {
     expect(entry.repoUrl).toBeNull();
   });
 
+  it("canonicalizes a GitHub repoUrl and preserves a non-GitHub repoUrl", () => {
+    const repoEntry = (slug: string, repoUrl: string) =>
+      buildEntry({
+        source: mdx(
+          [
+            `title: ${slug}`,
+            `slug: ${slug}`,
+            "description: Entry exercising repoUrl handling in the builder.",
+            "dateAdded: 2026-01-03",
+            `repoUrl: ${repoUrl}`,
+          ].join("\n"),
+        ),
+      });
+
+    // GitHub URLs still get the canonical owner/repo-derived URL.
+    expect(repoEntry("gh", "https://github.com/Acme/Widget").repoUrl).toBe(
+      "https://github.com/Acme/Widget",
+    );
+    // A valid non-GitHub repo URL now survives instead of being wiped to null.
+    expect(repoEntry("gl", "https://gitlab.com/acme/widget").repoUrl).toBe(
+      "https://gitlab.com/acme/widget",
+    );
+    // A credential-embedded URL is not a clean public URL -> stays null.
+    expect(
+      repoEntry("bad", "https://user:pass@gitlab.com/acme/widget").repoUrl,
+    ).toBeNull();
+  });
+
   it("builds a first-party skill package with sha256 and defaults", () => {
     const entry = buildEntry({
       source: mdx(


### PR DESCRIPTION
Closes #5246

## Problem

`content-schema-lib.js` validates `repoUrl` as any public http(s) URL (via `isPublicHttpUrl`), but `content-builder-lib.js` then discards anything that isn't a `github.com` URL:

```js
const githubRepo = parseGitHubRepo(repoUrl); // null for GitLab/sourcehut/self-hosted
...
repoUrl: githubRepo?.url ?? null,           // valid non-GitHub URL silently wiped
```

Any entry with a non-GitHub repo loses its repo link on build, degrading everything downstream that reads `entry.repoUrl` — `quality-lib.js` (`hasRepository`/`sourceQuality`), `seo-lib.js` schema.org `sameAs`, `relationships-lib.js` matching, and `artifacts-lib.js` metadata.

## Fix

Fall back to the raw, validated `repoUrl` when `parseGitHubRepo` returns null but the URL is still a public http(s) URL:

```js
repoUrl:
  githubRepo?.url ?? (repoUrl && isPublicHttpUrl(repoUrl) ? repoUrl : null),
```

- GitHub URLs keep the canonical owner/repo-derived URL (unchanged).
- `isPublicHttpUrl` mirrors the schema's own `repoUrl` validator (the reference implementation), so only genuinely public http(s) URLs survive.
- The `repoUrl &&` guard keeps an absent repo `null` (`isPublicHttpUrl` treats an empty string as valid-optional), and a credential-embedded URL is rejected (`isPublicHttpUrl` returns false for userinfo).

## Before / after

| Frontmatter `repoUrl` | Before | After |
|---|---|---|
| `https://github.com/Acme/Widget` | `https://github.com/Acme/Widget` | `https://github.com/Acme/Widget` (unchanged) |
| `https://gitlab.com/acme/widget` | **`null`** | `https://gitlab.com/acme/widget` |
| `https://user:pass@gitlab.com/acme/widget` | `null` | `null` (credentials rejected) |
| (absent) | `null` | `null` |

## Tests

`tests/content-builder-lib.test.ts` adds a case asserting all four rows above.

## Validation

```
pnpm exec vitest run tests/content-builder-lib.test.ts        # 31 passed
pnpm exec vitest run tests/quality-lib.test.ts tests/content-validation.test.ts tests/content-policy-validation.test.ts   # consumers green
pnpm exec prettier --check packages/registry/src/content-builder-lib.js tests/content-builder-lib.test.ts
```

No visual impact; no generated artifacts touched.