### PR TITLE
fix(web): paginate admin listing-leads list/CSV export with an offset param

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -6687,6 +6687,12 @@
             "in": "query"
           },
           {
+            "schema": { "type": ["integer", "null"], "minimum": 0, "maximum": 10000, "default": 0 },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
             "schema": { "type": "string", "default": "" },
             "required": false,
             "name": "format",

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -7852,6 +7852,16 @@ paths:
           name: limit
           in: query
         - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            maximum: 10000
+            default: 0
+          required: false
+          name: offset
+          in: query
+        - schema:
             type: string
             default: ""
           required: false

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -682,6 +682,7 @@ export const adminListingLeadsQuerySchema = z.object({
     .optional()
     .default(""),
   limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  offset: z.coerce.number().int().min(0).max(10_000).optional().default(0),
   format: z.string().trim().toLowerCase().optional().default(""),
 });
 

--- a/apps/web/src/routes/api/admin/listing-leads.ts
+++ b/apps/web/src/routes/api/admin/listing-leads.ts
@@ -38,6 +38,7 @@ export const GET = createApiHandler(
     const kind = normalizeKind(query.kind);
     const status = normalizeCommercialStatus(query.status);
     const limit = Math.max(1, Math.min(MAX_LIMIT, Math.trunc(query.limit)));
+    const offset = Math.max(0, Math.min(10_000, Math.trunc(query.offset)));
     const format = query.format;
 
     const where = [];
@@ -71,9 +72,9 @@ export const GET = createApiHandler(
       FROM listing_leads
       ${whereSql}
       ORDER BY created_at DESC
-      LIMIT ?`,
+      LIMIT ? OFFSET ?`,
       )
-      .bind(...values, limit)
+      .bind(...values, limit, offset)
       .all();
 
     if (format === "csv") {

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -7857,6 +7857,16 @@ paths:
           name: limit
           in: query
         - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            maximum: 10000
+            default: 0
+          required: false
+          name: offset
+          in: query
+        - schema:
             type: string
             default: ""
           required: false

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -241,6 +241,17 @@ describe("OpenAPI route coverage", () => {
     expect(schema).toContain("status transition");
   });
 
+  it("paginates the admin listing-leads endpoint with an offset query param", () => {
+    expect(
+      parsedSchema.paths["/api/admin/listing-leads"]?.get?.parameters,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "limit", in: "query" }),
+        expect.objectContaining({ name: "offset", in: "query" }),
+      ]),
+    );
+  });
+
   it("documents platform-aware search and social preview generation", () => {
     expect(parsedSchema.paths["/api/registry/search"]?.get?.parameters).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
Closes #5269

## Problem

`adminListingLeadsQuerySchema` had `limit` (capped at 100) but **no `offset`**, unlike `adminJobsQuerySchema` (which has both and is paginated by `check-d1-job-sources.mjs`). Because the router's `parseRequest` uses a non-`.strict()` schema, an unrecognized `?offset=100` was silently dropped before the handler saw it. Once `listing_leads` exceeds 100 rows, every lead older than the newest 100 became permanently unreachable via both the JSON list and the CSV export — with no error or truncation indicator.

## Fix

Mirror `adminJobsQuerySchema`'s proven pagination:

- `contracts-lib.ts`: add `offset: z.coerce.number().int().min(0).max(10_000).optional().default(0)` to `adminListingLeadsQuerySchema` (identical to the jobs reference).
- `listing-leads.ts`: clamp `offset` the same way as `limit` and append `OFFSET ?` to the shared query — so it applies to **both** the JSON list and the CSV export (they run the same statement before the `format` branch).

`limit`, `MAX_LIMIT`, and existing filters are unchanged.

## Generated artifacts

Regenerated the OpenAPI spec (`pnpm generate:openapi`) so the new query param is documented; `pnpm validate:openapi` passes. The diff is limited to the `offset` parameter on `/api/admin/listing-leads` (8 lines in `openapi.json`, plus the `.yaml` mirrors).

## Tests

`tests/api-contracts.test.ts`: asserts the `/api/admin/listing-leads` GET now documents both `limit` and `offset` query params. `tests/listing-leads-csv-lib.test.ts` is unaffected (the CSV formatting is unchanged).

## Validation

```
pnpm exec vitest run tests/api-contracts.test.ts tests/listing-leads-csv-lib.test.ts   # 20 passed
pnpm validate:openapi   # passes (spec is fresh)
pnpm --filter web exec tsc --noEmit   # no new type errors in changed files
```

No visual impact.