### PR TITLE
fix(web): derive brief approval send-slot copy from the schedule constants

### DIFF
--- a/apps/web/src/lib/brief-schedule-lib.ts
+++ b/apps/web/src/lib/brief-schedule-lib.ts
@@ -13,6 +13,26 @@
 const SEND_DOW = 0; // 0=Sun..6=Sat; Sunday
 const SEND_HOUR_UTC = 16;
 
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/**
+ * Human-readable label for the weekly send slot (e.g. "Sunday 16:00 UTC"),
+ * derived from SEND_DOW/SEND_HOUR_UTC so approval/marketing copy can reference
+ * the single source of truth instead of hardcoding a second copy that can drift.
+ */
+export function sendSlotLabel(): string {
+  const hour = String(SEND_HOUR_UTC).padStart(2, "0");
+  return `${DAY_NAMES[SEND_DOW]} ${hour}:00 UTC`;
+}
+
 /**
  * The next Sunday 16:00 UTC strictly at or after `from` (today if it's Sunday
  * before 16:00, otherwise the following Sunday). Returned as an ISO string for

--- a/apps/web/src/lib/brief-schedule.ts
+++ b/apps/web/src/lib/brief-schedule.ts
@@ -5,4 +5,4 @@
  * (`@/lib/brief-schedule-lib`). This module re-exports it so existing
  * `@/lib/brief-schedule` importers stay unchanged.
  */
-export { nextSendSlot } from "@/lib/brief-schedule-lib";
+export { nextSendSlot, sendSlotLabel } from "@/lib/brief-schedule-lib";

--- a/apps/web/src/routes/brief.approve.tsx
+++ b/apps/web/src/routes/brief.approve.tsx
@@ -10,6 +10,7 @@ import {
   briefApproveEgressAnalyticsEvent,
 } from "@/lib/brief-approve-cta-events";
 import { briefIssueHubDestination } from "@/lib/brief-entry-cta-events";
+import { sendSlotLabel } from "@/lib/brief-schedule";
 
 const tokenInput = z.object({ token: z.string() });
 const confirmInput = z.object({
@@ -95,7 +96,7 @@ function ApprovePage() {
   return (
     <Shell heading={`Approve Weekly Brief #${result.number}`}>
       Approving the draft for the week of <strong>{result.periodThrough}</strong> schedules it to
-      send to the newsletter audience at the next Tuesday 15:00 UTC slot. Review the full draft in
+      send to the newsletter audience at the next {sendSlotLabel()} slot. Review the full draft in
       your preview email first.
       {state.phase === "error" && (
         <p style={{ color: "#b4541f", marginTop: 12 }}>

--- a/tests/brief-schedule-lib.test.ts
+++ b/tests/brief-schedule-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { nextSendSlot } from "../apps/web/src/lib/brief-schedule-lib";
+import {
+  nextSendSlot,
+  sendSlotLabel,
+} from "../apps/web/src/lib/brief-schedule-lib";
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -69,6 +72,30 @@ describe("nextSendSlot", () => {
   it("returns an ISO 8601 UTC string", () => {
     expect(nextSendSlot(new Date("2026-06-01T00:00:00Z"))).toMatch(
       /^\d{4}-\d{2}-\d{2}T16:00:00\.000Z$/,
+    );
+  });
+});
+
+describe("sendSlotLabel", () => {
+  it("labels the send slot as Sunday 16:00 UTC", () => {
+    expect(sendSlotLabel()).toBe("Sunday 16:00 UTC");
+  });
+
+  it("stays consistent with the day/hour nextSendSlot actually produces", () => {
+    // Derived from the same constants, so the human copy can't drift from the
+    // real schedule the way the old hardcoded "Tuesday 15:00 UTC" copy did.
+    const dayNames = [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ];
+    const hour = String(knownSunday.getUTCHours()).padStart(2, "0");
+    expect(sendSlotLabel()).toBe(
+      `${dayNames[knownSunday.getUTCDay()]} ${hour}:00 UTC`,
     );
   });
 });


### PR DESCRIPTION
Closes #5257

## Problem

The brief approval page told the maintainer the brief would "send to the newsletter audience at the next **Tuesday 15:00 UTC** slot" — but the actual send slot is **Sunday 16:00 UTC** everywhere else in the codebase (`brief-schedule-lib.ts`'s `SEND_DOW = 0`/`SEND_HOUR_UTC = 16`, `wrangler.jsonc`'s `"0 16 * * SUN"` cron, `brief.tsx`'s "Sundays" copy). The approval copy was a stale, hardcoded second copy of the schedule.

## Fix

Rather than hardcode a corrected string (which could drift again), derive the label from the single source of truth:

- `brief-schedule-lib.ts`: add `sendSlotLabel()`, which formats `SEND_DOW`/`SEND_HOUR_UTC` into `"Sunday 16:00 UTC"`.
- `brief-schedule.ts`: re-export it alongside `nextSendSlot`.
- `brief.approve.tsx`: render `{sendSlotLabel()}` instead of the hardcoded `Tuesday 15:00 UTC`.

Now the approval copy can never diverge from the actual schedule constants.

## Before / after

> …schedules it to send to the newsletter audience at the next **~~Tuesday 15:00 UTC~~ → Sunday 16:00 UTC** slot.

## Tests

`tests/brief-schedule-lib.test.ts`:
- `sendSlotLabel()` returns `"Sunday 16:00 UTC"`;
- it stays consistent with the day/hour `nextSendSlot` actually produces (a drift guard: the label is derived from the same constants the slot computation uses).

## Validation

```
pnpm exec vitest run tests/brief-schedule-lib.test.ts   # 8 passed
pnpm exec prettier --check <changed files>
```

The pre-existing TanStack route-param type errors in `brief.approve.tsx` (unrelated to this change; they require the generated `routeTree.gen.ts` that CI's prebuild produces) are untouched. No visual layout change beyond the corrected copy string; no generated artifacts committed.