### PR TITLE
fix(web): route the MCP threat-model guide link to /entry/$category/$slug

### DIFF
--- a/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
+++ b/apps/web/src/lib/mcp-security-report-page-cta-events-lib.ts
@@ -127,7 +127,7 @@ export function mcpSecurityReportStatDestination(
 }
 
 export type McpSecurityReportRouteDestination =
-  | { to: "/guides/$slug"; params: { slug: string } }
+  | { to: "/entry/$category/$slug"; params: { category: string; slug: string } }
   | { to: "/state-of-mcp-servers" }
   | { to: "/$category"; params: { category: string } };
 
@@ -137,9 +137,15 @@ export function mcpSecurityReportRouteDestination(
 ): McpSecurityReportRouteDestination | null {
   switch (destination) {
     case "threat-model-guide":
+      // "guides" is a content category, not a URL segment: guide entries are
+      // served by /entry/$category/$slug like every other category, not a
+      // nonexistent /guides/$slug route.
       return {
-        to: "/guides/$slug",
-        params: { slug: "threat-model-mcp-servers-before-installation" },
+        to: "/entry/$category/$slug",
+        params: {
+          category: "guides",
+          slug: "threat-model-mcp-servers-before-installation",
+        },
       };
     case "state-of-mcp-servers":
       return { to: "/state-of-mcp-servers" };

--- a/tests/mcp-security-report-page-cta-events-lib.test.ts
+++ b/tests/mcp-security-report-page-cta-events-lib.test.ts
@@ -91,8 +91,11 @@ describe("mcp security report page cta events lib", () => {
     });
     expect(mcpSecurityReportStatDestination("unknown")).toBeNull();
     expect(mcpSecurityReportRouteDestination("threat-model-guide")).toEqual({
-      to: "/guides/$slug",
-      params: { slug: "threat-model-mcp-servers-before-installation" },
+      to: "/entry/$category/$slug",
+      params: {
+        category: "guides",
+        slug: "threat-model-mcp-servers-before-installation",
+      },
     });
     expect(mcpSecurityReportRouteDestination("state-of-mcp-servers")).toEqual({
       to: "/state-of-mcp-servers",


### PR DESCRIPTION
Closes #5234

## Problem

The "MCP threat-model guide" link on `/mcp-security-report` pointed at a route that doesn't exist. `mcpSecurityReportRouteDestination("threat-model-guide")` returned:

```ts
{ to: "/guides/$slug", params: { slug: "threat-model-mcp-servers-before-installation" } }
```

But there is no `/guides/$slug` route — "guides" is a content **category**, not a URL segment. Guide entries are served through `/entry/$category/$slug` like every other category (see `category-ranking-table.tsx`, `hub-highlights.tsx`, `compare-drawer.tsx`). So the link failed to resolve. (The issue predates a refactor that moved the link's `to`/`params` from an inline `<Link>` literal into this shared destination helper — the same bug, now in the lib.)

## Fix

`mcp-security-report-page-cta-events-lib.ts`: point the `threat-model-guide` destination at the real route, and update the union type accordingly:

```ts
{ to: "/entry/$category/$slug",
  params: { category: "guides", slug: "threat-model-mcp-servers-before-installation" } }
```

The page's `<Link to={destination.to} params={destination.params}>` consumes this generically, so no route-component change is needed. The target entry exists at `content/guides/threat-model-mcp-servers-before-installation.mdx`.

## Tests

`tests/mcp-security-report-page-cta-events-lib.test.ts`: the `threat-model-guide` destination assertion is updated to the corrected `/entry/$category/$slug` shape; the other destinations (`state-of-mcp-servers`, `mcp-category`, unknown→null) are unchanged.

## Validation

```
pnpm exec vitest run tests/mcp-security-report-page-cta-events-lib.test.ts   # 3 passed
pnpm exec prettier --check <changed files>
```

No visual layout change; the link now resolves to the guide's entry detail page. No generated artifacts committed.