### PR TITLE
fix(web): log why the brief send/preview path skips instead of silent return

### DIFF
--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -95,6 +95,16 @@ export default definePlugin((nitroApp) => {
               });
               await sendResendEmail({ apiKey, from, to: reviewEmail, subject, html, text });
               console.log("[brief-generate] preview sent", { number: draft.number });
+            } else {
+              const missing = [
+                !wrote && "no new draft persisted",
+                !draft && "no draft available",
+                !reviewEmail && "BRIEF_REVIEW_EMAIL",
+                !secret && "NEWSLETTER_CONFIRM_SECRET",
+                !apiKey && "RESEND_API_KEY",
+                !from && "RESEND_FROM",
+              ].filter(Boolean);
+              console.log(`[brief-generate] preview skipped: ${missing.join(", ")}`);
             }
           } catch (error) {
             console.error("[brief-generate] generation failed", error);
@@ -112,7 +122,15 @@ export default definePlugin((nitroApp) => {
             const apiKey = getEnvString("RESEND_API_KEY");
             const segmentId = getEnvString("RESEND_SEGMENT_ID");
             const from = getEnvString("RESEND_FROM");
-            if (!apiKey || !segmentId || !from) return;
+            if (!apiKey || !segmentId || !from) {
+              const missing = [
+                !apiKey && "RESEND_API_KEY",
+                !segmentId && "RESEND_SEGMENT_ID",
+                !from && "RESEND_FROM",
+              ].filter(Boolean);
+              console.warn(`[brief-send] skipped: missing ${missing.join("/")}`);
+              return;
+            }
             const due = await getDueApprovedBriefs(new Date().toISOString());
             for (const issue of due) {
               const { subject, html, text } = buildBriefEmail({


### PR DESCRIPTION
Closes #5254

## Problem

`newsletter-digest-scheduled.ts`'s `SEND_CRONS` branch (the actual audience-send path, firing every 6 hours and Sunday 16:00 UTC) returned early with **zero logging** when `RESEND_API_KEY`/`RESEND_SEGMENT_ID`/`RESEND_FROM` was unset — so an approved brief could silently never send, indefinitely, with nothing in the Cloudflare Worker logs to explain why. The `GENERATE_CRON` preview-email step had the same gap (no `else` branch when its conditions weren't met). The sibling `indexnow-scheduled.ts` already logs every skip reason.

## Fix

Logging only — no change to what triggers the skip or to send behavior:

- **Send path:** when secrets are missing, log the exact missing ones before returning:
  `console.warn("[brief-send] skipped: missing RESEND_API_KEY/RESEND_SEGMENT_ID/RESEND_FROM")` (only the actually-missing names are listed).
- **Generate preview path:** add an `else` branch logging why the preview wasn't sent:
  `console.log("[brief-generate] preview skipped: no new draft persisted, BRIEF_REVIEW_EMAIL, ...")` (only the unmet conditions are listed).

Both mirror the file's existing `"[brief-generate] draft persisted"` / `"[brief-send] sent"` conventions and `indexnow-scheduled.ts`'s `"[indexnow] skipped: ..."` pattern.

## Invariants

- No behavior change: the same conditions still skip/return; only a log line is added before returning.
- The success paths (`preview sent`, `sent`) are untouched.

## Validation

```
pnpm exec vitest run tests/weekly-brief-schedule.test.ts   # passes
pnpm --filter web exec tsc --noEmit   # no new type errors in the changed file
pnpm exec prettier --check apps/web/plugins/newsletter-digest-scheduled.ts
```

No visual impact; no generated artifacts touched.