### PR TITLE
fix(content): rename gittensory-mcp entry to loopover-mcp after project rename

### DIFF
--- a/content/mcp/loopover-mcp.mdx
+++ b/content/mcp/loopover-mcp.mdx
@@ -1,44 +1,45 @@
 ---
-title: Gittensory MCP Server for Claude
-slug: gittensory-mcp
+title: LoopOver MCP Server for Claude
+slug: loopover-mcp
 category: mcp
 description: >-
-  Gittensory MCP connects Claude and other MCP clients to private,
-  metadata-only Gittensor contribution mining workflows for branch preflight,
-  scoreability estimates, maintainer-fit checks, and public-safe PR packets.
+  LoopOver MCP connects Claude and other MCP clients to private, metadata-only
+  Gittensor contribution workflows for branch preflight, scoreability estimates,
+  maintainer-fit checks, and public-safe PR packets.
 cardDescription: >-
   MCP server for private Gittensor contribution preflight, branch metadata
   analysis, scoreability estimates, and public-safe PR packet drafting.
-seoTitle: Gittensory MCP Server for Claude
+seoTitle: LoopOver MCP Server for Claude
 seoDescription: >-
-  Connect Claude to Gittensory MCP for private Gittensor contribution mining
-  workflows, including metadata-only branch analysis, preflight blockers,
-  scoreability estimates, and public-safe PR packets.
+  Connect Claude to LoopOver MCP for private Gittensor contribution workflows,
+  including metadata-only branch analysis, preflight blockers, scoreability
+  estimates, and public-safe PR packets.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
-submittedBy: oktofeesh1
-submittedByUrl: "https://github.com/oktofeesh1"
+submittedBy: galuis116
+submittedByUrl: "https://github.com/galuis116"
 dateAdded: "2026-06-03"
-documentationUrl: "https://gittensory.aethereal.dev/docs/mcp-clients"
-repoUrl: "https://github.com/JSONbored/gittensory"
+contentUpdatedAt: "2026-07-20"
+documentationUrl: "https://loopover.ai/docs"
+repoUrl: "https://github.com/JSONbored/loopover"
 installable: true
-installCommand: "claude mcp add gittensory -- npx -y @jsonbored/gittensory-mcp@latest --stdio"
-usageSnippet: "claude mcp add gittensory -- npx -y @jsonbored/gittensory-mcp@latest --stdio"
+installCommand: "claude mcp add loopover -- npx -y @loopover/mcp@latest --stdio"
+usageSnippet: "claude mcp add loopover -- npx -y @loopover/mcp@latest --stdio"
 copySnippet: |-
   {
-    "gittensory": {
+    "loopover": {
       "command": "npx",
-      "args": ["-y", "@jsonbored/gittensory-mcp@latest", "--stdio"]
+      "args": ["-y", "@loopover/mcp@latest", "--stdio"]
     }
   }
 configSnippet: |-
   {
     "mcpServers": {
-      "gittensory": {
+      "loopover": {
         "command": "npx",
         "args": [
           "-y",
-          "@jsonbored/gittensory-mcp@latest",
+          "@loopover/mcp@latest",
           "--stdio"
         ],
         "type": "stdio"
@@ -51,10 +52,10 @@ prerequisites:
   - "Node.js and npx available (verify with: npx --version)"
   - Claude Code, Claude Desktop, Codex, Cursor, or another MCP-capable client
   - GitHub account access for the OAuth Device Flow login
-  - Network access to the Gittensory API when using login, preflight, or remote MCP
+  - Network access to the LoopOver API when using login, preflight, or remote MCP
 safetyNotes:
   - >-
-    Run Gittensory against the repository and branch you intend to analyze; the
+    Run LoopOver against the repository and branch you intend to analyze; the
     MCP is designed for branch preflight, maintainer-fit checks, and PR packet
     preparation, not broad autonomous code changes.
   - >-
@@ -69,27 +70,27 @@ safetyNotes:
     for cloud agents, but it shifts more workflow state through the hosted API.
 privacyNotes:
   - >-
-    Gittensory documents metadata-only analysis by default: source contents are
+    LoopOver documents metadata-only analysis by default: source contents are
     not uploaded during the normal MCP branch analysis flow.
   - >-
-    Authentication uses GitHub OAuth Device Flow and Gittensory session tokens;
+    Authentication uses GitHub OAuth Device Flow and LoopOver session tokens;
     the MCP does not ask users to paste or store GitHub personal access tokens.
   - >-
     Branch metadata, GitHub identity, repository context, linked issues,
     labels, validation summaries, and preflight blockers may be sent to
-    Gittensory API surfaces as part of analysis.
+    LoopOver API surfaces as part of analysis.
   - >-
     Avoid pasting secrets, wallet material, hotkeys, private source, or
     unpublished reviewability details into prompts or public PR output.
 tags:
-  - gittensory
+  - loopover
   - gittensor
   - contribution-mining
   - preflight
   - mcp
   - github
 keywords:
-  - gittensory mcp
+  - loopover mcp
   - gittensor contribution mining
   - claude mcp preflight
   - scoreability estimates
@@ -100,23 +101,23 @@ robotsFollow: true
 
 ## Content
 
-Gittensory MCP gives Claude and other MCP-capable coding agents a private
-control surface for Gittensor OSS contribution workflows. It focuses on the
-work that happens before a contributor opens or updates a PR: branch metadata
-analysis, preflight blockers, maintainer-fit context, scoreability estimates,
-queue pressure, duplicate risk, and public-safe PR packet drafting.
+LoopOver MCP gives Claude and other MCP-capable coding agents a private control
+surface for Gittensor OSS contribution workflows. It focuses on the work that
+happens before a contributor opens or updates a PR: branch metadata analysis,
+preflight blockers, maintainer-fit context, scoreability estimates, queue
+pressure, duplicate risk, and public-safe PR packet drafting.
 
-The server is published as `@jsonbored/gittensory-mcp` and is designed to run
-locally over stdio by default. Gittensory also exposes a remote MCP endpoint for
-cloud-hosted agents, but the local stdio path is the recommended starting point
-because it keeps the client process, GitHub Device Flow login, and local branch
-context on the user's machine.
+The server is published as `@loopover/mcp` (formerly `@jsonbored/gittensory-mcp`)
+and is designed to run locally over stdio by default. LoopOver also exposes a
+remote MCP endpoint for cloud-hosted agents, but the local stdio path is the
+recommended starting point because it keeps the client process, GitHub Device
+Flow login, and local branch context on the user's machine.
 
-Gittensory is built for the Gittensor ecosystem, but it is not an official
-subnet frontend and does not provide reward guarantees. Its scoreability
-language is private MCP/API context for planning and reviewability; users should
-treat those values as estimates and follow current Gittensor rules for any
-eligibility or rewards.
+LoopOver is built for the Gittensor ecosystem, but it is not an official subnet
+frontend and does not provide reward guarantees. Its scoreability language is
+private MCP/API context for planning and reviewability; users should treat those
+values as estimates and follow current Gittensor rules for any eligibility or
+rewards.
 
 ## Features
 
@@ -155,38 +156,37 @@ eligibility or rewards.
 2. Add the MCP server:
 
 ```bash
-claude mcp add gittensory -- npx -y @jsonbored/gittensory-mcp@latest --stdio
+claude mcp add loopover -- npx -y @loopover/mcp@latest --stdio
 ```
 
 3. Restart or refresh Claude Code's MCP session.
-4. Ask Claude to run a lightweight Gittensory status or doctor check.
+4. Ask Claude to run a lightweight LoopOver status or doctor check.
 
 ### Claude Desktop
 
 1. Open `claude_desktop_config.json`.
-2. Add the `gittensory` server to `mcpServers`.
+2. Add the `loopover` server to `mcpServers`.
 3. Restart Claude Desktop.
-4. Run `gittensory-mcp login` when the server asks for GitHub authentication.
+4. Run `loopover-mcp login` when the server asks for GitHub authentication.
 
 ## Configuration
 
 ```json
 {
-  "gittensory": {
+  "loopover": {
     "command": "npx",
-    "args": ["-y", "@jsonbored/gittensory-mcp@latest", "--stdio"]
+    "args": ["-y", "@loopover/mcp@latest", "--stdio"]
   }
 }
 ```
 
 ## Remote MCP
 
-For cloud agents or hosted clients that cannot run a local Node process, use the
-remote MCP endpoint documented by Gittensory:
-
-```text
-https://gittensory-api.aethereal.dev/mcp
-```
+For cloud agents or hosted clients that cannot run a local Node process, LoopOver
+also runs a hosted remote MCP surface. It requires operator-configured
+credentials rather than a plain public URL, so follow the current hosted setup in
+the [LoopOver docs](https://loopover.ai/docs) instead of pasting an endpoint
+directly.
 
 Use local stdio when possible. It is the simpler path for GitHub Device Flow
 login and keeps local branch inspection closest to the developer machine.
@@ -198,8 +198,8 @@ login and keeps local branch inspection closest to the developer machine.
 Generate client-specific config snippets before editing your agent settings.
 
 ```bash
-npx -y @jsonbored/gittensory-mcp@latest init-client --print claude
-npx -y @jsonbored/gittensory-mcp@latest init-client --print codex
+npx -y @loopover/mcp@latest init-client --print claude
+npx -y @loopover/mcp@latest init-client --print codex
 ```
 
 ### Sign in and check local readiness
@@ -208,35 +208,26 @@ Authenticate with GitHub Device Flow, then confirm the local MCP wrapper is
 ready.
 
 ```bash
-gittensory-mcp login
-gittensory-mcp whoami
-gittensory-mcp doctor
+loopover-mcp login
+loopover-mcp whoami
+loopover-mcp doctor
 ```
 
 ### Analyze the current branch
 
-Ask Gittensory for metadata-only branch context before opening or updating a PR.
+Ask LoopOver for metadata-only branch context before opening or updating a PR.
 
 ```bash
-gittensory-mcp analyze-branch --login your-login --json
-gittensory-mcp preflight --login your-login --json
-```
-
-### Draft a public-safe PR packet
-
-Create maintainer-facing PR text that avoids private scoreability and reward
-claims.
-
-```bash
-gittensory-mcp agent packet --json
+loopover-mcp agent plan --login your-login --json
+loopover-mcp agent packet --login your-login --json
 ```
 
 ## Security
 
-- Gittensory's normal MCP analysis path is metadata-only by default; do not
-  paste source code, credentials, wallet material, or private maintainer notes
-  into prompts unless you intend to expose them to your active agent context.
-- The CLI uses GitHub OAuth Device Flow and Gittensory session tokens, not raw
+- LoopOver's normal MCP analysis path is metadata-only by default; do not paste
+  source code, credentials, wallet material, or private maintainer notes into
+  prompts unless you intend to expose them to your active agent context.
+- The CLI uses GitHub OAuth Device Flow and LoopOver session tokens, not raw
   GitHub personal access token prompts.
 - Scoreability values are private estimates for planning and prioritization.
   They should not be copied into public GitHub comments, PR descriptions, or
@@ -249,20 +240,19 @@ gittensory-mcp agent packet --json
 ### `npx` cannot resolve the package
 
 Confirm Node.js and npm are installed, then retry with the explicit package
-name: `npx -y @jsonbored/gittensory-mcp@latest --help`.
+name: `npx -y @loopover/mcp@latest --help`.
 
 ### Authentication does not complete
 
-Run `gittensory-mcp login` again and complete the GitHub Device Flow in the
-browser. Then verify the session with `gittensory-mcp whoami`.
+Run `loopover-mcp login` again and complete the GitHub Device Flow in the
+browser. Then verify the session with `loopover-mcp whoami`.
 
 ### Claude cannot see the MCP server
 
-Check that the config uses the `npx` command and includes
-`@jsonbored/gittensory-mcp@latest` plus `--stdio`. Restart the MCP client after
-editing configuration.
+Check that the config uses the `npx` command and includes `@loopover/mcp@latest`
+plus `--stdio`. Restart the MCP client after editing configuration.
 
 ### The branch analysis looks stale
 
 Fetch the target repository, confirm the active branch is the branch you want to
-analyze, and rerun `gittensory-mcp analyze-branch --login your-login --json`.
+analyze, and rerun `loopover-mcp agent plan --login your-login --json`.


### PR DESCRIPTION
Closes #5236

Supersedes #5384, closed on two **valid** review findings — both now fixed. CI was green on #5384 (`validate:content:strict` passing); these were correctness catches, not gate/flake noise.

1. **`direct_pr_submitter_mismatch`** — `validate-submission-source` requires a direct content PR's `submittedBy` to equal the PR author. I'd preserved the original `oktofeesh1`, but this edit is opened by `galuis116`, so `submittedBy`/`submittedByUrl` are now `galuis116`. `author: JSONbored` (the actual tool author) is unchanged; oktofeesh1 remains in git history.
2. **Misleading Remote MCP code block** — I'd put `https://loopover.ai/docs` inside a ```` ```text ```` fence in the Remote MCP section, where the original had a literal endpoint. Fenced that way it reads as if the docs URL *were* the endpoint. It's now an inline markdown link in prose, with no code fence presenting a URL as an endpoint.

## What

The Gittensory project was renamed to **LoopOver** (repo, package, domain, CLI all changed). The existing `content/mcp/gittensory-mcp.mdx` pointed at resources that no longer resolve. This renames it to `loopover-mcp.mdx` and re-points every value at the current product.

## Every value changed — old vs new, each verified live

| field | old | new | check |
|---|---|---|---|
| package | `@jsonbored/gittensory-mcp` | `@loopover/mcp` | `npm view @loopover/mcp version` -> **3.2.3** |
| CLI / bin | `gittensory-mcp` | `loopover-mcp` | npm `bin` -> `loopover-mcp` |
| server key | `gittensory` | `loopover` | — |
| `repoUrl` | `github.com/JSONbored/gittensory` | `github.com/JSONbored/loopover` | **HTTP 200** |
| `documentationUrl` | `gittensory.aethereal.dev/docs/mcp-clients` (retired) | `loopover.ai/docs` | **HTTP 200** |
| install / usage / config | `@jsonbored/gittensory-mcp@latest`, `gittensory` key | `@loopover/mcp@latest`, `loopover` key | package resolves on npm |
| title / slug / seo / tags / keywords | Gittensory | LoopOver / `loopover-mcp` | — |
| example commands | `gittensory-mcp login/doctor/agent packet` | `loopover-mcp ...` | match the LoopOver README's documented CLI |

Note on the docs URL: the README links `loopover.ai/docs/mcp-clients`, but that subpage currently returns HTTP 500 (checked repeatedly; `loopover.ai/docs` returns 200), so the entry uses the working docs index. Worth swapping back once the subpage is fixed.

## Scope

- One file: `gittensory-mcp.mdx` -> `loopover-mcp.mdx` (`git mv` + rewrite).
- `@jsonbored/gittensory-mcp` kept once as a "(formerly …)" note for discoverability.
- Other `gittensory`/`aethereal.dev` hits are generated artifacts (`content-audit.json`, `atlas-registry.json` — regenerated by the maintainer build) and the unrelated `tasty.aethereal.dev` umami config; none touched.

## Validation

- `pnpm validate:content:strict` — the entry validates; the run's only failure is `mcp/desktop-mcp-setup.mdx` (missing recommended fields), identical on unmodified `main` and unrelated.
- `node scripts/validate-codebase-clean.mjs` — byte-identical to baseline.

No visual impact beyond the entry's own rendered page.
