### PR TITLE
docs(mcp): diversify Postmark MCP server SEO metadata

### DIFF
--- a/content/mcp/postmark-mcp-server.mdx
+++ b/content/mcp/postmark-mcp-server.mdx
@@ -3,11 +3,11 @@ title: Postmark MCP Server for Claude
 slug: postmark-mcp-server
 category: mcp
 description: >-
-  Connect Claude to Postmark — send transactional email, manage templates, search messages, and
-  diagnose delivery, bounces, and suppressions — with the official ActiveCampaign Postmark MCP server.
-cardDescription: "Official Postmark MCP server: send email, manage templates, and diagnose delivery from Claude."
-seoTitle: "Postmark MCP Server for Claude — Transactional Email"
-seoDescription: "Connect Claude to Postmark with the official MCP server: send transactional email, manage templates, search messages, and diagnose delivery, bounces, and suppressions."
+  ActiveCampaign's official server that wires Postmark into Claude over stdio, exposing 24 tools for
+  outbound mail, template authoring, message lookup, bounce handling, and suppression list cleanup.
+cardDescription: "Drive Postmark's transactional-email API from natural language — 24 stdio tools for templates, batches, and deliverability triage."
+seoTitle: "Postmark MCP Server — Send & Diagnose Email in Claude"
+seoDescription: "Wire Postmark into Claude with ActiveCampaign's official MCP server: 24 stdio tools to send templated mail, run batches, look up messages, and triage bounces."
 author: ActiveCampaign
 authorProfileUrl: "https://postmarkapp.com"
 dateAdded: "2026-06-17"
@@ -22,7 +22,7 @@ retrievalSources:
 installable: true
 installCommand: "git clone https://github.com/ActiveCampaign/postmark-mcp && cd postmark-mcp && npm install"
 usageSnippet: >-
-  Ask Claude to send a templated email, search recent outbound messages, or diagnose a delivery issue.
+  Ask Claude to fire off a templated welcome message, pull yesterday's outbound activity, or explain why a recipient bounced.
 copySnippet: |-
   {
     "mcpServers": {


### PR DESCRIPTION
## What

The Postmark MCP server entry had near-duplicate `description` and `seoDescription` fields, giving it a low unique-text ratio (0.41, below the 0.42 floor). This rewrites the SEO/description metadata so each field is distinct, while keeping every claim grounded in the official source.

## Changes (one file: `content/mcp/postmark-mcp-server.mdx`)

- **description** — now emphasizes the stdio transport and the 24-tool surface (outbound mail, template authoring, message lookup, bounce handling, suppression cleanup).
- **cardDescription** — distinct short form focused on the transactional-email API and deliverability triage.
- **seoTitle** — "Postmark MCP Server — Send & Diagnose Email in Claude" (53 chars, distinct from title).
- **seoDescription** — 158 chars, reworded so it no longer mirrors `description`.
- **usageSnippet** — a concrete, distinct example ask.

Unique-text ratio rises from **0.41 → 0.69**; the entry no longer appears in `report-thin-content.mjs`.

## Grounding

All claims verified against the official ActiveCampaign repo:

- `documentationUrl` / `repoUrl`: https://github.com/ActiveCampaign/postmark-mcp (live, 200) — **24 tools**, exact tool names, `POSTMARK_SERVER_TOKEN` / `DEFAULT_SENDER_EMAIL` / `DEFAULT_MESSAGE_STREAM` env vars, and stdio transport all match the README.
- Postmark developer docs (https://postmarkapp.com/developer) ground the underlying transactional-email APIs.
- Claude Code MCP docs (https://code.claude.com/docs/en/mcp) ground the connector setup.

Body sections, tool table, and install steps are unchanged and already accurate — no new claims introduced.

## Validation

- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs` → policy passed
- `report-thin-content.mjs` → entry no longer flagged
- `git diff --check` clean; exactly one file changed