### PR TITLE
docs(mcp): align the plan doc and package README with the live tool surface

### DIFF
--- a/docs/registry-mcp-plan.md
+++ b/docs/registry-mcp-plan.md
@@ -22,41 +22,72 @@ artifact directory.
 
 ## Tools
 
-- `search_registry`
-- `server_info`
-- `list_category_entries`
-- `get_recent_updates`
-- `get_related_entries`
-- `get_entry_detail`
-- `get_copyable_asset`
-- `compare_entries`
-- `get_registry_stats`
-- `get_client_setup`
-- `get_compatibility`
-- `get_install_guidance`
-- `get_platform_adapter`
-- `list_distribution_feeds`
-- `get_submission_schema`
-- `validate_submission_draft`
-- `search_duplicate_entries`
-- `build_submission_urls`
-- `get_category_submission_guidance`
-- `prepare_submission_draft`
-- `get_submission_examples`
-- `review_submission_draft`
+These names come from `packages/mcp/src/registry-tools-lib.js`
+(`READ_ONLY_TOOL_NAMES` / `TOOL_DEFINITIONS`), which is the source of truth.
+
+### registry
+
+- `registry.search`
+- `registry.plan`
+- `registry.recommend`
+- `registry.info`
+- `registry.list`
+- `registry.updates`
+- `registry.stats`
+- `registry.feeds`
+
+### entry
+
+- `entry.related`
+- `entry.detail`
+- `entry.asset`
+- `entry.compare`
+- `entry.trust`
+- `entry.safety`
+- `entry.coverage`
+
+### install
+
+- `install.setup`
+- `install.compatibility`
+- `install.guidance`
+- `install.adapter`
+
+### submission
+
+- `submission.schema`
+- `submission.validate`
+- `submission.duplicates`
+- `submission.urls`
+- `submission.guidance`
+- `submission.prepare`
+- `submission.examples`
+- `submission.review`
+- `submission.policy`
 
 ## Resources
 
-- `heyclaude://feeds/directory`
-- `heyclaude://category/{category}`
+From `packages/mcp/src/registry-resource-metadata-lib.js`.
+
+Discovery resources:
+
+- `heyclaude://registry/recent`
+- `heyclaude://registry/trending`
+- `heyclaude://jobs/active`
+
+Resource templates:
+
 - `heyclaude://entry/{category}/{slug}`
+- `heyclaude://category/{category}`
 
 ## Prompts
 
-- `find_best_asset`
-- `prepare_submission`
-- `review_submission_before_pr`
-- `install_asset_safely`
+From `packages/mcp/src/registry-prompts-lib.js`.
+
+- `asset.find`
+- `submission.prepare`
+- `submission.review`
+- `install.asset`
 
 ## Access and rate limits
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -34,8 +34,10 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
   the best-match entries for a plain-language task, each with why it fits, a
   trust summary, safety/privacy notes, and an inline install block, plus a
   `topPick` and consolidated `installPlan`.
-- `server.info` - fetch package version, registry generation, tool list,
+- `registry.info` - fetch package version, registry generation, tool list,
   public access policy, and rate-limit metadata.
+- `registry.plan` - assemble a workflow toolbox for a stated goal, returning
+  the entries that fit it with a consolidated install plan.
 - `registry.list` - browse entries with bounded pagination and optional
   category, platform, tag, and query filters.
 - `registry.updates` - list recently added or upstream-updated entries from
@@ -62,7 +64,7 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
   guidance.
 - `install.adapter` - fetch generated adapter content, currently Cursor
   rule adapters for skill packages.
-- `feeds.list` - discover public JSON, RSS, Atom, and platform
+- `registry.feeds` - discover public JSON, RSS, Atom, and platform
   feeds.
 - `submission.schema` - fetch category submission fields for PR-first
   intake.
@@ -98,7 +100,9 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
 
 The server also exposes read-only MCP resources:
 
-- `heyclaude://feeds/directory`
+- `heyclaude://registry/recent`
+- `heyclaude://registry/trending`
+- `heyclaude://jobs/active`
 - `heyclaude://category/{category}`
 - `heyclaude://entry/{category}/{slug}`
 


### PR DESCRIPTION
Closes #5261

Supersedes #5381, which was closed on a **correct** review finding: my regenerated plan-doc list conflicted with `packages/mcp/README.md`. The reviewer was right that two documents disagreed — but the README is the one that was wrong. This PR fixes both, so nothing conflicts.

## What was stale

`docs/registry-mcp-plan.md` — 21 snake_case tools, 3 resources, 4 prompts. **Not one name still exists.** It predates the rename to dot-namespaced tool ids and a resource/prompt reshuffle.

`packages/mcp/README.md` — drifted the same way, less far:

| README said | source has |
|---|---|
| `server.info` | `registry.info` |
| `feeds.list` | `registry.feeds` |
| *(absent)* | `registry.plan` |
| `heyclaude://feeds/directory` | `heyclaude://registry/recent`, `heyclaude://registry/trending`, `heyclaude://jobs/active` |

The README's prompt names (`asset.find`, `install.asset`, …) were already correct and are untouched.

## How

Both lists are generated **programmatically from the source modules**, not transcribed — hand-copying 37 names is precisely how these two documents drifted apart in the first place. Each list now names the file it came from, so the next divergence is visible in review:

- tools -> `packages/mcp/src/registry-tools-lib.js` (`READ_ONLY_TOOL_NAMES` / `TOOL_DEFINITIONS`)
- resources -> `packages/mcp/src/registry-resource-metadata-lib.js`
- prompts -> `packages/mcp/src/registry-prompts-lib.js`

In the plan doc the 28 tools are grouped by namespace (`registry`, `entry`, `install`, `submission`). The README keeps its existing one-line-description-per-tool format; only the three wrong entries changed, plus the new `registry.plan` line.

## Verification

Set-compared **both** committed files against the live exports:

```
plan doc: 37 source names, missing=none
README:   37 source names, missing=none
tools in README not in source: none
tools in source not in README: none
```

That covers all 28 tools, 3 discovery resources, 2 resource templates, and 4 prompts, in both documents — which is exactly the conflict #5381 was closed for.

## Scope

Plan doc: only the Tools/Resources/Prompts lists; rate limits, CLI commands, and everything after `## Access and rate limits` are untouched. README: only the three incorrect tool entries and the resource list. `packages/mcp/src/*.js` is not modified — it is the source of truth and out of scope per the issue.

No visual impact. Docs-only, so there is no automated check; verification is the cross-reference above. `prettier --check` passes on both files and `validate-codebase-clean.mjs` output is byte-identical to baseline.
