### PR TITLE
fix(web): stop marking non-content-addressed downloads immutable

### DIFF
--- a/apps/web/src/lib/download-asset-lib.ts
+++ b/apps/web/src/lib/download-asset-lib.ts
@@ -22,3 +22,20 @@ export function getContentType(asset: string): string {
 export function filenameFromAsset(asset: string): string {
   return asset.split("/").filter(Boolean).at(-1) || "download";
 }
+
+/**
+ * Cache-control for `/api/download` responses.
+ *
+ * These URLs are *not* content-addressed — `getDownloadHref` builds
+ * `/api/download?asset=/downloads/skills/<slug>.zip` from the slug alone, so a
+ * maintainer rebuilding a package publishes different bytes at an unchanged
+ * URL. `immutable` promised the opposite: never revalidate for a year, which
+ * would pin clients to a stale artifact whose bytes no longer match the entry's
+ * `downloadSha256`, with nothing short of a cache-busting query string able to
+ * dislodge it.
+ *
+ * So: still cacheable, but revalidated once the short TTL lapses. An unchanged
+ * artifact revalidates cheaply; a republished one is picked up within the hour
+ * rather than within a year.
+ */
+export const DOWNLOAD_CACHE_CONTROL = "public, max-age=3600, must-revalidate";

--- a/apps/web/src/routes/api/download.ts
+++ b/apps/web/src/routes/api/download.ts
@@ -4,7 +4,12 @@ import { downloadQuerySchema } from "@/lib/api/contracts";
 import { apiError, createApiHandler, type InferApiQuery } from "@/lib/api/router";
 import { logApiError, logApiInfo, logApiWarn, sample } from "@/lib/api-logs";
 import { readDownloadAsset } from "@/lib/download-assets.server";
-import { filenameFromAsset, getContentType, isAllowedAssetPath } from "@/lib/download-asset-lib";
+import {
+  DOWNLOAD_CACHE_CONTROL,
+  filenameFromAsset,
+  getContentType,
+  isAllowedAssetPath,
+} from "@/lib/download-asset-lib";
 
 export const GET = createApiHandler("download", async ({ request, query, requestId }) => {
   const { asset } = query as InferApiQuery<typeof downloadQuerySchema>;
@@ -31,7 +36,7 @@ export const GET = createApiHandler("download", async ({ request, query, request
       headers: {
         "content-type": getContentType(asset),
         "content-disposition": `attachment; filename="${filename}"`,
-        "cache-control": "public, max-age=31536000, immutable",
+        "cache-control": DOWNLOAD_CACHE_CONTROL,
         "x-content-type-options": "nosniff",
       },
     });

--- a/tests/download-asset-lib.test.ts
+++ b/tests/download-asset-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DOWNLOAD_CACHE_CONTROL,
   filenameFromAsset,
   getContentType,
   isAllowedAssetPath,
@@ -41,5 +42,24 @@ describe("filenameFromAsset", () => {
   it("falls back to 'download' when there is no segment", () => {
     expect(filenameFromAsset("///")).toBe("download");
     expect(filenameFromAsset("")).toBe("download");
+  });
+});
+
+describe("DOWNLOAD_CACHE_CONTROL", () => {
+  // getDownloadHref builds /api/download?asset=/downloads/<kind>/<slug>.<ext>
+  // from the slug alone, so a rebuilt package serves new bytes at the same URL.
+  // Promising immutability over that URL is what this guards against.
+  it("does not promise immutability for a non-content-addressed URL", () => {
+    expect(DOWNLOAD_CACHE_CONTROL).not.toContain("immutable");
+  });
+
+  it("stays cacheable but revalidates within an hour", () => {
+    expect(DOWNLOAD_CACHE_CONTROL).toContain("public");
+    expect(DOWNLOAD_CACHE_CONTROL).toContain("must-revalidate");
+
+    const maxAge = Number(/max-age=(\d+)/.exec(DOWNLOAD_CACHE_CONTROL)?.[1]);
+    expect(Number.isFinite(maxAge)).toBe(true);
+    expect(maxAge).toBeGreaterThan(0);
+    expect(maxAge).toBeLessThanOrEqual(3600);
   });
 });


### PR DESCRIPTION
Closes #5244

## Option chosen: (b) — drop `immutable`, revalidate on a short TTL

`/api/download` returned `public, max-age=31536000, immutable` for URLs that are **not** content-addressed. `getDownloadHref` builds them from the slug alone:

```
/api/download?asset=/downloads/skills/<slug>.zip
```

So a maintainer rebuilding a package publishes different bytes at an unchanged URL, while the response promises the opposite: never revalidate for a year. A client that cached the old artifact stays pinned to it, its bytes no longer matching the entry's `downloadSha256` (the value surfaced in `/.well-known/agent-skills/index.json` and the detail trust panel for verification) — and nothing short of a cache-busting query string could dislodge it.

**Why not (a) content-addressing:** it is the better long-term shape, but it is not a self-contained change. `getDownloadHref(downloadUrl)` takes only the URL — it has no access to the entry's `downloadSha256` — so content-addressing means threading the hash through the callers, widening `downloadQuerySchema` and its OpenAPI contract, and touching the components that render download buttons. That is a larger surface than this bug needs, and it would leave the incorrect header in place until all of it lands. Option (b) makes the header truthful now and does not foreclose (a) later.

Per the issue's instruction to check the publish workflow first: `AGENTS.md` describes `/downloads/...` artifacts as *"maintainer-built convenience packages only, with checksums and package trust metadata after review"* — rebuilt by maintainers under the existing slug, which is exactly the republish-in-place case. Nothing in `scripts/` versions the artifact filename.

## The change

```ts
export const DOWNLOAD_CACHE_CONTROL = "public, max-age=3600, must-revalidate";
```

Kept in `download-asset-lib.ts` (in the issue's stated scope) rather than inline in the route, so the reasoning travels with the value and it is unit-testable. The route imports it; nothing else about the handler changed.

Long-lived caching is preserved as far as it is actually justified: responses stay `public` and cacheable, an unchanged artifact revalidates cheaply with a 304, and a republished one is picked up within the hour instead of within a year.

## Evidence

No visual impact.

Mutation-tested — restoring `"public, max-age=31536000, immutable"` fails both new assertions:
```
x does not promise immutability for a non-content-addressed URL
x stays cacheable but revalidates within an hour
Tests  2 failed | 5 passed
```
The second test asserts the bound rather than the literal (`max-age` parsed, `> 0` and `<= 3600`), so it constrains the policy instead of restating the string.

## Validation

- `pnpm exec vitest run tests/download-asset-lib.test.ts` — 7/7 pass (the issue's stated validation)
- `pnpm exec vitest run tests/api-contracts.test.ts tests/detail-assembly-text-download.test.ts tests/download-package-url.test.ts` — 26/26 pass
- `pnpm --filter web exec tsc --noEmit` — clean (exit 0)
- `prettier --check` on all three touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
- No other test or source referenced the old header value
