### PR TITLE
feat(mcp): let registry.list filter by the same trust signals as registry.search

### DIFF
--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -342,6 +342,7 @@ export async function listCategoryEntries(args = {}, options = {}) {
   const query = normalizeText(args.query);
   const offset = normalizeOffset(args.offset);
   const limit = normalizeLimit(args.limit, 20);
+  const trustFilters = parsedTrustArgs(args);
   const searchIndex = unwrapEntries(
     await readJsonArtifact("search-index.json", options),
   );
@@ -350,7 +351,8 @@ export async function listCategoryEntries(args = {}, options = {}) {
     .filter((entry) => !category || entry.category === category)
     .filter((entry) => entryMatchesPlatform(entry, platform))
     .filter((entry) => entryMatchesTag(entry, tag))
-    .filter((entry) => entryMatchesQuery(entry, query));
+    .filter((entry) => entryMatchesQuery(entry, query))
+    .filter((entry) => entryMatchesTrustFilters(entry, trustFilters));
   const page = paginateEntries(entries, offset, limit).map(toEntrySummary);
 
   return buildCategoryEntriesPageResponse({

--- a/packages/mcp/src/schemas-lib.js
+++ b/packages/mcp/src/schemas-lib.js
@@ -244,6 +244,31 @@ export const ListCategoryEntriesInputSchema = z
       .max(240)
       .optional()
       .describe("Keyword search to narrow the listing."),
+    hasSafetyNotes: trustBooleanFilter
+      .optional()
+      .describe(
+        "Filter by whether entries include safety notes ('true', 'false', or 'all').",
+      ),
+    hasPrivacyNotes: trustBooleanFilter
+      .optional()
+      .describe(
+        "Filter by whether entries include privacy notes ('true', 'false', or 'all').",
+      ),
+    downloadTrust: downloadTrustFilter
+      .optional()
+      .describe(
+        "Filter by package download trust level ('first-party', 'external', 'none', or 'all').",
+      ),
+    claimStatus: claimStatusFilter
+      .optional()
+      .describe(
+        "Filter by claim or verification status ('unclaimed', 'pending', 'verified', or 'all').",
+      ),
+    sourceStatus: sourceStatusFilter
+      .optional()
+      .describe(
+        "Filter by whether the entry's source URL is reachable ('available', 'missing', or 'all').",
+      ),
     offset: z
       .number()
       .int()

--- a/tests/mcp-registry-tool-orchestration-lib-i.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-i.test.ts
@@ -42,6 +42,49 @@ describe("registry-tool-orchestration unscoped listings", () => {
   });
 });
 
+describe("registry-tool-orchestration listing trust filters", () => {
+  const withNotes = {
+    category: "mcp",
+    slug: "with-notes",
+    title: "With Notes",
+    description: "mcp server with safety notes",
+    platforms: ["claude-code"],
+    tags: [],
+    safetyNotes: [{ text: "Runs shell commands" }],
+  };
+  const withoutNotes = {
+    category: "mcp",
+    slug: "without-notes",
+    title: "Without Notes",
+    description: "mcp server with no notes",
+    platforms: ["claude-code"],
+    tags: [],
+  };
+  const options = {
+    readJsonArtifact: async () => ({ entries: [withNotes, withoutNotes] }),
+    readTextArtifact: async () => "{}",
+  };
+
+  it("filters the listing by hasSafetyNotes before pagination", async () => {
+    const result = await listCategoryEntries(
+      { hasSafetyNotes: "true" },
+      options,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.total).toBe(1);
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["with-notes"]);
+  });
+
+  it("still returns every entry when no trust filter is supplied", async () => {
+    const result = await listCategoryEntries({}, options);
+    expect(result.total).toBe(2);
+    expect(result.entries.map((entry) => entry.slug).sort()).toEqual([
+      "with-notes",
+      "without-notes",
+    ]);
+  });
+});
+
 describe("registry-tool-orchestration install guidance platform selection", () => {
   it("leaves compatibility unselected when no platform is requested", async () => {
     const result = await getInstallGuidance(


### PR DESCRIPTION
Closes #5222

## Problem

`registry.list` is the paginated browse tool, but it could only filter by `category`/`platform`/`tag`/`query` — not by trust signals — while `registry.search` already supports `hasSafetyNotes`, `hasPrivacyNotes`, `downloadTrust`, `claimStatus`, and `sourceStatus` over the same `search-index.json` data. So "show me all first-party MCP servers with safety notes, paginated" wasn't expressible. The filter machinery (`entryMatchesTrustFilters` / `parsedTrustArgs`) already existed and was used only by `searchRegistry`.

## Fix

Pure parity, reusing the existing helpers:

- `schemas-lib.js`: add the same 5 optional trust fields to `ListCategoryEntriesInputSchema` (identical definitions/descriptions as `SearchRegistryInputSchema`).
- `registry-tool-orchestration-lib.js`: `listCategoryEntries` now computes `parsedTrustArgs(args)` and applies `entryMatchesTrustFilters(...)` in its filter chain **before** pagination — exactly as `searchRegistry` does.

## Backward compatibility

All 5 fields are optional. A `registry.list` call without them behaves identically to before (the filter is a no-op when no trust args are parsed). `registry.search`'s schema and behavior are untouched. Pagination applies on top of the trust-filtered set.

## Tests

`tests/mcp-registry-tool-orchestration-lib-i.test.ts`:
- `listCategoryEntries({ hasSafetyNotes: "true" })` returns only the entry with safety notes (filtered before pagination);
- with no trust filter, every entry is still returned.

## Validation

```
pnpm exec vitest run tests/mcp-registry-filter-lib.test.ts tests/mcp-registry-collection-lib.test.ts tests/mcp-schemas-lib.test.ts tests/mcp-registry-tool-orchestration-lib-i.test.ts   # green
pnpm exec vitest run tests/non-ui-branch-matrix.test.ts tests/mcp-server.test.ts   # consumers green (674)
pnpm exec prettier --check <changed files>
```

No visual impact; no generated artifacts committed.