### PR TITLE
fix(mcp): return the unavailable envelope when an artifact fails to load

### DIFF
--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -1004,6 +1004,27 @@ export async function callRegistryTool(name, args = {}, options = {}) {
   }
 
   let result;
+  try {
+    result = await dispatchReadOnlyTool(name, parsedArgs, options);
+  } catch (error) {
+    // Artifact reads (missing file, wrong --data-dir, corrupt JSON) throw from
+    // deep inside the handlers. Without this boundary they escape through the
+    // SDK request handler as a raw transport error, bypassing the tool's own
+    // outputSchema. Report them as the domain-level "unavailable" envelope the
+    // HTTP-backed and remote-proxy paths already return.
+    return withPublicPolicy(
+      unavailable(
+        "HeyClaude registry data is unavailable.",
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+  }
+
+  return withPublicPolicy(result);
+}
+
+async function dispatchReadOnlyTool(name, parsedArgs, options) {
+  let result;
   switch (name) {
     case "registry.search":
       result = await searchRegistry(parsedArgs, options);
@@ -1091,5 +1112,5 @@ export async function callRegistryTool(name, args = {}, options = {}) {
       break;
   }
 
-  return withPublicPolicy(result);
+  return result;
 }

--- a/tests/mcp-registry-tool-orchestration-lib-a.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-a.test.ts
@@ -2917,3 +2917,40 @@ describe("registry-tool-orchestration-lib validation (a)", () => {
     expect(result.ok).toBe(false);
   });
 });
+
+describe("read-only tool artifact failures", () => {
+  // A missing artifact (partial deploy, wrong --data-dir, corrupt JSON) used to
+  // throw out through the MCP SDK request handler as a raw transport error,
+  // bypassing each tool's declared outputSchema. It has to come back as the
+  // same "unavailable" envelope the HTTP-backed and remote-proxy paths return.
+  const missingDataDir = { dataDir: "/nonexistent-heyclaude-data-dir" };
+
+  const artifactBackedCalls: Array<[string, Record<string, unknown>]> = [
+    ["registry.search", { query: "database" }],
+    ["registry.list", { category: "mcp" }],
+    ["registry.updates", {}],
+    ["registry.stats", {}],
+    ["entry.related", { category: "mcp", slug: "duckdb-mcp-server" }],
+  ];
+
+  it.each(artifactBackedCalls)(
+    "returns a clean unavailable envelope for %s",
+    async (tool, args) => {
+      const result = await callRegistryTool(tool, args, missingDataDir);
+
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("unavailable");
+      expect(typeof result.error?.message).toBe("string");
+    },
+  );
+
+  it("does not leak the raw thrown error as a rejection", async () => {
+    await expect(
+      callRegistryTool(
+        "registry.search",
+        { query: "database" },
+        missingDataDir,
+      ),
+    ).resolves.toMatchObject({ ok: false });
+  });
+});


### PR DESCRIPTION
Closes #5231

## What

The local stdio server's read-only tools read artifacts through `readJsonArtifact`, which does an unguarded `JSON.parse(await readTextArtifact(...))`. A missing file, a wrong `--data-dir`, or corrupt JSON threw a raw `Error` all the way up through the MCP SDK's `CallToolRequestSchema` handler — which has no try/catch either — so a domain-level "data unavailable" case reached the client as an opaque transport failure and bypassed the tool's own `outputSchema` (`{ ok: boolean, ... }`).

## How — centralized, not per-call-site

The issue allows either. Centralizing avoids the failure mode of patching 16+ `readJsonArtifact` call sites and missing one, and it covers all ~27 read-only tools including any added later.

The dispatch `switch` moved verbatim into a new `dispatchReadOnlyTool(name, parsedArgs, options)`, and `callRegistryTool` wraps that one call:

```js
try {
  result = await dispatchReadOnlyTool(name, parsedArgs, options);
} catch (error) {
  return withPublicPolicy(
    unavailable(
      "HeyClaude registry data is unavailable.",
      error instanceof Error ? error.message : String(error),
    ),
  );
}
```

`unavailable` was already imported. Argument-validation (`invalid`/`invalidWithDetails`) still runs *before* the boundary, so a bad-arguments call is still reported as `invalid_request`, not masked as `unavailable`.

## Reproduction — before / after

`--data-dir` pointed at a missing directory:

| tool | before | after |
|---|---|---|
| `registry.search` | **throws** `Error: ENOENT: no such file or directory` | `ok=false`, `code=unavailable` |
| `registry.list` | **throws** `Error: ENOENT: ...` | `ok=false`, `code=unavailable` |
| `registry.updates` | **throws** `Error: ENOENT: ...` | `ok=false`, `code=unavailable` |
| `registry.stats` | **throws** `Error: ENOENT: ...` | `ok=false`, `code=unavailable` |
| `entry.related` | **throws** `Error: ENOENT: ...` | `ok=false`, `code=unavailable` |
| `entry.detail` | `ok=false`, `code=not_found` | `ok=false`, `code=not_found` *(already guarded — unchanged)* |

## Invariants / compatibility

- **outputSchema satisfied in both cases.** Success returns exactly what it did before — the switch body is unmoved and its `result` flows through the same `withPublicPolicy(result)`. The failure case now returns `{ ok: false, error: { code: "unavailable", message, details } }`, the same shape `listRegistryTrending`/`listJobsActive` and the remote-proxy path already emit, so it validates against the same `{ok: boolean, ...}` schema the throw used to bypass.
- **No behavior change when nothing throws** — the boundary is inert on the success path.
- **Error codes stay distinguishable:** `invalid_request` (bad args) and `not_found` (no such entry) are unaffected; only previously-uncaught throws become `unavailable`.
- Untouched, per the issue's out-of-scope list: `registry-response-lib.js`, `remote-proxy-lib.js`, and artifact generation.

## Evidence

Mutation-tested — removing the try/catch (calling `dispatchReadOnlyTool` directly) fails all six new assertions:
```
x returns a clean unavailable envelope for registry.search
x returns a clean unavailable envelope for registry.list
x returns a clean unavailable envelope for registry.updates
x returns a clean unavailable envelope for registry.stats
x returns a clean unavailable envelope for entry.related
x does not leak the raw thrown error as a rejection
Tests  6 failed | 726 passed
```

## Validation

- `pnpm exec vitest run tests/mcp-server-lib-handlers.test.ts` — 5/5 pass (the issue's stated validation)
- `pnpm run test:mcp` — exit 0, 72/72 pass (also stated)
- `pnpm exec vitest run` across all six `mcp-registry-tool-orchestration-lib-*` suites — 2898/2898 pass, confirming success-path behavior is unchanged
- `prettier --check` on both touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
