### PR TITLE
fix(docs): clarify newsletter confirm-token de-dupe limits

### DIFF
--- a/docs/newsletter-resend-playbook.md
+++ b/docs/newsletter-resend-playbook.md
@@ -12,7 +12,10 @@ emails are generated in-worker and sent programmatically.
   `buildDigestEmail`. No tracking pixels.
 - **Confirm (double opt-in):** `api/newsletter/subscribe` emails a signed
   (HMAC) confirm link; `api/public/newsletter/confirm` verifies it (POST, rate
-  limited, single-use, 8 KB body cap) and adds the contact to the Resend audience.
+  limited, 8 KB body cap) and adds the contact to the Resend audience. Token
+  replay is best-effort de-duped in an in-memory `Map` within a single Worker
+  isolate (not durable across isolates); true idempotency comes from Resend's
+  contact-create duplicate handling (HTTP 409).
 - **Welcome:** sent transactionally on first-time confirm.
 - **Weekly digest:** `plugins/newsletter-digest-scheduled.ts`, Cloudflare cron
   `0 16 * * SUN` (Sundays 16:00 UTC). Selects entries added in the last 7 days,


### PR DESCRIPTION
## Summary
- Soften the confirm-endpoint `single-use` claim in `docs/newsletter-resend-playbook.md`.
- Document actual behavior: best-effort in-isolate `Map` de-dupe, with Resend contact-create 409 as the durable idempotency net (matches `confirm.ts`).

Closes #5264

## Quality evidence
- No visual impact (docs only).
- Confirmed against `apps/web/src/routes/api/public/newsletter/confirm.ts` (`consumedConfirmTokens`).

## Test plan
- [x] Manual: wording no longer claims durable cross-isolate single-use
- [ ] CI green