### PR TITLE
fix(scripts): align d1-jobs-cli env vars with job-sources-admin

### DIFF
--- a/scripts/lib/d1-jobs-cli.mjs
+++ b/scripts/lib/d1-jobs-cli.mjs
@@ -25,7 +25,11 @@ export function parseArgs(argv) {
 /** Resolve the admin API token from the accepted environment variables. */
 export function getToken(env = process.env) {
   return String(
-    env.ADMIN_API_TOKEN || env.LEADS_ADMIN_TOKEN || env.ADMIN_LEADS_TOKEN || "",
+    env.ADMIN_API_TOKEN ||
+      env.JOBS_ADMIN_API_TOKEN ||
+      env.LEADS_ADMIN_TOKEN ||
+      env.ADMIN_LEADS_TOKEN ||
+      "",
   ).trim();
 }
 
@@ -38,12 +42,10 @@ export function getBaseUrl(args, env = process.env) {
     args["base-url"] ||
       env.HEYCLAUDE_ADMIN_BASE_URL ||
       env.HEYCLAUDE_BASE_URL ||
-      env.HEYCLOUD_ADMIN_BASE_URL ||
-      env.HEYCLOUD_BASE_URL ||
       "",
   ).trim();
   if (!baseUrl) {
-    throw new Error("Missing --base-url or HEYCLOUD_ADMIN_BASE_URL.");
+    throw new Error("Missing --base-url or HEYCLAUDE_ADMIN_BASE_URL.");
   }
   return baseUrl.replace(/\/$/, "");
 }

--- a/tests/d1-jobs-cli.test.ts
+++ b/tests/d1-jobs-cli.test.ts
@@ -42,6 +42,7 @@ describe("parseArgs", () => {
 describe("getToken", () => {
   it("prefers ADMIN_API_TOKEN, then the fallbacks, and trims", () => {
     expect(getToken({ ADMIN_API_TOKEN: "  a  " })).toBe("a");
+    expect(getToken({ JOBS_ADMIN_API_TOKEN: "jobs" })).toBe("jobs");
     expect(getToken({ LEADS_ADMIN_TOKEN: "b" })).toBe("b");
     expect(getToken({ ADMIN_LEADS_TOKEN: "c" })).toBe("c");
   });
@@ -62,12 +63,14 @@ describe("getBaseUrl", () => {
     expect(getBaseUrl({}, { HEYCLAUDE_ADMIN_BASE_URL: "https://a.dev" })).toBe(
       "https://a.dev",
     );
-    expect(getBaseUrl({}, { HEYCLOUD_BASE_URL: "https://b.dev" })).toBe(
+    expect(getBaseUrl({}, { HEYCLAUDE_BASE_URL: "https://b.dev" })).toBe(
       "https://b.dev",
     );
   });
 
   it("throws when neither a flag nor an env var provides a base URL", () => {
-    expect(() => getBaseUrl({}, {})).toThrow(/Missing --base-url/);
+    expect(() => getBaseUrl({}, {})).toThrow(
+      /Missing --base-url or HEYCLAUDE_ADMIN_BASE_URL/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Align `d1-jobs-cli.mjs` credential resolution with `job-sources-admin.mjs` so `pnpm jobs:admin` accepts the same env vars as `pnpm jobs:check-sources`.
- `getToken()`: add `JOBS_ADMIN_API_TOKEN` (was missing).
- `getBaseUrl()`: remove typod `HEYCLOUD_*` fallbacks; error message now references `HEYCLAUDE_ADMIN_BASE_URL`.

Closes #5227

Reland of #5343 (closed by LoopOver after an unrelated `registry-artifacts` coverage timeout flake; `required-pr-gate` had already passed).

## Env-var before/after

| Helper | Before | After |
| --- | --- | --- |
| `getToken()` | `ADMIN_API_TOKEN`, `LEADS_ADMIN_TOKEN`, `ADMIN_LEADS_TOKEN` | + `JOBS_ADMIN_API_TOKEN` |
| `getBaseUrl()` | `HEYCLAUDE_*` + typod `HEYCLOUD_*` | `HEYCLAUDE_ADMIN_BASE_URL`, `HEYCLAUDE_BASE_URL` only |

## Test plan
- [x] `pnpm exec vitest run tests/d1-jobs-cli.test.ts`
- [ ] CI green (including coverage)