### PR TITLE
fix(web): flag admin job rows that are active but not publicly visible

### DIFF
--- a/apps/web/src/lib/job-admin-lib.ts
+++ b/apps/web/src/lib/job-admin-lib.ts
@@ -231,10 +231,25 @@ export async function getJobsHealth(db: D1DatabaseLike) {
   };
 }
 
+/** An admin job row plus whether it would currently pass the public list's gate. */
+export type AdminJobListing = JobListing & { publiclyVisible: boolean };
+
+/**
+ * Whether a job would be visible on the public `/jobs` list right now, mirroring
+ * `queryActiveJobs`'s gate exactly: status `active`, not past its `expiresAt`,
+ * and passing `validateJobPublicExposure`. Lets the admin list flag rows that are
+ * "active" in the table but silently hidden from the public site.
+ */
+export function isJobPubliclyVisible(job: JobListing, now: number = Date.now()): boolean {
+  if (job.status !== "active") return false;
+  if (job.expiresAt && new Date(job.expiresAt).getTime() < now) return false;
+  return validateJobPublicExposure(job as Record<string, unknown>).ok;
+}
+
 export async function queryAdminJobs(
   db: D1DatabaseLike,
   filters: JobAdminListFilters = {},
-): Promise<JobListing[]> {
+): Promise<AdminJobListing[]> {
   const where: string[] = [];
   const values: unknown[] = [];
 
@@ -272,7 +287,10 @@ export async function queryAdminJobs(
     .bind(...values, limit, offset)
     .all<JobAdminRow>();
 
-  return results.map((row) => mapJobListingRow(row));
+  return results.map((row) => {
+    const job = mapJobListingRow(row);
+    return { ...job, publiclyVisible: isJobPubliclyVisible(job) };
+  });
 }
 
 export async function queryAdminJobBySlug(

--- a/tests/job-admin-lib.test.ts
+++ b/tests/job-admin-lib.test.ts
@@ -447,6 +447,46 @@ describe("queryAdminJobs", () => {
     expect(db.allCalls.at(-1)?.values.slice(-2)).toEqual([50, 0]);
   });
 
+  it("flags each row's public visibility via the active/expiry/exposure gate", async () => {
+    const db = new FakeD1();
+    db.jobRows = [
+      // active, far-future expiry, fully valid -> visible on /jobs.
+      validActiveJobRow({
+        slug: "visible",
+        status: "active",
+        expires_at: "2099-01-01",
+      }),
+      // active but past its expiry -> hidden on /jobs (the exact case an admin
+      // otherwise couldn't distinguish from a live "active" row).
+      validActiveJobRow({
+        slug: "expired",
+        status: "active",
+        expires_at: "2000-01-01",
+      }),
+      // not active at all.
+      validActiveJobRow({
+        slug: "pending",
+        status: "pending_review",
+        expires_at: "2099-01-01",
+      }),
+      // active + unexpired but fails the public exposure gate (no apply/source URL).
+      validActiveJobRow({
+        slug: "no-apply",
+        status: "active",
+        expires_at: "2099-01-01",
+        apply_url: "",
+        source_url: "",
+      }),
+    ];
+    const jobs = await queryAdminJobs(db);
+    const flag = (slug: string) =>
+      jobs.find((job) => job.slug === slug)?.publiclyVisible;
+    expect(flag("visible")).toBe(true);
+    expect(flag("expired")).toBe(false);
+    expect(flag("pending")).toBe(false);
+    expect(flag("no-apply")).toBe(false);
+  });
+
   it.each([
     ["status", "active", "free-curated"],
     ["tier", "featured", "featured-manual"],


### PR DESCRIPTION
Closes #5268

## Problem

`queryActiveJobs` (the public `/jobs` path) shows a job only when it's `status = 'active'` **AND** unexpired (`expires_at` null or `>= now`) **AND** passes `validateJobPublicExposure`. `queryAdminJobs` filtered on `status`/`tier`/`source`/`sourceKind` only — no expiry cutoff, no exposure gate. So an admin viewing `?status=active` saw rows that are simultaneously "active" in the table and **invisible on the public site** (already past `expires_at`, or failing the exposure quality gate — e.g. missing HTTPS apply URL), with nothing indicating the discrepancy.

## Fix

Surface the discrepancy rather than hide it from the admin (an admin needs to see the full picture). Add a computed `publiclyVisible: boolean` to each admin job row, using the **exact** gate `queryActiveJobs` uses:

```ts
export function isJobPubliclyVisible(job, now = Date.now()): boolean {
  if (job.status !== "active") return false;
  if (job.expiresAt && new Date(job.expiresAt).getTime() < now) return false;
  return validateJobPublicExposure(job).ok;
}
```

`queryAdminJobs` now returns `AdminJobListing[]` (`JobListing & { publiclyVisible }`). The admin jobs GET route already returns `entries: jobs` with no response schema, so this is additive — no contracts-lib/OpenAPI change, and existing status/tier/source filtering is untouched.

## Invariants

- The flag matches `queryActiveJobs`'s logic exactly (same `active` check, same `expires_at` comparison, same `validateJobPublicExposure` call).
- The public path (`jobs.ts` `queryActiveJobs`) and `validateJobPublicExposure` are unchanged.
- `now` is injectable for deterministic testing.

## Tests

`tests/job-admin-lib.test.ts`: a seeded set covering `active`+future-expiry (→ `true`), `active`+past-expiry (→ `false`), non-active (→ `false`), and `active`+no-apply-URL/exposure-failing (→ `false`).

## Validation

```
pnpm exec vitest run tests/job-admin-lib.test.ts tests/web-job-admin.test.ts   # 259 passed
pnpm --filter web exec tsc --noEmit   # no new type errors in changed files
pnpm exec prettier --check apps/web/src/lib/job-admin-lib.ts tests/job-admin-lib.test.ts
```

No visual impact on the public site; no generated artifacts touched.