### PR TITLE
fix(registry): install the first usable server from a multi-server MCP snippet

### DIFF
--- a/packages/registry/src/mcp-install-config-lib.js
+++ b/packages/registry/src/mcp-install-config-lib.js
@@ -131,22 +131,27 @@ export function normalizeMcpServerConfig(value) {
   return config;
 }
 
-function singleServerFromMap(value) {
+// One-click install targets a single named server. A `mcpServers` map may
+// legitimately declare several (e.g. an SSE and a streamable variant of the
+// same backend), so take the first one that normalizes rather than refusing
+// the whole snippet — a user offered one working install target is better
+// served than one offered none. The remaining servers stay visible in the
+// entry's own configSnippet for anyone who wants them.
+function installableServerFromMap(value) {
   if (!isRecord(value)) return null;
-  const servers = Object.entries(value).filter(([, config]) =>
-    isRecord(config),
-  );
-  if (servers.length !== 1) return null;
-  const [name, config] = servers[0];
-  const normalized = normalizeMcpServerConfig(config);
-  return normalized ? { name, config: normalized } : null;
+  for (const [name, config] of Object.entries(value)) {
+    if (!isRecord(config)) continue;
+    const normalized = normalizeMcpServerConfig(config);
+    if (normalized) return { name, config: normalized };
+  }
+  return null;
 }
 
 export function extractMcpServerConfig(value) {
   const parsed = typeof value === "string" ? JSON.parse(value.trim()) : value;
   if (!isRecord(parsed)) return null;
 
-  return singleServerFromMap(parsed.mcpServers);
+  return installableServerFromMap(parsed.mcpServers);
 }
 
 function bearerTokenEnvVar(config) {

--- a/tests/mcp-install-config-lib.test.ts
+++ b/tests/mcp-install-config-lib.test.ts
@@ -194,16 +194,8 @@ describe("extractMcpServerConfig", () => {
     expect(extracted?.config.url).toBe("https://remote.example.com/mcp");
   });
 
-  it("rejects maps with zero or multiple servers and invalid inner configs", () => {
+  it("rejects empty maps and invalid inner configs", () => {
     expect(extractMcpServerConfig({ mcpServers: {} })).toBeNull();
-    expect(
-      extractMcpServerConfig({
-        mcpServers: {
-          a: { command: "npx" },
-          b: { command: "node" },
-        },
-      }),
-    ).toBeNull();
     expect(
       extractMcpServerConfig({
         mcpServers: {
@@ -212,6 +204,46 @@ describe("extractMcpServerConfig", () => {
       }),
     ).toBeNull();
     expect(() => extractMcpServerConfig("not json")).toThrow(SyntaxError);
+  });
+
+  it("takes the first installable server from a multi-server map", () => {
+    // Shape of the published ai-aliengiraffe-spotdb-mcp-server entry: one
+    // backend exposed as both an SSE and a streamable server.
+    const extracted = extractMcpServerConfig({
+      mcpServers: {
+        "spotdb-sse": {
+          command: "npx",
+          args: ["-y", "mcp-remote", "https://sse.example.com/sse"],
+        },
+        "spotdb-streamable": {
+          command: "npx",
+          args: ["-y", "mcp-remote", "https://stream.example.com/mcp"],
+        },
+      },
+    });
+    expect(extracted?.name).toBe("spotdb-sse");
+    expect(extracted?.config.args).toContain("https://sse.example.com/sse");
+  });
+
+  it("skips leading servers that do not normalize", () => {
+    const extracted = extractMcpServerConfig({
+      mcpServers: {
+        broken: { transport: "sse", url: "https://example.com/sse" },
+        usable: { type: "http", url: "https://api.example.com/mcp" },
+      },
+    });
+    expect(extracted?.name).toBe("usable");
+  });
+
+  it("returns null when no server in a multi-server map normalizes", () => {
+    expect(
+      extractMcpServerConfig({
+        mcpServers: {
+          a: { transport: "sse", url: "https://a.example.com/sse" },
+          b: { type: "http", url: "http://insecure.example.com/mcp" },
+        },
+      }),
+    ).toBeNull();
   });
 
   it("returns null when the payload or its mcpServers is not a record", () => {

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -2195,6 +2195,8 @@ describe("non-UI branch matrix", () => {
         headers: { Authorization: { secret: true } },
       }),
     ).toBeNull();
+    // Multi-server maps install their first usable server rather than
+    // resolving to nothing at all.
     expect(
       extractMcpServerConfig({
         mcpServers: {
@@ -2202,7 +2204,7 @@ describe("non-UI branch matrix", () => {
           two: { command: "node" },
         },
       }),
-    ).toBeNull();
+    ).toEqual({ name: "one", config: { command: "node", type: "stdio" } });
     expect(() => extractMcpServerConfig("not json")).toThrow();
     expect(formatMcpConfigSnippet("", { command: "node" })).toContain(
       '"heyclaude-mcp"',

--- a/tests/registry-mcp-install-config-edges.test.ts
+++ b/tests/registry-mcp-install-config-edges.test.ts
@@ -24,13 +24,13 @@ describe("mcp-install-config-lib extractMcpServerConfig", () => {
     expect(extractMcpServerConfig({ mcpServers: "nope" })).toBeNull();
   });
 
-  it("rejects a map that does not hold exactly one server", () => {
+  it("rejects an empty map but installs the first of several servers", () => {
+    expect(extractMcpServerConfig({ mcpServers: {} })).toBeNull();
     expect(
       extractMcpServerConfig({
         mcpServers: { a: { command: "x" }, b: { command: "y" } },
       }),
-    ).toBeNull();
-    expect(extractMcpServerConfig({ mcpServers: {} })).toBeNull();
+    ).toEqual({ name: "a", config: { command: "x", type: "stdio" } });
   });
 
   it("extracts a single normalized stdio server", () => {


### PR DESCRIPTION
Closes #5251

## Option chosen: (a) — take the first valid server

`singleServerFromMap` required `mcpServers` to hold **exactly one** entry, so any snippet declaring several resolved to `null` and the entry got zero one-click install targets. Option (a) is the smallest change that matches the issue's framing of "give the user *something* to install" over "give them nothing", and it needs no schema or artifact-shape change. Options (b) and (c) were rejected: (b) changes the `ResolvedMcpInstallConfig` contract and every consumer of it for one published entry, and (c) would mean restructuring a legitimately-shaped, valid MCP config — a two-server map is normal, not a content defect.

The remaining servers are unchanged and still visible in the entry's own `configSnippet` for anyone who wants them; only the one-click target is narrowed to one.

## Before / after on the real entry

Run against `content/mcp/ai-aliengiraffe-spotdb-mcp-server.mdx`'s actual `configSnippet`:

**Before** — `resolveMcpInstallConfig(...)` -> `null` (zero install targets)

**After:**
```json
{
  "name": "spotdb-sse",
  "targets": ["claude-code", "codex", "cursor", "antigravity"],
  "config": {
    "command": "npx",
    "args": ["-y", "mcp-remote", "SPOTDB_MCP_SSE_URL_FROM_DOCS", "--allow-http"],
    "env": { "npm_config_yes": "true" },
    "type": "stdio"
  }
}
```

## Behavior

- Multi-server map -> first server that normalizes.
- Leading server that fails to normalize -> skipped, next usable one wins.
- **No** server normalizes -> still `null`. The fix loosens the arity rule only; it does not weaken any per-server validation (loopback/https checks, transport rejection, scalar env/header checks all still gate each candidate).

## Tests

Three existing tests encoded the exactly-one rule as an expectation and are updated to the new contract (`mcp-install-config-lib`, `registry-mcp-install-config-edges`, `non-ui-branch-matrix`), plus three new cases for the behaviors above.

Mutation-tested — restoring the old `servers.length !== 1` guard fails all three new assertions:
```
x rejects an empty map but installs the first of several servers
x takes the first installable server from a multi-server map
x skips leading servers that do not normalize
Tests  3 failed | 37 passed
```

## Validation

- `pnpm exec vitest run tests/mcp-install-config-lib.test.ts tests/registry-mcp-install-config.test.ts tests/registry-mcp-install-config-edges.test.ts` — 41/41 pass (the issue's stated validation command)
- plus `tests/non-ui-branch-matrix.test.ts` — 61/61 across all four
- `pnpm generate:registry` then `pnpm exec vitest run tests/registry-artifacts.test.ts` — the trust-signals/aggregate artifact tests pass; the spotdb entry's `trustSignals.platforms` goes `[]` -> `["claude-code","codex","cursor"]`, which is the intended effect of the fix. No tracked artifact churn (`apps/web/public/data/**` is gitignored).
- `pnpm --filter web exec tsc --noEmit` — clean
- `prettier --check` on all four touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
