### PR TITLE
fix(web): derive brief approval send-slot copy from the schedule constants

### DIFF
--- a/apps/web/src/lib/brief-schedule-lib.ts
+++ b/apps/web/src/lib/brief-schedule-lib.ts
@@ -13,6 +13,23 @@
 const SEND_DOW = 0; // 0=Sun..6=Sat; Sunday
 const SEND_HOUR_UTC = 16;
 
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/**
+ * Human-readable name of the send slot ("Sunday 16:00 UTC"), derived from the
+ * constants above so UI copy can't drift from the schedule it describes — the
+ * approval page had hardcoded a stale "Tuesday 15:00 UTC".
+ */
+export const SEND_SLOT_LABEL = `${DAY_NAMES[SEND_DOW]} ${String(SEND_HOUR_UTC).padStart(2, "0")}:00 UTC`;
+
 /**
  * The next Sunday 16:00 UTC strictly at or after `from` (today if it's Sunday
  * before 16:00, otherwise the following Sunday). Returned as an ISO string for

--- a/apps/web/src/lib/brief-schedule.ts
+++ b/apps/web/src/lib/brief-schedule.ts
@@ -5,4 +5,4 @@
  * (`@/lib/brief-schedule-lib`). This module re-exports it so existing
  * `@/lib/brief-schedule` importers stay unchanged.
  */
-export { nextSendSlot } from "@/lib/brief-schedule-lib";
+export { nextSendSlot, SEND_SLOT_LABEL } from "@/lib/brief-schedule-lib";

--- a/apps/web/src/routes/brief.approve.tsx
+++ b/apps/web/src/routes/brief.approve.tsx
@@ -10,6 +10,7 @@ import {
   briefApproveEgressAnalyticsEvent,
 } from "@/lib/brief-approve-cta-events";
 import { briefIssueHubDestination } from "@/lib/brief-entry-cta-events";
+import { SEND_SLOT_LABEL } from "@/lib/brief-schedule-lib";
 
 const tokenInput = z.object({ token: z.string() });
 const confirmInput = z.object({
@@ -95,7 +96,7 @@ function ApprovePage() {
   return (
     <Shell heading={`Approve Weekly Brief #${result.number}`}>
       Approving the draft for the week of <strong>{result.periodThrough}</strong> schedules it to
-      send to the newsletter audience at the next Tuesday 15:00 UTC slot. Review the full draft in
+      send to the newsletter audience at the next {SEND_SLOT_LABEL} slot. Review the full draft in
       your preview email first.
       {state.phase === "error" && (
         <p style={{ color: "#b4541f", marginTop: 12 }}>

--- a/tests/brief-schedule-lib.test.ts
+++ b/tests/brief-schedule-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { nextSendSlot } from "../apps/web/src/lib/brief-schedule-lib";
+import {
+  nextSendSlot,
+  SEND_SLOT_LABEL,
+} from "../apps/web/src/lib/brief-schedule-lib";
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -70,5 +73,19 @@ describe("nextSendSlot", () => {
     expect(nextSendSlot(new Date("2026-06-01T00:00:00Z"))).toMatch(
       /^\d{4}-\d{2}-\d{2}T16:00:00\.000Z$/,
     );
+  });
+});
+
+describe("SEND_SLOT_LABEL", () => {
+  // The approval page renders this label as the promise of when a brief will
+  // go out, so it has to describe the slot nextSendSlot actually returns.
+  it("describes the same day and hour that nextSendSlot schedules", () => {
+    const slot = new Date(nextSendSlot(new Date("2026-06-01T00:00:00Z")));
+    const day = slot.toLocaleDateString("en-US", {
+      weekday: "long",
+      timeZone: "UTC",
+    });
+    const hour = String(slot.getUTCHours()).padStart(2, "0");
+    expect(SEND_SLOT_LABEL).toBe(`${day} ${hour}:00 UTC`);
   });
 });


### PR DESCRIPTION
Closes #5257

## What

`brief.approve.tsx` told the approving maintainer the brief would send "at the next **Tuesday 15:00 UTC** slot". The real slot is **Sunday 16:00 UTC** — `brief-schedule-lib.ts` (`SEND_DOW = 0`, `SEND_HOUR_UTC = 16`), the `"0 16 * * SUN"` cron in `wrangler.jsonc`, and `brief.tsx`'s "Sundays" copy all agree. Only the approval page disagreed.

## How

Rather than hardcode a second, correctable copy of the schedule, the label is now derived from the same two constants `nextSendSlot` computes from:

```ts
export const SEND_SLOT_LABEL = `${DAY_NAMES[SEND_DOW]} ${String(SEND_HOUR_UTC).padStart(2, "0")}:00 UTC`;
```

`brief.approve.tsx` renders `{SEND_SLOT_LABEL}`, and `brief-schedule.ts` re-exports it alongside `nextSendSlot`. If the schedule ever moves, the copy moves with it — the drift this issue reports can't recur.

Before: `send to the newsletter audience at the next Tuesday 15:00 UTC slot.`
After:  `send to the newsletter audience at the next Sunday 16:00 UTC slot.`

## Evidence

Per the issue, deriving from the shared constant is offered in place of a screenshot; the rendered string is the diff above.

Regression test asserts the label against the slot `nextSendSlot` actually returns (not a hardcoded expectation), so the two can't disagree:

```ts
const slot = new Date(nextSendSlot(new Date("2026-06-01T00:00:00Z")));
const day = slot.toLocaleDateString("en-US", { weekday: "long", timeZone: "UTC" });
expect(SEND_SLOT_LABEL).toBe(`${day} ${String(slot.getUTCHours()).padStart(2, "0")}:00 UTC`);
```

Mutation-tested — the test is not vacuous:
- `SEND_SLOT_LABEL = "Tuesday 15:00 UTC"` (the old hardcoded string) -> **fails**
- `DAY_NAMES[SEND_DOW]` -> `DAY_NAMES[2]` -> **fails** (`expected 'Tuesday 16:00 UTC' to be 'Sunday 16:00 UTC'`)
- reverted -> 7/7 pass

## Validation

- `pnpm exec vitest run tests/brief-schedule-lib.test.ts` — 7/7 pass
- `pnpm --filter web exec tsc --noEmit` — clean (exit 0)
- `pnpm exec prettier --check` on all four touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
