### PR TITLE
fix(registry): auto-resolve brandLogoUrl via the brand asset proxy

### DIFF
--- a/packages/registry/src/brand-assets-lib.js
+++ b/packages/registry/src/brand-assets-lib.js
@@ -417,7 +417,17 @@ export function buildBrandAssetMetadata(data = {}, options = {}) {
           siteUrl: options.assetBaseUrl || options.siteUrl,
         })
       : "");
-  const brandLogoUrl = clean(data.brandLogoUrl);
+  // Mirrors the icon fallback above: a manual value still wins, and otherwise
+  // the logo resolves through the same proxy, so brandAssetSource:"brandfetch"
+  // describes both fields rather than only the icon.
+  const brandLogoUrl =
+    clean(data.brandLogoUrl) ||
+    (shouldUseBrandfetch
+      ? brandAssetProxyUrl(brandDomain, {
+          kind: "logo",
+          siteUrl: options.assetBaseUrl || options.siteUrl,
+        })
+      : "");
   const safeBrandIconUrl =
     brandIconUrl && isAllowedBrandAssetUrl(brandIconUrl) ? brandIconUrl : "";
   const safeBrandLogoUrl =

--- a/tests/brand-assets-lib.test.ts
+++ b/tests/brand-assets-lib.test.ts
@@ -342,6 +342,42 @@ describe("buildBrandAssetMetadata", () => {
     });
   });
 
+  // brandAssetSource: "brandfetch" claims brand assets were resolved, so the
+  // logo has to resolve on the same terms as the icon rather than staying empty.
+  it("auto-resolves the brandfetch logo alongside the icon", () => {
+    expect(
+      buildBrandAssetMetadata(
+        { title: "Zapier Workflow", tags: ["zapier"] },
+        { allowAliasFallback: true },
+      ),
+    ).toMatchObject({
+      brandIconUrl: "/api/brand-assets/icon/zapier.com",
+      brandLogoUrl: "/api/brand-assets/logo/zapier.com",
+      brandAssetSource: "brandfetch",
+    });
+  });
+
+  it("prefers a manually supplied brandLogoUrl over auto-resolution", () => {
+    expect(
+      buildBrandAssetMetadata(
+        {
+          title: "Zapier Workflow",
+          tags: ["zapier"],
+          brandLogoUrl: "https://cdn.brandfetch.io/zapier.com/logo.png",
+        },
+        { allowAliasFallback: true },
+      ),
+    ).toMatchObject({
+      brandLogoUrl: "https://cdn.brandfetch.io/zapier.com/logo.png",
+    });
+  });
+
+  it("leaves brandLogoUrl empty when brandfetch resolution does not apply", () => {
+    expect(
+      buildBrandAssetMetadata({ title: "No Brand Here" }).brandLogoUrl,
+    ).toBeUndefined();
+  });
+
   it("does not auto-resolve hosting domains without a known brand match", () => {
     expect(
       buildBrandAssetMetadata({


### PR DESCRIPTION
Closes #5250

## What

`buildBrandAssetMetadata` only ever called `brandAssetProxyUrl` with `kind: "icon"`. `brandLogoUrl` was a bare `clean(data.brandLogoUrl)` — no fallback — so every auto-resolved entry recorded `brandAssetSource: "brandfetch"`, implying brand-asset resolution happened, while the logo field stayed empty. `brandAssetProxyUrl` already supports `kind: "logo"` and `routes/api/brand-assets/$kind/$domain.ts` implements it end to end; only this one call site was missing.

## The change

`brandLogoUrl` now mirrors `brandIconUrl` exactly — manual value first, proxy fallback when `shouldUseBrandfetch`:

```js
const brandLogoUrl =
  clean(data.brandLogoUrl) ||
  (shouldUseBrandfetch
    ? brandAssetProxyUrl(brandDomain, {
        kind: "logo",
        siteUrl: options.assetBaseUrl || options.siteUrl,
      })
    : "");
```

The existing `isAllowedBrandAssetUrl` guard on `safeBrandLogoUrl` is unchanged, so the resolved value passes the same allowlist as before.

## Before / after

Fixture with only `brandDomain` set (`{ brandDomain: "vercel.com", brandName: "Vercel", title: "Vercel" }`):

| | before | after |
|---|---|---|
| `brandIconUrl` | `/api/brand-assets/icon/vercel.com` | `/api/brand-assets/icon/vercel.com` |
| `brandLogoUrl` | *(absent)* | `/api/brand-assets/logo/vercel.com` |
| `brandAssetSource` | `brandfetch` | `brandfetch` |

Other paths, confirmed unchanged before vs after:

| case | before | after |
|---|---|---|
| manual `brandLogoUrl` supplied | `https://cdn.brandfetch.io/...` | `https://cdn.brandfetch.io/...` (manual still wins) |
| no `brandDomain` / no brand match | `undefined` | `undefined` |
| `{ siteUrl }` option passed | *(absent)* | `https://heyclau.de/api/brand-assets/logo/vercel.com` (absolute, same as the icon) |

## Invariants / compatibility

- Additive only: `brandLogoUrl` goes from absent to populated on entries that already resolve an icon. No field changes type, and no existing value is overwritten.
- Regenerated the registry: **518 of 1384** entries now carry a `brandLogoUrl`. No tracked artifact churn — `apps/web/public/data/**` is gitignored and rebuilt by CI.
- No visual impact: nothing in the frontend renders `brandLogoUrl` today, which is exactly why the field could stay silently wrong. This makes the data correct ahead of any consumer.

## Evidence

Mutation-tested — two independent mutants, both killed by the new test:
- revert to `const brandLogoUrl = clean(data.brandLogoUrl);` -> **fails**
- change the fallback to `kind: "icon"` -> **fails**
- restored -> 32/32 pass

Three tests added: auto-resolution alongside the icon, manual precedence, and no resolution when brandfetch doesn't apply.

## Validation

- `pnpm exec vitest run tests/brand-assets-lib.test.ts tests/brand-assets.test.ts` — 35/35 pass (the issue's stated validation)
- `pnpm generate:registry` — exits 0
- `pnpm exec vitest run tests/registry-artifacts.test.ts` — 45/46; the one failure ("Retro Daily startup debug logs") is pre-existing on unmodified `main` and unrelated to this change
- `pnpm --filter web exec tsc --noEmit` — clean (exit 0)
- `prettier --check` on both touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
