### PR TITLE
fix(registry): catch bare-target and split/long-form rm -rf in submission risk scan

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -898,6 +898,39 @@ function addSchemaSignals(report, validationReport) {
   );
 }
 
+// Detect a destructive recursive-force `rm` aimed at a root/home target
+// (`/`, `~`, `$HOME`), including a BARE target with nothing appended. Flags are
+// parsed token-by-token so split (`rm -r -f /`), reversed (`rm -fr /`), and
+// long-form (`rm --recursive --force /`) spellings all count — not just the
+// literal `-rf` token. `installText` is already lowercased by the caller; the
+// extra toLowerCase keeps the helper correct if reused elsewhere.
+export function hasDestructiveRootRemove(text) {
+  const lower = String(text ?? "").toLowerCase();
+  // Bound each `rm` to its own command segment so unrelated later tokens (after
+  // a pipe or `;`) can't supply the target or flags.
+  const commandRe = /\brm\b([^\n|;&]*)/g;
+  let match;
+  while ((match = commandRe.exec(lower)) !== null) {
+    let recursive = false;
+    let force = false;
+    for (const token of match[1].split(/\s+/).filter(Boolean)) {
+      if (token === "--recursive") {
+        recursive = true;
+      } else if (token === "--force") {
+        force = true;
+      } else if (/^-[a-z]+$/.test(token)) {
+        if (token.includes("r")) recursive = true;
+        if (token.includes("f")) force = true;
+      } else if (recursive && force && /^(\/|~|\$home)/.test(token)) {
+        // A root/home target reached with both flags already set is the
+        // destructive form (`rm -rf /`, `rm -rf /etc`, `rm -rf ~`, `rm -rf $HOME`).
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function addContentRiskSignals(report, fields, text) {
   const installText = lower(
     [
@@ -973,7 +1006,7 @@ function addContentRiskSignals(report, fields, text) {
   }
 
   if (
-    /rm\s+-rf\s+(\/|~|\$home)\b/i.test(installText) ||
+    hasDestructiveRootRemove(installText) ||
     /\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(sh|bash)\b/i.test(
       installText,
     ) ||

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -9,6 +9,7 @@ import {
   analyzeSubmissionDraftRisk,
   directContentRequestChangesReasons,
   formatSubmissionRiskMarkdown,
+  hasDestructiveRootRemove,
   tierFromFlags,
 } from "@heyclaude/registry/submission-risk";
 
@@ -187,6 +188,20 @@ describe("submission risk invariants", () => {
         "non_https_executable_source",
         "unsafe_install_pipeline",
       ]),
+    );
+  });
+
+  it("flags a bare `rm -rf /` install command as an unsafe pipeline", () => {
+    const draft = buildSubmissionPrDraft({
+      ...validMcpFields,
+      name: "Destructive Install MCP",
+      slug: "destructive-install-mcp",
+      install_command: "rm -rf /",
+    });
+    const validation = validateSubmission(draft);
+    const risk = analyzeSubmissionDraftRisk(draft, validation);
+    expect(risk.reviewFlags.map((flag) => flag.id)).toContain(
+      "unsafe_install_pipeline",
     );
   });
 
@@ -526,5 +541,35 @@ describe("www.github.com source URL normalization", () => {
     expect(www.trustSignals).toEqual(
       expect.arrayContaining(["GitHub source: example/www-parity-mcp"]),
     );
+  });
+});
+
+describe("hasDestructiveRootRemove", () => {
+  const cases: Array<[string, boolean]> = [
+    ["rm -rf /", true], // bare root target (previously MISSED)
+    ["rm -rf ~", true], // bare tilde target (previously MISSED)
+    ["rm -rf $HOME", true], // bare $HOME target
+    ["rm -r -f /", true], // split flags (previously MISSED)
+    ["rm -f -r /", true], // split, reversed
+    ["rm -fr /", true], // bundled, reversed (previously MISSED)
+    ["rm --recursive --force /", true], // long-form (previously MISSED)
+    ["rm -rf /etc", true], // path under root (previously caught)
+    ["rm -rf ~/Documents", true], // path under home
+    ["sudo rm -rf /", true], // sudo prefix
+    ["rm -r /", false], // recursive only, no force
+    ["rm --force /", false], // force only, no recursive
+    ["rm -rf ./build", false], // relative path, not root/home
+    ["rm -rf node_modules", false], // benign named target
+    ["npx -y some-mcp", false], // no rm at all
+    ["rm -r x | echo -f /", false], // flags/target split across a pipe
+  ];
+
+  it.each(cases)("%s -> %s", (input, expected) => {
+    expect(hasDestructiveRootRemove(input)).toBe(expected);
+  });
+
+  it("is case-insensitive on the target and flags", () => {
+    expect(hasDestructiveRootRemove("RM -RF /")).toBe(true);
+    expect(hasDestructiveRootRemove("rm -rf $home")).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #5232

## Problem

The `unsafe_install_pipeline` **critical** destructive-command check in `submission-risk.js` used:

```js
/rm\s+-rf\s+(\/|~|\$home)\b/i.test(installText)
```

The trailing `\b` requires a word character after the target, so it silently missed the most classic destructive forms:

- `rm -rf /` (bare root) — **missed** (`\b` after bare `/` has no following word char)
- `rm -rf ~` (bare tilde) — **missed**
- `rm -r -f /` (split flags) — **missed**
- `rm -fr /` (reversed) — **missed**
- `rm --recursive --force /` (long-form) — **missed**
- `rm -rf /etc` — caught (has a trailing word char)

## Fix

Replace the single-token regex with a self-contained `hasDestructiveRootRemove` helper that parses `rm` flags token-by-token — flagging a `rm` that carries **both** a recursive (`-r`/`-R`/`--recursive`) and a force (`-f`/`--force`) flag, in any order/spelling, aimed at a root/home target (`/`, `~`, `$HOME`), bare or with a path. Each `rm` is bounded to its own command segment so flags/target split across a pipe or `;` don't combine.

Kept independent of `command-safety-lib.js`'s separate detector, per the issue's out-of-scope note.

## Test matrix (`tests/submission-risk-invariants.test.ts`)

`hasDestructiveRootRemove` — **true**: `rm -rf /`, `rm -rf ~`, `rm -rf $HOME`, `rm -r -f /`, `rm -f -r /`, `rm -fr /`, `rm --recursive --force /`, `rm -rf /etc`, `rm -rf ~/Documents`, `sudo rm -rf /`, `RM -RF /`, `rm -rf $home`; **false**: `rm -r /`, `rm --force /`, `rm -rf ./build`, `rm -rf node_modules`, `npx -y some-mcp`, `rm -r x | echo -f /`.

Plus an integration test: a submission with `install_command: "rm -rf /"` now raises the `unsafe_install_pipeline` critical flag.

## Validation

```
pnpm exec vitest run tests/submission-risk-invariants.test.ts   # 35 passed
pnpm exec vitest run tests/submission-gate-*.test.ts tests/submission-api.test.ts   # unrelated CRLF source-text guards aside, green
pnpm exec prettier --check packages/registry/src/submission-risk.js tests/submission-risk-invariants.test.ts
```

No visual impact; no generated artifacts touched.