### PR TITLE
fix(api): document the preflight honeypot response in the contract

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -5054,6 +5054,16 @@
                         "routeSuggestion"
                       ],
                       "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": { "type": "boolean", "enum": [true] },
+                        "valid": { "type": "boolean", "enum": [false] },
+                        "queued": { "type": "boolean", "enum": [false] }
+                      },
+                      "required": ["ok", "valid", "queued"],
+                      "additionalProperties": false
                     }
                   ]
                 }

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -5923,6 +5923,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -607,9 +607,25 @@ const submissionPreflightNonPrResponseSchema = submissionPreflightBaseResponseSc
   })
   .strict();
 
+/**
+ * Honeypot short-circuit: a filled honeypot field is discarded without
+ * validating or queueing anything, so the response carries none of the analysis
+ * fields the other variants do, plus a `queued` flag they lack. It is a
+ * permanent, intentional code path, so the published contract describes it
+ * rather than leaving consumers to infer a shape the endpoint can return.
+ */
+const submissionPreflightDiscardedResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    valid: z.literal(false),
+    queued: z.literal(false),
+  })
+  .strict();
+
 export const submissionPreflightResponseSchema = z.union([
   submissionPreflightPrReadyResponseSchema,
   submissionPreflightNonPrResponseSchema,
+  submissionPreflightDiscardedResponseSchema,
 ]);
 
 export const downloadQuerySchema = z.object({

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -5927,6 +5927,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -5,6 +5,7 @@ import { parse } from "yaml";
 
 import { ENDPOINTS, OPENAPI_TAGS } from "../apps/web/src/data/openapi";
 import { listApiRouteDefinitions } from "../apps/web/src/lib/api/contracts";
+import { submissionPreflightResponseSchema } from "../apps/web/src/lib/api/contracts-lib";
 import { repoRoot } from "./helpers/registry-fixtures";
 
 function findRouteFiles(directory: string): string[] {
@@ -410,5 +411,32 @@ describe("OpenAPI route coverage", () => {
     expect(schema).toContain("lastVerifiedAt");
     expect(schema).toContain("adapterGenerated");
     expect(schema).toContain("RSS, changelog, category feeds, platform feeds");
+  });
+});
+
+describe("submissions preflight response contract", () => {
+  // The honeypot short-circuit is a permanent code path (see
+  // tests/submission-api.test.ts, "silently discards honeypot submissions"),
+  // so the published contract has to accept exactly what it returns.
+  const honeypotResponse = { ok: true, valid: false, queued: false };
+
+  it("accepts the honeypot discard response", () => {
+    expect(
+      submissionPreflightResponseSchema.safeParse(honeypotResponse).success,
+    ).toBe(true);
+  });
+
+  it("still rejects near-miss shapes", () => {
+    for (const invalid of [
+      { ok: true, valid: false },
+      { ok: true, valid: false, queued: true },
+      { ok: true, valid: false, queued: false, extra: 1 },
+      { ok: false, valid: false, queued: false },
+    ]) {
+      expect(
+        submissionPreflightResponseSchema.safeParse(invalid).success,
+        JSON.stringify(invalid),
+      ).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
Closes #5245

## The mismatch

`/api/submissions/preflight` is registered with `responseSchema: submissionPreflightResponseSchema`, a union of two variants that both require `category`, `slug`, `schema`, `risk`, `expectedNotes`, `blockers`, `warnings`, `duplicates`, `nextAction` and a `routeSuggestion`.

The honeypot short-circuit returns:

```ts
{ ok: true, valid: false, queued: false }
```

None of those required fields, plus a `queued` flag no variant declares. So the published contract described responses the endpoint cannot return on that path, and omitted one it does. Verified directly against the schema:

| | before | after |
|---|---|---|
| `{ ok: true, valid: false, queued: false }` | **rejected** (`unrecognized_keys: ["queued"]`, 9 missing fields) | accepted |

## The fix

The honeypot path is permanent and intentional — `tests/submission-api.test.ts` pins it ("silently discards honeypot submissions without queueing anything") and the issue puts the discard logic out of scope. So the contract is what changes, not the behaviour: the discard shape becomes a documented third union variant.

```ts
const submissionPreflightDiscardedResponseSchema = z
  .object({
    ok: z.literal(true),
    valid: z.literal(false),
    queued: z.literal(false),
  })
  .strict();
```

`.strict()` and the literals keep it tight — it accepts exactly the one shape the route emits, not any `{ok, valid}` object.

## Invariants

- **Runtime behaviour unchanged.** `preflight.ts` is not touched. Same trigger, same silent discard, same `no-store` response, nothing queued.
- **No new information leak.** The response body is byte-identical to what it was. The honeypot's shape was already distinguishable from a normal reply at runtime — documenting it does not add a signal a bot could not already observe by calling the endpoint. What the honeypot protects is that it never *says* it was detected, and it still doesn't: it returns `ok: true` like a success.
- **Still rejects near-misses**, asserted by test: missing `queued`, `queued: true`, an extra key, and `ok: false` are all refused.
- Purely additive: **92 insertions, 0 deletions** across all five files. No existing variant changed.

## Generated artifacts

Changing the contract makes `pnpm validate:openapi` fail with *"OpenAPI schema is stale"*, so `pnpm generate:openapi` was run and its output committed: `apps/web/public/openapi.{json,yaml}` and `cloudflare/api-schema-heyclaude-openapi.yaml`. These are additive-only (the new `oneOf` branch) and are a required part of this change, not incidental churn — happy to drop them if maintainers would rather regenerate on their side.

## Evidence

Mutation-tested — removing the new variant from the union fails the new test:
```
x accepts the honeypot discard response
Tests  1 failed | 15 passed
```
Restored: 16/16 pass. No visual impact.

## Validation

- `pnpm exec vitest run tests/submission-api.test.ts tests/api-contracts.test.ts` — 30/30 pass (the issue's stated validation)
- plus `tests/api-router-security.test.ts` — 67/67 across all three
- `pnpm validate:openapi` — passes after regeneration
- `pnpm --filter web exec tsc --noEmit` — clean, exit 0
- `prettier --check` on both hand-edited files — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline
