### PR TITLE
fix(web): log why the weekly brief send and preview steps skip

### DIFF
--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -36,6 +36,18 @@ type CloudflareScheduledPayload = {
 };
 
 /**
+ * Names of the falsy entries in `conditions`, for skip logs that say exactly
+ * which requirement was unmet. A silent early return on this path means an
+ * approved brief never reaches the audience with nothing in the Worker logs to
+ * explain it, so every skip names its cause.
+ */
+function missingNames(conditions: Record<string, unknown>): string[] {
+  return Object.entries(conditions)
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+}
+
+/**
  * The Weekly Brief pipeline — the single weekly newsletter send. Friday:
  * generate a draft + email the maintainer an approve link. 6-hourly and Sunday
  * 16:00 UTC: send any approved-and-due brief to the Resend audience
@@ -95,6 +107,16 @@ export default definePlugin((nitroApp) => {
               });
               await sendResendEmail({ apiKey, from, to: reviewEmail, subject, html, text });
               console.log("[brief-generate] preview sent", { number: draft.number });
+            } else {
+              console.warn(
+                `[brief-generate] preview skipped: ${missingNames({
+                  draft: wrote && draft,
+                  BRIEF_REVIEW_EMAIL: reviewEmail,
+                  NEWSLETTER_CONFIRM_SECRET: secret,
+                  RESEND_API_KEY: apiKey,
+                  RESEND_FROM: from,
+                }).join("/")}`,
+              );
             }
           } catch (error) {
             console.error("[brief-generate] generation failed", error);
@@ -112,7 +134,16 @@ export default definePlugin((nitroApp) => {
             const apiKey = getEnvString("RESEND_API_KEY");
             const segmentId = getEnvString("RESEND_SEGMENT_ID");
             const from = getEnvString("RESEND_FROM");
-            if (!apiKey || !segmentId || !from) return;
+            if (!apiKey || !segmentId || !from) {
+              console.warn(
+                `[brief-send] skipped: missing ${missingNames({
+                  RESEND_API_KEY: apiKey,
+                  RESEND_SEGMENT_ID: segmentId,
+                  RESEND_FROM: from,
+                }).join("/")}`,
+              );
+              return;
+            }
             const due = await getDueApprovedBriefs(new Date().toISOString());
             for (const issue of due) {
               const { subject, html, text } = buildBriefEmail({

--- a/tests/weekly-brief-schedule.test.ts
+++ b/tests/weekly-brief-schedule.test.ts
@@ -20,4 +20,26 @@ describe("weekly brief schedule", () => {
     expect(plugin).toContain(sundaySendCron);
     expect(wranglerConfig).toContain(sundaySendCron);
   });
+
+  // A silent early return on the send path means an approved brief never
+  // reaches the audience, with nothing in the Worker logs to explain why.
+  it("logs a named reason on both silent-skip paths", () => {
+    const plugin = readFileSync(
+      join(repoRoot, "apps/web/plugins/newsletter-digest-scheduled.ts"),
+      "utf8",
+    );
+
+    expect(plugin).toContain("[brief-send] skipped: missing ");
+    expect(plugin).toContain("[brief-generate] preview skipped: ");
+    // Every secret the send path gates on is named in its skip log.
+    for (const secret of [
+      "RESEND_API_KEY",
+      "RESEND_SEGMENT_ID",
+      "RESEND_FROM",
+    ]) {
+      expect(plugin, secret).toContain(`${secret}: `);
+    }
+    // The skip must still return without sending — logging-only change.
+    expect(plugin).toMatch(/\[brief-send\] skipped[\s\S]{0,400}?return;/);
+  });
 });


### PR DESCRIPTION
Closes #5254

## What

The `SEND_CRONS` branch — the actual audience-send path — returned early with **zero logging** when `RESEND_API_KEY`, `RESEND_SEGMENT_ID`, or `RESEND_FROM` was unset. An approved brief would then silently fail to send every 6 hours, indefinitely, with nothing in the Worker logs to explain it. The `GENERATE_CRON` preview-email step had the same gap: a 6-condition `if` with no `else`.

Both now name the unmet requirement, following `indexnow-scheduled.ts`'s `"[indexnow] skipped: ..."` pattern.

## Exact log text

Send path (`[brief-send]`), listing only the secrets actually missing:
```
[brief-send] skipped: missing RESEND_SEGMENT_ID
[brief-send] skipped: missing RESEND_API_KEY/RESEND_FROM
```

Preview path (`[brief-generate]`), covering the non-secret conditions too:
```
[brief-generate] preview skipped: draft
[brief-generate] preview skipped: NEWSLETTER_CONFIRM_SECRET/RESEND_FROM
```

Both are emitted via a small local helper that returns the falsy keys of a condition record, so the message always names the specific cause rather than a generic "misconfigured":

```ts
function missingNames(conditions: Record<string, unknown>): string[] {
  return Object.entries(conditions)
    .filter(([, value]) => !value)
    .map(([name]) => name);
}
```

## Behavior

Logging only, per the issue's out-of-scope note. The skip conditions are byte-identical and the send path still `return`s without sending — `console.warn` is added ahead of the existing early return, nothing else moved.

## Evidence

No visual impact.

The plugin has no importable export (it is a `definePlugin` default), so the assertions follow the file's existing source-inspection style in `tests/weekly-brief-schedule.test.ts`: both log prefixes are present, every gated secret is named in the skip record, and a regex confirms the send-path skip still reaches `return;`.

Mutation-tested — the test is not vacuous:
- restore `if (!apiKey || !segmentId || !from) return;` (no log) -> **fails**
- rename the preview log to something that isn't a skip message -> **fails**
- restored -> 2/2 pass

Helper semantics verified directly:
```
all set        -> []
segment unset  -> RESEND_SEGMENT_ID
key+from unset -> RESEND_API_KEY/RESEND_FROM
no draft       -> draft
```

## Validation

- `pnpm --filter web exec tsc --noEmit` — clean (exit 0), the issue's stated validation
- `pnpm exec vitest run tests/weekly-brief-schedule.test.ts` — 2/2 pass
- `prettier --check` on both touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
