### PR TITLE
fix(registry): include trust signals in the Raycast feed so local filters work

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -917,6 +917,12 @@ export function buildRaycastEntries(entries) {
       documentationUrl: entry.documentationUrl || "",
       downloadTrust: entry.downloadTrust,
       verificationStatus: entry.verificationStatus || "",
+      // Mirror buildSearchEntries so the locally-browsed Raycast feed carries the
+      // same trust signals (incl. hasSafetyNotes/hasPrivacyNotes) the extension's
+      // advanced filters and accessory badges read; without this the "Has Safety
+      // Notes"/"Has Privacy Notes" filters match nothing when the search box is
+      // empty (feed path) instead of the server-search path.
+      trustSignals: buildListTrustSignals(entry),
       ...buildCompactInstallFields(entry),
       platformCompatibility:
         entry.category === "skills"

--- a/tests/artifacts-lib.test.ts
+++ b/tests/artifacts-lib.test.ts
@@ -803,6 +803,22 @@ describe("buildRaycastEntries", () => {
       buildEntryTrustSignals(FIXTURE_MCP).platforms,
     );
   });
+
+  it("includes trust signals so the local feed can filter by safety/privacy notes", () => {
+    const withNotes = buildRaycastEntries([
+      syntheticEntry("mcp", "with-notes"),
+    ])[0];
+    expect(withNotes?.trustSignals).toMatchObject({
+      hasSafetyNotes: true,
+      hasPrivacyNotes: true,
+    });
+
+    const withoutNotes = buildRaycastEntries([
+      syntheticEntry("mcp", "plain", { safetyNotes: [], privacyNotes: [] }),
+    ])[0];
+    expect(withoutNotes?.trustSignals?.hasSafetyNotes).toBe(false);
+    expect(withoutNotes?.trustSignals?.hasPrivacyNotes).toBe(false);
+  });
 });
 
 describe("buildRaycastEnvelope", () => {


### PR DESCRIPTION
Closes #5240

## Problem

`buildRaycastEntries` (the source of `raycast-index.json`, which the Raycast extension caches and browses locally) never included `trustSignals`, so feed-loaded entries always had `trustSignals === undefined`. The extension's advanced filters read `entry.trustSignals?.hasSafetyNotes` / `hasPrivacyNotes`, so "Has Safety Notes" / "Has Privacy Notes" with an empty search box always returned **zero** results — those fields were only populated on the server-search path (`buildSearchEntries`) and in `buildRaycastDetail`, not in the browsed feed. The safety/privacy accessory badge was defeated the same way.

## Fix

Mirror `buildSearchEntries` — add `trustSignals: buildListTrustSignals(entry)` to `buildRaycastEntries`. `buildListTrustSignals` already yields `hasSafetyNotes`/`hasPrivacyNotes` (plus `sourceStatus`, `packageVerified`, etc.), which is exactly what the extension's local filter and accessory badge read. One-line, reusing the existing shared helper; the server-search path is unchanged.

## Tests

`tests/artifacts-lib.test.ts`:
- an entry with safety/privacy notes now yields `trustSignals: { hasSafetyNotes: true, hasPrivacyNotes: true, ... }` in its Raycast row;
- an entry without notes yields `hasSafetyNotes: false` / `hasPrivacyNotes: false`.

## Validation

```
pnpm exec vitest run tests/artifacts-lib.test.ts   # 287 passed
pnpm exec prettier --check packages/registry/src/artifacts-lib.js tests/artifacts-lib.test.ts
```

No visual impact (generated feed JSON, not the website UI). The Raycast feed is a generated artifact regenerated by CI's prebuild; no generated files are committed here. The feed validator (`validate-raycast-feed.mjs`) doesn't reject the added field.