### PR TITLE
fix(registry): auto-resolve brandLogoUrl via Brandfetch like brandIconUrl

### DIFF
--- a/packages/registry/src/brand-assets-lib.js
+++ b/packages/registry/src/brand-assets-lib.js
@@ -417,7 +417,14 @@ export function buildBrandAssetMetadata(data = {}, options = {}) {
           siteUrl: options.assetBaseUrl || options.siteUrl,
         })
       : "");
-  const brandLogoUrl = clean(data.brandLogoUrl);
+  const brandLogoUrl =
+    clean(data.brandLogoUrl) ||
+    (shouldUseBrandfetch
+      ? brandAssetProxyUrl(brandDomain, {
+          kind: "logo",
+          siteUrl: options.assetBaseUrl || options.siteUrl,
+        })
+      : "");
   const safeBrandIconUrl =
     brandIconUrl && isAllowedBrandAssetUrl(brandIconUrl) ? brandIconUrl : "";
   const safeBrandLogoUrl =

--- a/tests/brand-assets-lib.test.ts
+++ b/tests/brand-assets-lib.test.ts
@@ -342,6 +342,33 @@ describe("buildBrandAssetMetadata", () => {
     });
   });
 
+  it("auto-resolves brandfetch logos alongside icons for known brands", () => {
+    // Before the fix brandLogoUrl was left empty even when the icon resolved.
+    const metadata = buildBrandAssetMetadata(
+      { title: "Zapier Workflow", tags: ["zapier"] },
+      { allowAliasFallback: true, assetBaseUrl: "https://heyclau.de" },
+    );
+    expect(metadata).toMatchObject({
+      brandIconUrl: "https://heyclau.de/api/brand-assets/icon/zapier.com",
+      brandLogoUrl: "https://heyclau.de/api/brand-assets/logo/zapier.com",
+      brandAssetSource: "brandfetch",
+    });
+  });
+
+  it("keeps a manually supplied brandLogoUrl over the brandfetch fallback", () => {
+    const metadata = buildBrandAssetMetadata(
+      {
+        title: "Zapier Workflow",
+        tags: ["zapier"],
+        brandLogoUrl: "https://heyclau.de/custom-logo.png",
+      },
+      { allowAliasFallback: true },
+    );
+    // Manual value wins; the icon still auto-resolves independently.
+    expect(metadata.brandLogoUrl).toBe("https://heyclau.de/custom-logo.png");
+    expect(metadata.brandIconUrl).toBe("/api/brand-assets/icon/zapier.com");
+  });
+
   it("does not auto-resolve hosting domains without a known brand match", () => {
     expect(
       buildBrandAssetMetadata({


### PR DESCRIPTION
Closes #5250

## Problem

In `buildBrandAssetMetadata`, `brandIconUrl` falls back to the Brandfetch proxy (`brandAssetProxyUrl(brandDomain, { kind: "icon" })`) when `shouldUseBrandfetch` is true, but `brandLogoUrl` had no fallback at all:

```js
const brandLogoUrl = clean(data.brandLogoUrl);   // never auto-resolves
```

So every entry that auto-resolved an icon still left `brandLogoUrl` empty, even though `brandAssetProxyUrl` supports `kind: "logo"` and the runtime route (`/api/brand-assets/logo/$domain`) fully implements it — and `brandAssetSource: "brandfetch"` was recorded as if both fields resolved uniformly.

## Fix

Give `brandLogoUrl` the exact same fallback as `brandIconUrl`, with `kind: "logo"`:

```js
const brandLogoUrl =
  clean(data.brandLogoUrl) ||
  (shouldUseBrandfetch
    ? brandAssetProxyUrl(brandDomain, {
        kind: "logo",
        siteUrl: options.assetBaseUrl || options.siteUrl,
      })
    : "");
```

A manually-supplied `brandLogoUrl` still takes precedence (the `clean(...) ||` short-circuit), matching `brandIconUrl`'s existing precedence, and the unsafe-URL sanitization (`isAllowedBrandAssetUrl`) is unchanged.

## Before / after

For `{ title: "Zapier Workflow", tags: ["zapier"] }` with `{ allowAliasFallback: true, assetBaseUrl: "https://heyclau.de" }`:

| Field | Before | After |
|---|---|---|
| `brandIconUrl` | `…/api/brand-assets/icon/zapier.com` | `…/api/brand-assets/icon/zapier.com` |
| `brandLogoUrl` | **empty** | `…/api/brand-assets/logo/zapier.com` |

## Tests

`tests/brand-assets-lib.test.ts`:
- logos now auto-resolve alongside icons for a known brand;
- a manually-supplied `brandLogoUrl` still wins over the fallback.

## Validation

```
pnpm exec vitest run tests/brand-assets-lib.test.ts tests/brand-assets.test.ts   # 34 passed
pnpm exec vitest run tests/content-builder-lib.test.ts tests/artifacts-lib.test.ts tests/content-schema.test.ts tests/non-ui-branch-matrix.test.ts   # consumers green (318)
pnpm exec prettier --check packages/registry/src/brand-assets-lib.js tests/brand-assets-lib.test.ts
```

No visual impact (no current UI consumer renders `brandLogoUrl`); no generated artifacts committed.