### PR TITLE
fix(mcp): give entry.related a consistent shape on both paths

### DIFF
--- a/packages/mcp/src/registry-handlers-lib.js
+++ b/packages/mcp/src/registry-handlers-lib.js
@@ -166,12 +166,42 @@ export function buildRelatedEntriesGraphResponse({ target, entries, limit }) {
   };
 }
 
+/**
+ * Relation type for a scored (non-graph) related entry.
+ *
+ * A narrow port of the applicable `relationTypeFor` branches, classified from
+ * the `relatedReasons` the scorer already emits: `same_category` plus a shared
+ * tag/keyword is the "alternative" case, a shared source host is the
+ * "same-ecosystem" case. The collection-member/same-project/category-pair
+ * branches depend on evidence the scored path does not compute, so those fall
+ * through to the generic "related" rather than being guessed at.
+ */
+function scoredRelationType(reasons) {
+  const list = Array.isArray(reasons) ? reasons : [];
+  const sameCategory = list.includes("same_category");
+  const sharedTokens = list.some(
+    (reason) => reason.startsWith("tag:") || reason.startsWith("keyword:"),
+  );
+  const sharedDomains = list.some((reason) => reason.startsWith("source:"));
+
+  if (sameCategory && (sharedTokens || sharedDomains)) return "alternative";
+  if (sharedDomains) return "same-ecosystem";
+  return "related";
+}
+
 export function buildRelatedEntriesScoredResponse({ target, entries, limit }) {
   return {
     ok: true,
     key: `${target.category}:${target.slug}`,
+    // Mirrors the graph path's `relationGraph: true` so the key is always
+    // present and always a boolean, and every entry carries a `relation`,
+    // whether or not a relation-graph row existed for the target.
+    relationGraph: false,
     count: entries.length,
-    entries: entries.slice(0, limit),
+    entries: entries.slice(0, limit).map((entry) => ({
+      ...entry,
+      relation: entry.relation || scoredRelationType(entry.relatedReasons),
+    })),
   };
 }
 

--- a/tests/mcp-registry-handlers-lib.test.ts
+++ b/tests/mcp-registry-handlers-lib.test.ts
@@ -9378,10 +9378,11 @@ describe("registry-handlers-lib related, adapter, and compatibility responses", 
     expect(response).toEqual({
       ok: true,
       key: "mcp:browser-bridge",
+      relationGraph: false,
       count: 3,
       entries: [
-        { category: "mcp", slug: "a" },
-        { category: "mcp", slug: "b" },
+        { category: "mcp", slug: "a", relation: "related" },
+        { category: "mcp", slug: "b", relation: "related" },
       ],
     });
   });
@@ -9496,5 +9497,125 @@ describe("registry-handlers-lib related, adapter, and compatibility responses", 
       { platform: "claude-code", feedSlug: "feed-claude-code" },
       { platform: "cursor", feedSlug: "feed-cursor" },
     ]);
+  });
+});
+
+describe("entry.related response shape consistency", () => {
+  const target = { category: "mcp", slug: "duckdb" };
+
+  it("marks the scored fallback with relationGraph: false", () => {
+    const response = buildRelatedEntriesScoredResponse({
+      target,
+      limit: 3,
+      entries: [
+        { category: "mcp", slug: "a", relatedScore: 9, relatedReasons: [] },
+      ],
+    });
+
+    expect(response.relationGraph).toBe(false);
+  });
+
+  it("exposes the same keys on both paths", () => {
+    const scored = buildRelatedEntriesScoredResponse({
+      target,
+      limit: 3,
+      entries: [
+        { category: "mcp", slug: "a", relatedScore: 9, relatedReasons: [] },
+      ],
+    });
+    const graph = buildRelatedEntriesGraphResponse({
+      target,
+      limit: 3,
+      entries: [
+        {
+          category: "mcp",
+          slug: "a",
+          relation: "same-project",
+          relatedScore: 9,
+          relatedReasons: [],
+        },
+      ],
+    });
+
+    expect(Object.keys(scored).sort()).toEqual(Object.keys(graph).sort());
+    expect(typeof scored.relationGraph).toBe("boolean");
+    expect(typeof graph.relationGraph).toBe("boolean");
+  });
+
+  it("classifies a relation for every scored entry", () => {
+    const response = buildRelatedEntriesScoredResponse({
+      target,
+      limit: 5,
+      entries: [
+        {
+          category: "mcp",
+          slug: "same-cat-shared-tag",
+          relatedScore: 9,
+          relatedReasons: ["same_category", "tag:sql"],
+        },
+        {
+          category: "mcp",
+          slug: "shared-host",
+          relatedScore: 7,
+          relatedReasons: ["source:github.com"],
+        },
+        {
+          category: "guides",
+          slug: "weak",
+          relatedScore: 5,
+          relatedReasons: [],
+        },
+      ],
+    });
+
+    expect(response.entries.map((entry) => entry.relation)).toEqual([
+      "alternative",
+      "same-ecosystem",
+      "related",
+    ]);
+    for (const entry of response.entries) {
+      expect(typeof entry.relation).toBe("string");
+    }
+  });
+
+  it("does not overwrite a relation the caller already supplied", () => {
+    const response = buildRelatedEntriesScoredResponse({
+      target,
+      limit: 3,
+      entries: [
+        {
+          category: "mcp",
+          slug: "a",
+          relation: "collection-member",
+          relatedScore: 9,
+          relatedReasons: ["same_category", "tag:sql"],
+        },
+      ],
+    });
+
+    expect(response.entries[0].relation).toBe("collection-member");
+  });
+
+  it("leaves the graph path untouched", () => {
+    const response = buildRelatedEntriesGraphResponse({
+      target,
+      limit: 2,
+      entries: [
+        {
+          category: "mcp",
+          slug: "a",
+          relation: "same-project",
+          relatedScore: 9,
+          relatedReasons: ["tag:sql"],
+        },
+      ],
+    });
+
+    expect(response.relationGraph).toBe(true);
+    expect(response.entries[0]).toMatchObject({
+      relation: "same-project",
+      relatedScore: 9,
+      relatedReasons: ["tag:sql"],
+    });
   });
 });


### PR DESCRIPTION
Closes #5223

## What

`entry.related` answered with two different shapes for the same tool:

| | graph path | scored fallback (before) |
|---|---|---|
| `relationGraph` | `true` | **key absent** |
| per-entry `relation` | present | **absent** |

A client keying off `relation` for classification, or off `relationGraph` being present, silently broke for whichever path it happened not to hit — and the tool's loose output schema didn't catch it.

## The fix — option (b), plus (a)

The issue prefers (b) if it can be done narrowly. It can: the scored entries already carry `relatedReasons`, which encodes the same evidence `relationTypeFor` classifies on, so the relation is derived without recomputing anything or touching `relationships-lib.js`:

```js
if (sameCategory && (sharedTokens || sharedDomains)) return "alternative";
if (sharedDomains) return "same-ecosystem";
return "related";
```

The `collection-member` / `same-project` / category-pair branches depend on evidence the scored path never computes, so those deliberately fall through to the generic `"related"` rather than being guessed at. `relationGraph: false` is set too, so the key is always present and always a boolean.

## Before / after

Scored fallback with three representative entries:

| | before | after |
|---|---|---|
| response keys | `ok,key,count,entries` | `ok,key,relationGraph,count,entries` |
| `relationGraph` | `undefined` | `false` |
| `same_category` + `tag:sql` | `relation: undefined` | `relation: "alternative"` |
| `source:github.com` | `relation: undefined` | `relation: "same-ecosystem"` |
| no shared evidence | `relation: undefined` | `relation: "related"` |

Graph path, unchanged: `relationGraph: true`, `relation: "same-project"`, `relatedScore`, `relatedReasons` all identical before and after.

## Invariants / backward compatibility

- **Rechecked at PR time as the issue asks:** grepped `packages/` and `apps/` for `relationGraph` — no consumer reads it off the tool response or branches on its presence/absence. The only other hits are the artifact builder's own `relation-graph.json` URL and local variable names, unrelated to this response.
- **Purely additive.** No existing key changes type or value; the fallback gains two fields, and a caller-supplied `relation` is preserved rather than overwritten (covered by a test).
- **Graph path untouched** — asserted by a dedicated test.
- Not modified, per the issue's out-of-scope list: `relation-graph.json` generation, `relationTypeFor` itself, and every other MCP tool.
- Note: with the current artifact every entry has a graph row, so the fallback is reachable only after an artifact rebuild — which is exactly the "same entry before/after the next rebuild" drift the issue describes. Evidence is therefore at the handler level.

## Evidence

One existing test (`buildRelatedEntriesScoredResponse keys the target and caps entries at the limit`) asserted the old shape with `toEqual` and is updated — it had encoded the inconsistency.

Mutation-tested, two independent mutants:
- drop `relationGraph: false` -> **3 tests fail**
- disable the `alternative` classification -> **1 test fails**
- restored -> 1038/1038 pass

Five tests added: `relationGraph: false`, same-keys-on-both-paths, relation classified for every entry, caller-supplied relation preserved, graph path untouched.

## Validation

- `pnpm exec vitest run tests/mcp-registry-projection-lib.test.ts` — pass (the issue's stated validation)
- `pnpm run test:mcp` — exit 0, 72/72 pass (also stated)
- `pnpm exec vitest run tests/mcp-registry-handlers-lib.test.ts` — 1038/1038 pass
- `prettier --check` on both touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
