### PR TITLE
fix(scripts): close the TASKS.md policy gap in validate-codebase-clean

### DIFF
--- a/scripts/validate-codebase-clean.mjs
+++ b/scripts/validate-codebase-clean.mjs
@@ -298,12 +298,29 @@ if (fs.existsSync(tasksPath)) {
     }
   }
 
-  const completedLines = tasks
-    .split("\n")
-    .filter((line) => line.trim().startsWith("- [x]"));
+  // Kept in step with scripts/validate-tasks.mjs: both entry points
+  // (`pnpm validate:clean` and `pnpm validate:tasks`) enforce one TASKS.md
+  // policy, so a tracker that one rejects must not pass the other.
+  const taskLines = tasks.split("\n");
+  const completedLines = taskLines.filter((line) =>
+    line.trim().startsWith("- [x]"),
+  );
+  if (!completedLines.length) {
+    failures.push("TASKS.md has no completed items with evidence");
+  }
   for (const line of completedLines) {
     if (!line.includes("Evidence:") || !line.includes("`")) {
       failures.push(`Completed TASKS.md item lacks command evidence: ${line}`);
+    }
+  }
+
+  for (const line of taskLines.filter((entry) =>
+    /^- \[[ ~]\]/.test(entry.trim()),
+  )) {
+    if (line.includes("Evidence:")) {
+      failures.push(
+        `Non-complete TASKS.md item should not claim evidence: ${line}`,
+      );
     }
   }
 


### PR DESCRIPTION
Closes #5229

Reopened from #5364, which was auto-closed on a **flaky** coverage failure unrelated to this diff (details at the bottom). No content changes — same commit, rebased on current `main` for a fresh CI run.

## What

`validate-codebase-clean.mjs` and `validate-tasks.mjs` enforce the same TASKS.md evidence policy from two entry points (`pnpm validate:clean` and `pnpm validate:tasks`, both wired into `.github/workflows/content-validation.yml`). They share identical `requiredSections`/`forbiddenBenchmarkNames` arrays and an identical "completed line needs `Evidence:` and a backtick" check — but the codebase-clean copy was missing two checks the other has, so a tracker `validate-tasks` rejects passed `validate-clean` silently.

Added, mirroring the reference implementation:
- at least one completed item with evidence must exist
- a non-complete item (`- [ ]` / `- [~]`) must not claim `Evidence:`

I took the "add the two checks directly" option rather than extracting `scripts/lib/tasks-md-policy.mjs`. The shared-helper refactor touches `validate-tasks.mjs`, which the issue lists as out of scope ("already correct, reference implementation"), and it would turn a 2-check parity fix into a cross-script refactor. The comment above the block names the parity requirement so the coupling is visible.

## Before / after

Fixtures built against the real script (only the TASKS.md-policy lines shown):

| fixture | before | after |
|---|---|---|
| sections present, **no** completed items | *(silently accepted)* | `TASKS.md has no completed items with evidence` |
| a `- [ ]` item claiming `Evidence:` alongside a valid completed item | *(silently accepted)* | `Non-complete TASKS.md item should not claim evidence: ...` |
| one valid `- [x] ... Evidence:` + a clean `- [ ]` | accepted | accepted *(unchanged)* |

Both rejected fixtures are ones `validate-tasks.mjs` already rejects by the same rules — that is the drift this closes.

## Invariants

- **Inert when TASKS.md is absent.** The whole block sits inside `if (fs.existsSync(tasksPath))`, and TASKS.md is a gitignored local-only tracker, so on a clean checkout (and in CI) behavior is unchanged — `node scripts/validate-codebase-clean.mjs` output is byte-identical to baseline.
- Existing checks in the block (required sections, forbidden benchmark names, completed-item evidence, gate commands) are untouched; the completed-line filter was only lifted to a shared `taskLines` so both new checks read the same split.
- `validate-tasks.mjs` not modified, per the issue's out-of-scope list.

## Note for maintainers (not fixed here — out of scope)

`validate-tasks.mjs` computes `repoRoot` as `path.resolve(new URL("..", import.meta.url).pathname)`, which yields `/C:/...` on Windows and resolves to `C:\C:\...`. It therefore prints *"TASKS.md is not present; skipping"* and exits 0 on Windows even when an invalid TASKS.md is present. It behaves correctly on Linux CI, so this PR's parity fix is unaffected — but it is worth a separate issue if you want the local gate usable there. I verified the two new checks against fixtures directly rather than relying on that script locally.

## On the previous run's CI failure

#5364 was closed for `coverage` failing. That job failed on a **180s timeout** in `tests/registry-artifacts.test.ts` — `Tests 1 failed | 39663 passed` — a suite this diff cannot reach: the only changed file is a standalone script under `scripts/`, never imported by that test.

The same job failed on **`main` itself** at 17:12 UTC, and on another contributor's PR at 16:27 which then passed unchanged at 16:40. The test sits right at the 180s limit and tips over under v8 coverage instrumentation.

## Validation

- `node scripts/validate-codebase-clean.mjs` — runs clean; output byte-identical to the unmodified baseline (the issue's stated validation)
- `node scripts/validate-tasks.mjs` — runs (also stated; see the Windows note above)
- `pnpm exec vitest run tests/cleanup-policy.test.ts` — 9 pass / 2 fail, and those 2 fail identically on unmodified `main` (pre-existing Windows path-separator failures, unrelated)
- `prettier --check scripts/validate-codebase-clean.mjs` — clean
