### PR TITLE
fix(web): stop marking slug download URLs immutable

### DIFF
--- a/apps/web/src/lib/download-asset-lib.ts
+++ b/apps/web/src/lib/download-asset-lib.ts
@@ -2,6 +2,17 @@
 // against the allowlist, resolve its content type, and derive a filename. Split
 // out of the route so the guards/mappings can be unit-tested without the handler.
 
+/**
+ * Cache policy for `/api/download` responses.
+ *
+ * Local package URLs are slug-addressed (`/downloads/skills/<slug>.zip`), not
+ * content-addressed, and rebuilds can replace bytes under the same path when
+ * `downloadSha256` changes. Keep a long edge TTL for unchanged artifacts, but
+ * never mark the response `immutable` — that would pin stale bytes for a year.
+ */
+export const DOWNLOAD_CACHE_CONTROL =
+  "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000";
+
 /** True only for allow-listed skill (.zip) and mcp (.mcpb) download paths. */
 export function isAllowedAssetPath(asset: string): boolean {
   const normalized = String(asset || "").trim();

--- a/apps/web/src/routes/api/download.ts
+++ b/apps/web/src/routes/api/download.ts
@@ -4,7 +4,12 @@ import { downloadQuerySchema } from "@/lib/api/contracts";
 import { apiError, createApiHandler, type InferApiQuery } from "@/lib/api/router";
 import { logApiError, logApiInfo, logApiWarn, sample } from "@/lib/api-logs";
 import { readDownloadAsset } from "@/lib/download-assets.server";
-import { filenameFromAsset, getContentType, isAllowedAssetPath } from "@/lib/download-asset-lib";
+import {
+  filenameFromAsset,
+  getContentType,
+  isAllowedAssetPath,
+  DOWNLOAD_CACHE_CONTROL,
+} from "@/lib/download-asset-lib";
 
 export const GET = createApiHandler("download", async ({ request, query, requestId }) => {
   const { asset } = query as InferApiQuery<typeof downloadQuerySchema>;
@@ -31,7 +36,7 @@ export const GET = createApiHandler("download", async ({ request, query, request
       headers: {
         "content-type": getContentType(asset),
         "content-disposition": `attachment; filename="${filename}"`,
-        "cache-control": "public, max-age=31536000, immutable",
+        "cache-control": DOWNLOAD_CACHE_CONTROL,
         "x-content-type-options": "nosniff",
       },
     });

--- a/tests/download-asset-lib.test.ts
+++ b/tests/download-asset-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DOWNLOAD_CACHE_CONTROL,
   filenameFromAsset,
   getContentType,
   isAllowedAssetPath,
@@ -41,5 +42,15 @@ describe("filenameFromAsset", () => {
   it("falls back to 'download' when there is no segment", () => {
     expect(filenameFromAsset("///")).toBe("download");
     expect(filenameFromAsset("")).toBe("download");
+  });
+});
+
+describe("DOWNLOAD_CACHE_CONTROL", () => {
+  it("keeps long-lived caching without immutable pinning", () => {
+    expect(DOWNLOAD_CACHE_CONTROL).toContain("max-age=");
+    expect(DOWNLOAD_CACHE_CONTROL).toContain("s-maxage=");
+    expect(DOWNLOAD_CACHE_CONTROL).toContain("stale-while-revalidate=");
+    expect(DOWNLOAD_CACHE_CONTROL).not.toContain("immutable");
+    expect(DOWNLOAD_CACHE_CONTROL).not.toContain("31536000");
   });
 });


### PR DESCRIPTION
## Summary
- Drop `immutable` / 1-year `max-age` from `/api/download` responses.
- Use a revalidatable long TTL: browser 1d, edge 7d, SWR 30d.
- Document why in `DOWNLOAD_CACHE_CONTROL` (slug paths are not content-addressed).

Closes #5244

## Decision (option b)
Package URLs are `/downloads/skills/<slug>.zip` / `/downloads/mcp/<slug>.mcpb` with a separately published `downloadSha256`. Rebuilds can replace bytes under the same slug path when the checksum changes. Content-addressing (option a) would require URL/format changes across clients and indexes; adjusting cache headers is the correct small fix.

## Submission Source
- [x] Not a direct content submission.
- [x] Screenshot evidence included below (no rendered UI change; production before/after identical).
- [x] Linked issue: #5244.

## Quality Evidence
- Changed: `download.ts`, `download-asset-lib.ts`, tests.
- Expected: unchanged packages still cache well; republished same-slug packages are not pinned for a year as immutable.
- No rendered page/component/CSS change. Cache-Control header only.

### UI Evidence (required matrix)
No visible UI delta — before and after are production homepage captures (identical) for the required viewport × theme pairs:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | [before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) | [after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) |
| Desktop · Dark | [before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) | [after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) |
| Tablet · Light | [before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) | [after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) |
| Tablet · Dark | [before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) | [after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) |
| Mobile · Light | [before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) | [after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) |
| Mobile · Dark | [before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) | [after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) |

## Validation
- [x] `pnpm exec vitest run tests/download-asset-lib.test.ts`
- [ ] CI green (draft until green)