### PR TITLE
fix(web): use durable rate limit for newsletter unsubscribe

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -4520,6 +4520,266 @@
         }
       }
     },
+    "/api/public/newsletter/unsubscribe": {
+      "post": {
+        "tags": ["Newsletter"],
+        "summary": "Unsubscribe an email from newsletter segments",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": { "type": "string", "maxLength": 320 },
+                  "segments": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 64,
+                      "pattern": "^[a-z0-9:_-]+$/i"
+                    },
+                    "maxItems": 20,
+                    "default": []
+                  }
+                },
+                "required": ["email"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Request accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "ok": { "type": "boolean", "enum": [true] } },
+                  "required": ["ok"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON, invalid query, invalid payload, or invalid status transition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin token or invalid webhook signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden origin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload too large.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Invalid content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Route-level or Cloudflare-native rate limited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream provider error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Site DB not configured, provider not configured, or endpoint unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/newsletter/webhook": {
       "post": {
         "tags": ["Newsletter"],

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -5242,6 +5242,288 @@ paths:
                 required:
                   - ok
                   - error
+  /api/public/newsletter/unsubscribe:
+    post:
+      tags:
+        - Newsletter
+      summary: Unsubscribe an email from newsletter segments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  maxLength: 320
+                segments:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 64
+                    pattern: ^[a-z0-9:_-]+$/i
+                  maxItems: 20
+                  default: []
+              required:
+                - email
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - true
+                required:
+                  - ok
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/newsletter/webhook:
     post:
       tags:

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -191,6 +191,7 @@ const BODY_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
   "votes.query": { keys: ["mcp:github-mcp-server"], clientId: "anon-client-1234" },
   "votes.toggle": { key: "mcp:github-mcp-server", clientId: "anon-client-1234", vote: true },
   "newsletter.subscribe": { email: "reader@example.com", source: "api-docs" },
+  "newsletter.unsubscribe": { email: "reader@example.com" },
   "newsletter.webhook": { type: "contact.created", data: { email: "reader@example.com" } },
   "submissions.preflight": {
     fields: {
@@ -345,6 +346,7 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
   },
   "votes.toggle": { ok: true, key: "mcp:github-mcp-server", voted: true, count: 12 },
   "newsletter.subscribe": { ok: true, subscribed: true },
+  "newsletter.unsubscribe": { ok: true, unsubscribed: true },
   "newsletter.webhook": { ok: true, accepted: true },
   "submissions.preflight": {
     ok: true,

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -527,6 +527,15 @@ export const newsletterConfirmBodySchema = z.object({
   token: z.string().trim().min(1).max(4096),
 });
 
+export const newsletterUnsubscribeBodySchema = z.object({
+  email: safeEmailSchema,
+  segments: z.array(newsletterSegmentIdSchema).max(20).optional().default([]),
+});
+
+export const newsletterUnsubscribeResponseSchema = z.object({
+  ok: z.literal(true),
+});
+
 export const newsletterWebhookBodySchema = z
   .object({
     type: z.string().optional(),
@@ -1132,6 +1141,23 @@ export const apiRouteDefinitions = {
     bodyLimitBytes: 8 * 1024,
     rateLimit: {
       scope: "newsletter-confirm",
+      limit: 15,
+      windowMs: 60_000,
+      binding: "API_STRICT_RATE_LIMIT",
+    },
+  }),
+  "newsletter.unsubscribe": route({
+    id: "newsletter.unsubscribe",
+    method: "POST",
+    path: "/api/public/newsletter/unsubscribe",
+    summary: "Unsubscribe an email from newsletter segments",
+    tags: ["Newsletter"],
+    originCheck: true,
+    bodySchema: newsletterUnsubscribeBodySchema,
+    responseSchema: newsletterUnsubscribeResponseSchema,
+    bodyLimitBytes: 8 * 1024,
+    rateLimit: {
+      scope: "newsletter-unsubscribe",
       limit: 15,
       windowMs: 60_000,
       binding: "API_STRICT_RATE_LIMIT",

--- a/apps/web/src/routes/api/public/newsletter/unsubscribe.ts
+++ b/apps/web/src/routes/api/public/newsletter/unsubscribe.ts
@@ -4,149 +4,76 @@
  * Best-effort: removes the contact from the resolved Resend segments, or from
  * the general newsletter segment when no segments resolve. The endpoint keeps
  * compatibility with the Atlas client path while applying the same origin,
- * content-type, body-size, and rate-limit controls as dynamic API routes.
+ * content-type, body-size, and durable Cloudflare rate-limit controls as its
+ * newsletter siblings (subscribe/confirm).
  */
 import { createApiFileRoute } from "@/lib/api/file-route";
-import { z, ZodError } from "zod";
 
-import { apiError, apiJson } from "@/lib/api/router";
-import {
-  BodyTooLargeError,
-  hasJsonContentType,
-  isAllowedOrigin,
-  isRateLimited,
-  readRequestTextWithinLimit,
-} from "@/lib/api-security";
-import { logApiError, logApiWarn, redactEmail } from "@/lib/api-logs";
+import { newsletterUnsubscribeBodySchema } from "@/lib/api/contracts";
+import { apiError, apiJson, createApiHandler, type InferApiBody } from "@/lib/api/router";
+import { logApiError, redactEmail } from "@/lib/api-logs";
 import { getEnvString } from "@/lib/cloudflare-env.server";
-
-const BODY_LIMIT_BYTES = 8 * 1024;
-const RATE_LIMIT = {
-  scope: "newsletter-unsubscribe",
-  limit: 15,
-  windowMs: 60_000,
-} as const;
-
-const Schema = z.object({
-  email: z.string().trim().toLowerCase().email().max(320),
-  segments: z
-    .array(
-      z
-        .string()
-        .trim()
-        .min(1)
-        .max(64)
-        .regex(/^[a-z0-9:_-]+$/i),
-    )
-    .max(20)
-    .optional()
-    .default([]),
-});
-
-type UnsubscribePayload = z.infer<typeof Schema>;
-
-function getRequestId(request: Request) {
-  return (
-    request.headers.get("cf-ray") || request.headers.get("x-request-id") || crypto.randomUUID()
-  );
-}
 
 function envSegmentId(followId: string): string | undefined {
   const key = `RESEND_SEGMENT_${followId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
   return getEnvString(key) || undefined;
 }
 
-async function parsePayload(request: Request): Promise<UnsubscribePayload> {
-  const rawBody = await readRequestTextWithinLimit(request, BODY_LIMIT_BYTES);
-  return Schema.parse(JSON.parse(rawBody)) as UnsubscribePayload;
-}
+export const POST = createApiHandler(
+  "newsletter.unsubscribe",
+  async ({ request, body, requestId }) => {
+    const payload = body as InferApiBody<typeof newsletterUnsubscribeBodySchema>;
 
-export async function POST(request: Request): Promise<Response> {
-  const requestId = getRequestId(request);
-
-  if (!isAllowedOrigin(request)) {
-    logApiWarn(request, "newsletter.unsubscribe.forbidden_origin");
-    return apiError("forbidden_origin", 403, { requestId });
-  }
-
-  if (!hasJsonContentType(request)) {
-    logApiWarn(request, "newsletter.unsubscribe.invalid_content_type");
-    return apiError("invalid_content_type", 415, { requestId });
-  }
-
-  if (isRateLimited({ request, ...RATE_LIMIT })) {
-    logApiWarn(request, "newsletter.unsubscribe.rate_limited");
-    return apiError("rate_limited", 429, { requestId });
-  }
-
-  let payload: UnsubscribePayload;
-  try {
-    payload = await parsePayload(request);
-  } catch (error) {
-    if (error instanceof BodyTooLargeError) {
-      logApiWarn(request, "newsletter.unsubscribe.payload_too_large");
-      return apiError("payload_too_large", 413, { requestId });
+    const apiKey = getEnvString("RESEND_API_KEY");
+    const generalSegment = getEnvString("RESEND_SEGMENT_ID");
+    if (!apiKey || !generalSegment) {
+      logApiError(request, "newsletter.unsubscribe.not_configured");
+      return apiError("newsletter_not_configured", 503, { requestId });
     }
-    if (error instanceof SyntaxError) {
-      logApiWarn(request, "newsletter.unsubscribe.invalid_json");
-      return apiError("invalid_json", 400, { requestId });
+
+    const resolved = new Set<string>();
+    for (const segment of payload.segments) {
+      const id = envSegmentId(segment);
+      if (id) resolved.add(id);
     }
-    if (error instanceof ZodError) {
-      logApiWarn(request, "newsletter.unsubscribe.invalid_payload");
-      return apiError("invalid_payload", 400, { requestId });
-    }
-    throw error;
-  }
+    if (resolved.size === 0) resolved.add(generalSegment);
 
-  const apiKey = getEnvString("RESEND_API_KEY");
-  const generalSegment = getEnvString("RESEND_SEGMENT_ID");
-  if (!apiKey || !generalSegment) {
-    logApiError(request, "newsletter.unsubscribe.not_configured");
-    return apiError("newsletter_not_configured", 503, { requestId });
-  }
-
-  const resolved = new Set<string>();
-  for (const segment of payload.segments) {
-    const id = envSegmentId(segment);
-    if (id) resolved.add(id);
-  }
-  if (resolved.size === 0) resolved.add(generalSegment);
-
-  let lastError: string | null = null;
-  for (const id of resolved) {
-    try {
-      const res = await fetch(
-        `https://api.resend.com/audiences/${id}/contacts/${encodeURIComponent(payload.email)}`,
-        {
-          method: "DELETE",
-          headers: { Authorization: `Bearer ${apiKey}` },
-          signal: AbortSignal.timeout(8000),
-        },
-      );
-      // 404 = not subscribed; treat as success (don't leak membership).
-      if (!res.ok && res.status !== 404) {
-        lastError = `HTTP ${res.status}`;
+    let lastError: string | null = null;
+    for (const id of resolved) {
+      try {
+        const res = await fetch(
+          `https://api.resend.com/audiences/${id}/contacts/${encodeURIComponent(payload.email)}`,
+          {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${apiKey}` },
+            signal: AbortSignal.timeout(8000),
+          },
+        );
+        // 404 = not subscribed; treat as success (don't leak membership).
+        if (!res.ok && res.status !== 404) {
+          lastError = `HTTP ${res.status}`;
+        }
+      } catch {
+        lastError = "network";
       }
-    } catch {
-      lastError = "network";
     }
-  }
 
-  if (lastError) {
-    logApiError(request, "newsletter.unsubscribe.provider_error", {
-      email: redactEmail(payload.email),
-      error: lastError,
-    });
-    return apiError("provider_error", 502, { requestId });
-  }
+    if (lastError) {
+      logApiError(request, "newsletter.unsubscribe.provider_error", {
+        email: redactEmail(payload.email),
+        error: lastError,
+      });
+      return apiError("provider_error", 502, { requestId });
+    }
 
-  return apiJson({ ok: true });
-}
+    return apiJson({ ok: true });
+  },
+);
 
 export const Route = createApiFileRoute("/api/public/newsletter/unsubscribe")({
   server: {
     handlers: {
-      POST: async ({ request }) => POST(request),
+      POST: async ({ request, params }) => POST(request, { params }),
     },
   },
 });

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -5246,6 +5246,288 @@ paths:
                 required:
                   - ok
                   - error
+  /api/public/newsletter/unsubscribe:
+    post:
+      tags:
+        - Newsletter
+      summary: Unsubscribe an email from newsletter segments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  maxLength: 320
+                segments:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 64
+                    pattern: ^[a-z0-9:_-]+$/i
+                  maxItems: 20
+                  default: []
+              required:
+                - email
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - true
+                required:
+                  - ok
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/newsletter/webhook:
     post:
       tags:

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -33,6 +33,7 @@ const apiRoutes = [
   "/api/newsletter/subscribe",
   "/api/newsletter/webhook",
   "/api/public/newsletter/confirm",
+  "/api/public/newsletter/unsubscribe",
   "/api/og",
   "/api/submissions/preflight",
   "/api/download",

--- a/tests/codeql-regressions.test.ts
+++ b/tests/codeql-regressions.test.ts
@@ -84,9 +84,19 @@ describe("CodeQL regression coverage", () => {
 
     expect(unsubscribeRoute).not.toContain("Access-Control-Allow-Origin");
     expect(unsubscribeRoute).not.toContain("request.json()");
-    expect(unsubscribeRoute).toContain("readRequestTextWithinLimit");
-    expect(unsubscribeRoute).toContain("isAllowedOrigin");
-    expect(unsubscribeRoute).toContain("isRateLimited");
+    expect(unsubscribeRoute).toContain("createApiHandler");
+    expect(unsubscribeRoute).toContain('"newsletter.unsubscribe"');
+    expect(unsubscribeRoute).toContain("POST(request, { params })");
+
+    const contracts = read("apps/web/src/lib/api/contracts-lib.ts");
+    expect(contracts).toContain('"newsletter.unsubscribe"');
+    expect(contracts).toMatch(
+      /"newsletter\.unsubscribe"[\s\S]*?binding:\s*"API_STRICT_RATE_LIMIT"/,
+    );
+
+    const apiRouter = read("apps/web/src/lib/api/router.ts");
+    expect(apiRouter).toContain("isAllowedOrigin");
+    expect(apiRouter).toContain("enforceRateLimit");
 
     expect(confirmRoute).not.toContain("request.json()");
     expect(confirmRoute).not.toContain("request.formData()");


### PR DESCRIPTION
## Summary
- Register `newsletter.unsubscribe` in `apiRouteDefinitions` with `API_STRICT_RATE_LIMIT` (15 req / 60s — same as before and as subscribe/confirm).
- Refactor `unsubscribe.ts` onto `createApiHandler` so production uses the durable Cloudflare RateLimit binding (in-memory remains the fallback).
- Regenerate OpenAPI assets; document the route in Atlas docs examples.

Closes #5242

## Invariants
- Rate limit **preserved** at 15 / 60s (not tightened/loosened).
- Unsubscribe behavior / response shape unchanged (`{ ok: true }`; 404 from Resend still success).
- Origin + JSON content-type checks still enforced via the central router.

## Test plan
- [x] `pnpm exec vitest run tests/newsletter-unsubscribe-route.test.ts tests/api-contracts.test.ts`
- [ ] CI green