### PR TITLE
fix(registry): stop stripping blank-line separators from LLMS and Cursor adapter output

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -886,12 +886,15 @@ export function buildCursorSkillAdapter(entry) {
     "",
     "Use this rule when the user asks for this reusable skill workflow in Cursor. Cursor does not natively install Agent Skills from this package, so follow the SKILL.md instructions as a scoped workflow adapter.",
     "",
-    install ? "## Install" : "",
-    install ? codeBlock("bash", install) : "",
+    // `undefined` omits the optional Install block; `""` entries are intentional
+    // blank-line separators that must survive the filter (the previous `!== ""`
+    // filter stripped every blank line, collapsing the adapter into one block).
+    install ? "## Install" : undefined,
+    install ? codeBlock("bash", install) : undefined,
     "## Source",
     source,
   ]
-    .filter((line) => line !== "")
+    .filter((line) => line !== undefined)
     .join("\n");
 }
 

--- a/packages/registry/src/llms-lib.js
+++ b/packages/registry/src/llms-lib.js
@@ -146,22 +146,27 @@ export function buildEntryCitationFacts(entry, params = {}) {
 export function renderEntryLlms(entry, params = {}) {
   const siteUrl = params.siteUrl || "https://heyclau.de";
   const permalink = `${siteUrl.replace(/\/$/, "")}/entry/${entry.category}/${entry.slug}`;
+  // `undefined` marks a line to omit entirely; `""` is an intentional blank-line
+  // separator that must survive the filter. (A single `""` sentinel for both
+  // intents is the bug this fixes — `.filter(Boolean)` dropped every blank line.)
   const lines = [
     `# ${clean(entry.title)}`,
     "",
     `URL: ${permalink}`,
     `Category: ${entry.category}`,
-    entry.author ? `Author: ${entry.author}` : "",
-    entry.submittedBy ? `Submitted by: ${entry.submittedBy}` : "",
+    entry.author ? `Author: ${entry.author}` : undefined,
+    entry.submittedBy ? `Submitted by: ${entry.submittedBy}` : undefined,
     entry.sourceSubmissionUrl
       ? `Original submission: ${entry.sourceSubmissionUrl}`
-      : "",
-    entry.importPrUrl ? `Import PR: ${entry.importPrUrl}` : "",
-    entry.dateAdded ? `Date added: ${entry.dateAdded}` : "",
-    entry.documentationUrl ? `Documentation: ${entry.documentationUrl}` : "",
-    entry.repoUrl ? `Repository: ${entry.repoUrl}` : "",
-    entry.githubUrl ? `Directory source: ${entry.githubUrl}` : "",
-    entry.downloadUrl ? `Download: ${entry.downloadUrl}` : "",
+      : undefined,
+    entry.importPrUrl ? `Import PR: ${entry.importPrUrl}` : undefined,
+    entry.dateAdded ? `Date added: ${entry.dateAdded}` : undefined,
+    entry.documentationUrl
+      ? `Documentation: ${entry.documentationUrl}`
+      : undefined,
+    entry.repoUrl ? `Repository: ${entry.repoUrl}` : undefined,
+    entry.githubUrl ? `Directory source: ${entry.githubUrl}` : undefined,
+    entry.downloadUrl ? `Download: ${entry.downloadUrl}` : undefined,
     "",
     "## Citation Facts",
     buildEntryCitationFacts(entry, { siteUrl }),
@@ -174,16 +179,16 @@ export function renderEntryLlms(entry, params = {}) {
       ? entry.tags.map((tag) => `- ${tag}`).join("\n")
       : "- none",
     "",
-    entry.safetyNotes?.length ? "## Safety Notes" : "",
+    entry.safetyNotes?.length ? "## Safety Notes" : undefined,
     ...bulletList(entry.safetyNotes),
-    entry.safetyNotes?.length ? "" : "",
-    entry.privacyNotes?.length ? "## Privacy Notes" : "",
+    entry.safetyNotes?.length ? "" : undefined,
+    entry.privacyNotes?.length ? "## Privacy Notes" : undefined,
     ...bulletList(entry.privacyNotes),
-    entry.privacyNotes?.length ? "" : "",
+    entry.privacyNotes?.length ? "" : undefined,
     "## Content",
     sectionText(entry),
     "",
-  ].filter(Boolean);
+  ].filter((line) => line !== undefined);
 
   return trimLineEndings(lines.join("\n"));
 }

--- a/tests/artifacts-lib.test.ts
+++ b/tests/artifacts-lib.test.ts
@@ -888,6 +888,16 @@ describe("buildCursorSkillAdapter", () => {
     );
     expect(adapter).toContain("https://github.com/example/synthetic");
   });
+
+  it("keeps blank-line separators, including right after the closing frontmatter", () => {
+    const adapter = buildCursorSkillAdapter(FIXTURE_SKILLS);
+    // Blank line between the closing `---` and the body heading.
+    expect(adapter).toContain("---\n\n# skills lint-helper");
+    // Blank line before the optional Install section (not glued to the intro).
+    expect(adapter).toContain("\n\n## Install");
+    // The document is not collapsed into a single blank-line-free block.
+    expect(adapter).toMatch(/\n\n/);
+  });
 });
 
 describe("buildArtifactEnvelope", () => {

--- a/tests/llms-lib.test.ts
+++ b/tests/llms-lib.test.ts
@@ -325,6 +325,31 @@ describe("renderEntryLlms", () => {
     expect(output).not.toContain("## Privacy Notes");
   });
 
+  it("keeps blank-line separators between every section", () => {
+    const output = renderEntryLlms(
+      entry({
+        author: "Ada",
+        tags: ["claude"],
+        safetyNotes: ["Runs locally"],
+        privacyNotes: ["No telemetry"],
+        body: "Do helpful things.",
+      }),
+    );
+    // A blank line follows the title and precedes each section header, rather
+    // than every blank line being stripped by the old `.filter(Boolean)`.
+    expect(output).toContain("# Demo Agent\n\n");
+    for (const header of [
+      "Citation Facts",
+      "Summary",
+      "Tags",
+      "Safety Notes",
+      "Privacy Notes",
+      "Content",
+    ]) {
+      expect(output).toContain(`\n\n## ${header}\n`);
+    }
+  });
+
   it("renders structured section content instead of raw body", () => {
     const output = renderEntryLlms(
       entry({


### PR DESCRIPTION
Closes #5230

_Re-opened after the previous PR was auto-closed on a flaky `coverage`-job timeout of an unrelated slow test (`registry-artifacts.test.ts` "derives all generated aggregate artifacts", which hit its 180s limit at 186s under v8 instrumentation). That test passes locally on this branch and does not exercise the renderers changed here._

## Problem

`renderEntryLlms` (`llms-lib.js`) and `buildCursorSkillAdapter` (`artifacts-lib.js`) build output as an array that interleaves content lines with `""` blank-line spacers, then call `.filter(Boolean)` / `.filter((line) => line !== "")`. Because the same `""` is used **both** as an intentional spacer and as the "omit this optional line" sentinel, the filter strips **every** blank line — collapsing each entry's `/llms` artifact (and `llms-full.txt`) and every skill's Cursor `.mdc` adapter into one unbroken block. Existing tests only used `.toContain(...)`, so a missing blank line was never caught.

## Fix

Distinguish the two intents: optional lines now use `undefined` as the omit-sentinel and the filter drops only `undefined`, so real `""` separators survive.

- `llms-lib.js`: conditional metadata/section lines emit `undefined` when absent; the two `x ? "" : ""` lines become `x ? "" : undefined`; filter is `line !== undefined`. `renderCorpusLlms` never filtered and just calls `renderEntryLlms`, so it is fixed transitively.
- `artifacts-lib.js` `buildCursorSkillAdapter`: the optional Install lines emit `undefined`; filter is `line !== undefined`.

## Tests

- `tests/llms-lib.test.ts`: asserts `# Demo Agent\n\n` and `\n\n## <Header>\n` for Citation Facts / Summary / Tags / Safety Notes / Privacy Notes / Content — real `\n\n` boundary checks, not just `.toContain`.
- `tests/artifacts-lib.test.ts`: asserts `---\n\n# skills lint-helper` (blank line after frontmatter) and `\n\n## Install`.

## Validation

```
pnpm exec vitest run tests/llms-lib.test.ts tests/artifacts-lib.test.ts   # 309 passed
pnpm exec vitest run tests/registry-artifacts.test.ts -t "derives all generated aggregate artifacts"   # passes locally
pnpm exec prettier --check <changed files>
```

No visual impact (build-artifact output, not website UI); no generated artifacts committed.