### PR TITLE
fix(web): count browse summaries over the population they report

### DIFF
--- a/apps/web/src/lib/browse-adoption-queue-lib.ts
+++ b/apps/web/src/lib/browse-adoption-queue-lib.ts
@@ -206,7 +206,12 @@ export function browseAdoptionQueueState(
   preset: BrowseAdoptionPresetId,
   maxRows = 8,
 ): BrowseAdoptionQueueState {
-  const rows = entries
+  // Scored across the whole result set. `rows` slices this for display, but the
+  // summary counts stay on the full population so its numerator and
+  // `scannedCount` denominator describe the same set - counting only the
+  // top-scored slice reported "0 in hold tier" while hold-tier entries sat just
+  // outside it.
+  const scored = entries
     .map((entry) => {
       const signals = signalMap(entry);
       const blockers = blockersFromSignals(signals, preset);
@@ -223,13 +228,13 @@ export function browseAdoptionQueueState(
         confidence: confidenceScore(signals),
       } satisfies BrowseAdoptionQueueRow;
     })
-    .sort((a, b) => b.readinessScore - a.readinessScore || a.title.localeCompare(b.title))
-    .slice(0, maxRows);
+    .sort((a, b) => b.readinessScore - a.readinessScore || a.title.localeCompare(b.title));
+  const rows = scored.slice(0, maxRows);
 
   return {
     preset,
     heading: headingForPreset(preset),
-    summary: summary(rows, entries.length),
+    summary: summary(scored, scored.length),
     scannedCount: entries.length,
     rows,
     readyCount: rows.filter((row) => row.tier === "ready").length,

--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -179,7 +179,12 @@ export function browseDecisionConfidenceState(
   preset: BrowseConfidencePresetId,
   maxEntries = 8,
 ): BrowseDecisionConfidenceState {
-  const mapped = entries
+  // Scored across the whole result set. `mapped` slices this for display, but
+  // the summary counts stay on the full population so its numerator and
+  // `scannedCount` denominator describe the same set - counting only the
+  // top-scored slice reported "0 low-confidence" while low-confidence entries
+  // sat just outside it.
+  const scored = entries
     .map((entry) => {
       const signalState = signals(entry);
       const missingSignals = (Object.keys(signalState) as BrowseConfidenceSignalId[])
@@ -197,13 +202,13 @@ export function browseDecisionConfidenceState(
         recommendation: recommendationFor(confidenceScore, missingSignals, entry),
       } satisfies BrowseConfidenceEntry;
     })
-    .sort((a, b) => b.confidenceScore - a.confidenceScore || a.title.localeCompare(b.title))
-    .slice(0, maxEntries);
+    .sort((a, b) => b.confidenceScore - a.confidenceScore || a.title.localeCompare(b.title));
+  const mapped = scored.slice(0, maxEntries);
 
   return {
     preset,
     heading: headingForPreset(preset),
-    summary: summary(mapped, entries.length),
+    summary: summary(scored, scored.length),
     scannedCount: entries.length,
     highCount: mapped.filter((row) => row.band === "high").length,
     mediumCount: mapped.filter((row) => row.band === "medium").length,

--- a/tests/browse-adoption-queue-lib.test.ts
+++ b/tests/browse-adoption-queue-lib.test.ts
@@ -187,3 +187,35 @@ describe("browse adoption queue lib", () => {
     expect(browseAdoptionTierClass("hold")).toContain("trust-blocked");
   });
 });
+
+describe("summary population", () => {
+  // rows keeps only the top-scored maxRows entries; counting the numerator
+  // there while labelling it with the full result count hid hold-tier entries
+  // that sat just outside the slice.
+  function population(strongCount: number, weakCount: number): Entry[] {
+    return [
+      ...Array.from({ length: strongCount }, (_, index) =>
+        entry({ ...strong, slug: `strong-${index}`, title: `Strong ${index}` }),
+      ),
+      ...Array.from({ length: weakCount }, (_, index) =>
+        entry({ ...weak, slug: `weak-${index}`, title: `Weak ${index}` }),
+      ),
+    ];
+  }
+
+  it("counts hold-tier rows that fall outside the display slice", () => {
+    const state = browseAdoptionQueueState(population(8, 12), "balanced");
+
+    expect(state.rows).toHaveLength(8);
+    expect(state.summary).toContain("12/20");
+    expect(state.summary).toContain("hold tier");
+  });
+
+  it("draws the numerator and denominator from the same population", () => {
+    const state = browseAdoptionQueueState(population(3, 5), "balanced");
+    const [, numerator, denominator] = /(\d+)\/(\d+)/.exec(state.summary) ?? [];
+
+    expect(Number(denominator)).toBe(state.scannedCount);
+    expect(Number(numerator)).toBeLessThanOrEqual(Number(denominator));
+  });
+});

--- a/tests/browse-decision-confidence-lib.test.ts
+++ b/tests/browse-decision-confidence-lib.test.ts
@@ -211,3 +211,43 @@ describe("browse decision confidence lib", () => {
     expect(browseConfidenceBandClass("low")).toContain("trust-blocked");
   });
 });
+
+describe("summary population", () => {
+  // The display slice keeps only the top-scored maxEntries rows. Counting the
+  // numerator there while labelling it with the full result count reported
+  // "0 low-confidence" for a set that was mostly low-confidence.
+  function population(strongCount: number, weakCount: number): Entry[] {
+    return [
+      ...Array.from({ length: strongCount }, (_, index) =>
+        entry({
+          ...strong,
+          slug: `strong-${index}`,
+          title: `Strong ${index}`,
+        }),
+      ),
+      ...Array.from({ length: weakCount }, (_, index) =>
+        entry({
+          ...weak,
+          slug: `weak-${index}`,
+          title: `Weak ${index}`,
+        }),
+      ),
+    ];
+  }
+
+  it("counts low-confidence entries that fall outside the display slice", () => {
+    const state = browseDecisionConfidenceState(population(8, 12), "balanced");
+
+    expect(state.entries).toHaveLength(8);
+    expect(state.summary).toContain("12/20");
+    expect(state.summary).toContain("low-confidence");
+  });
+
+  it("draws the numerator and denominator from the same population", () => {
+    const state = browseDecisionConfidenceState(population(3, 5), "balanced");
+    const [, numerator, denominator] = /(\d+)\/(\d+)/.exec(state.summary) ?? [];
+
+    expect(Number(denominator)).toBe(state.scannedCount);
+    expect(Number(numerator)).toBeLessThanOrEqual(Number(denominator));
+  });
+});


### PR DESCRIPTION
Closes #5214

## The bug

Both state builders sort by score, `slice()` to the display rows, then count the reported band **from that slice** while labelling the count with the **full** result total. Because the slice keeps the *highest*-scoring rows, the counted band is usually empty — so the panel reports the opposite of the problem it exists to surface.

Fixture: 20 results, 8 strong and 12 genuinely low-confidence (`maxEntries` = 8).

| | before | after |
|---|---|---|
| decision-confidence | `8/20 results are high-confidence for the selected preset.` | `12/20 results are low-confidence and need review before adoption.` |
| adoption-queue | `8/20 visible results are ready for staged adoption under this preset.` | `12/20 visible results are in hold tier and need mitigation before adoption.` |

Before, the 12 low-confidence entries were invisible in the summary: `low` counted 0 inside the top-8 slice, so the text fell through to the "high-confidence" branch — exactly the "reports 0 low-confidence when many exist" case in the issue.

## The fix

Scoring is unchanged; only *what the summary counts over* changed. The mapped/sorted rows are kept as `scored`, the display slice becomes `scored.slice(0, maxEntries)`, and the summary is computed as `summary(scored, scored.length)`.

I took the "count over the full population" option rather than shrinking the denominator to the slice, because the acceptance criteria asks for **the true count** ("previously reported '0 low-confidence' now reports the true count"). Scoping the denominator to 8 instead would have kept the summary saying `0/8 low-confidence` while 12 low-confidence entries sat outside the slice — same misleading guidance, just with a smaller denominator.

## Invariants

- **Numerator and denominator now share a population**, and that population is `scannedCount` (`entries.length`), which the panels already display — asserted directly by a test.
- **`entries` / `rows` are unchanged** — still the same top-`maxEntries` display slice, same order, same contents.
- **`highCount` / `mediumCount` / `lowCount` / `lowRefs` and `readyCount` / `cautionCount` / `holdCount` are deliberately left scoped to the display slice.** They describe the rows actually rendered, and changing them would alter component behavior — out of scope per the issue.
- No change to `browse-freshness-distribution-lib.ts` or `browse-rollout-signals-lib.ts`.
- No visual impact beyond the corrected summary sentence itself; this is a data-layer fix.

## Evidence

Mutation-tested — restoring the original `summary(mapped, entries.length)` / `summary(rows, entries.length)` fails both new counting tests and nothing else:
```
x counts low-confidence entries that fall outside the display slice
x counts hold-tier rows that fall outside the display slice
Tests  2 failed | 33 passed
```

Four tests added (two per module): the outside-the-slice count, and a parse of the rendered `N/M` asserting `M === scannedCount`.

## Validation

- `pnpm exec vitest run tests/browse-decision-confidence-lib.test.ts tests/browse-adoption-queue-lib.test.ts` — 35/35 pass (the issue's stated validation)
- `pnpm --filter web type-check` — clean (exit 0), also stated
- Full browse suite — 1408 pass, 0 fail
- Grepped for the old summary strings elsewhere in `apps/`/`tests/` — no other consumer asserts them
- `prettier --check` on all four touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
