### PR TITLE
fix(registry): catch bare-root and reordered rm -rf install commands

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1107,6 +1107,40 @@ function isMutableGithubSourceUrl(value) {
   return Boolean(source && !FULL_COMMIT_SHA_PATTERN.test(source.ref));
 }
 
+/**
+ * Recursive-force removal aimed at the filesystem root or the user's home.
+ *
+ * The previous single regex required the literal `-rf` token and a word
+ * boundary after the target, so it missed `rm -rf /` and `rm -rf ~` - the two
+ * most literal ways to write "delete everything" - along with every
+ * flag-ordering variant. Parse the flag run instead of pattern-matching one
+ * spelling: any option cluster carrying both recursive and force counts,
+ * whether written `-rf`, `-fr`, `-r -f`, or `--recursive --force`.
+ *
+ * Targets stay deliberately narrow (root, `~`, `$HOME`). Relative paths like
+ * `./build` are ordinary cleanup and must not flag.
+ */
+function referencesDestructiveRootRemoval(value) {
+  const text = String(value || "");
+  const pattern =
+    /\brm\b((?:\s+-{1,2}[a-z][a-z-]*)+)\s+(?:\/[^\s;&|)'"`]*|~[^\s;&|)'"`]*|\$home\b|\$\{home\})/gi;
+
+  for (const match of text.matchAll(pattern)) {
+    const flags = match[1].toLowerCase().split(/\s+/).filter(Boolean);
+    const recursive = flags.some(
+      (flag) =>
+        flag === "--recursive" || (!flag.startsWith("--") && /r/.test(flag)),
+    );
+    const force = flags.some(
+      (flag) =>
+        flag === "--force" || (!flag.startsWith("--") && /f/.test(flag)),
+    );
+    if (recursive && force) return true;
+  }
+
+  return false;
+}
+
 function addContentRiskSignals(report, fields, text) {
   const installText = lower(
     [
@@ -1213,7 +1247,7 @@ function addContentRiskSignals(report, fields, text) {
   }
 
   if (
-    /rm\s+-rf\s+(\/|~|\$home)\b/i.test(installText) ||
+    referencesDestructiveRootRemoval(installText) ||
     /\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(sh|bash)\b/i.test(
       installText,
     ) ||

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -631,3 +631,43 @@ describe("checks ported from validate-content-policy", () => {
     ).toHaveLength(1);
   });
 });
+
+describe("destructive rm detection", () => {
+  function flagged(installCommand: string) {
+    const report = analyzeSubmissionDraftRisk({ title: "t", body: "b" }, {
+      fields: { install_command: installCommand },
+    } as never);
+    return (report.reviewFlags || []).some(
+      (flag) => flag.id === "unsafe_install_pipeline",
+    );
+  }
+
+  // The old regex required a literal "-rf" token plus a word boundary after
+  // the target, so the two most literal destructive forms slipped through.
+  it.each([
+    "rm -rf /",
+    "rm -rf ~",
+    "rm -rf $HOME",
+    "rm -r -f /",
+    "rm -fr /",
+    "rm --recursive --force /",
+    "rm -r --force ~",
+    "rm -Rf /",
+    "rm -rf /etc",
+    "sudo rm -rf / --no-preserve-root",
+  ])("flags %s", (command) => {
+    expect(flagged(command)).toBe(true);
+  });
+
+  it.each([
+    "rm -rf ./build",
+    "rm -rf node_modules",
+    "rm -f /tmp/scratch",
+    "rm -r /tmp/scratch",
+    "git rm -r --cached .",
+    "npm run rm-rf-helper",
+    "npm install acme",
+  ])("does not flag %s", (command) => {
+    expect(flagged(command)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #5232

## The gap

`unsafe_install_pipeline` is a **critical**-severity check meant to catch destructive install commands. Its destructive-command test was:

```js
/rm\s+-rf\s+(\/|~|\$home)/i
```

Two problems: it required the literal `-rf` token, and the trailing `` after a bare `/` or `~` needs a *word* character after it — so the shortest, most literal forms never matched.

Measured against the unmodified check, **8 of 10** destructive forms slipped through:

| command | before | after |
|---|---|---|
| `rm -rf /` | **missed** | flagged |
| `rm -rf ~` | **missed** | flagged |
| `rm -r -f /` | **missed** | flagged |
| `rm -fr /` | **missed** | flagged |
| `rm --recursive --force /` | **missed** | flagged |
| `rm -r --force ~` | **missed** | flagged |
| `rm -Rf /` | **missed** | flagged |
| `sudo rm -rf / --no-preserve-root` | **missed** | flagged |
| `rm -rf $HOME` | flagged | flagged |
| `rm -rf /etc` | flagged | flagged |

(`$HOME` and `/etc` matched before only because a word character happened to follow the target, satisfying the ``.)

## The fix

Parse the flag run rather than matching one spelling — any option cluster carrying **both** recursive and force counts, however written:

```js
const recursive = flags.some(
  (flag) => flag === "--recursive" || (!flag.startsWith("--") && /r/.test(flag)),
);
const force = flags.some(
  (flag) => flag === "--force" || (!flag.startsWith("--") && /f/.test(flag)),
);
if (recursive && force) return true;
```

Targets stay deliberately narrow — root, `~`, `$HOME`/`${HOME}` — so ordinary cleanup does not become a critical flag. Everything else in the `unsafe_install_pipeline` OR-chain (curl-pipe-sh, `iex`, base64-pipe-sh, encoded PowerShell) is untouched.

## Every covered input

**Flags as destructive (10):** `rm -rf /`, `rm -rf ~`, `rm -rf $HOME`, `rm -r -f /`, `rm -fr /`, `rm --recursive --force /`, `rm -r --force ~`, `rm -Rf /`, `rm -rf /etc`, `sudo rm -rf / --no-preserve-root`

**Does not flag (7):** `rm -rf ./build`, `rm -rf node_modules`, `rm -f /tmp/scratch`, `rm -r /tmp/scratch`, `git rm -r --cached .`, `npm run rm-rf-helper`, `npm install acme`

The negatives cover the three ways this could over-fire: relative/named targets (`./build`, `node_modules`), recursive-or-force but not both (`-f` alone, `-r` alone), and `rm` appearing as a substring or subcommand (`git rm`, `rm-rf-helper`). No visual impact.

## Evidence

Mutation-tested by restoring the exact original regex: **8 of the 10 positive tests fail**, all 7 negatives still pass — confirming the new tests pin the fix and not incidental behavior.

```
x flags rm -rf /            x flags rm -r --force ~
x flags rm -rf ~            x flags rm -Rf /
x flags rm -r -f /          x flags sudo rm -rf / --no-preserve-root
x flags rm -fr /            x flags rm --recursive --force /
Tests  8 failed | 32 passed
```

Restored: 40/40 pass.

## Validation

- `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — 40/40 pass (the issue's stated validation)
- `pnpm --filter web exec tsc --noEmit` — clean, exit 0
- `prettier --check` on both touched files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
- Out of scope per the issue and untouched: `command-safety-lib.js`'s separate `REMOVE_PATTERN`/`CHMOD_PATTERN`
