### PR TITLE
fix(web): detect listing-leads status lost-update races

### DIFF
--- a/apps/web/src/routes/api/admin/listing-leads.ts
+++ b/apps/web/src/routes/api/admin/listing-leads.ts
@@ -132,10 +132,23 @@ export const PATCH = createApiHandler(
       return apiError("invalid_transition", 400, { requestId });
     }
 
-    await db
-      .prepare("UPDATE listing_leads SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?")
-      .bind(nextStatus, id)
+    // Condition the write on the status we just read so a concurrent PATCH
+    // cannot silently overwrite a different transition (lost-update race).
+    const result = await db
+      .prepare(
+        "UPDATE listing_leads SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?",
+      )
+      .bind(nextStatus, id, current.status)
       .run();
+
+    if (Number(result.meta?.changes ?? 0) === 0) {
+      logApiWarn(request, "admin.listing_leads.status_conflict", {
+        id,
+        from: current.status,
+        attempted: nextStatus,
+      });
+      return apiError("conflict", 409, { requestId });
+    }
 
     logApiInfo(request, "admin.listing_leads.status_updated", {
       id,

--- a/tests/admin-listing-leads-conflict.test.ts
+++ b/tests/admin-listing-leads-conflict.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSiteDbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  getSiteDb: getSiteDbMock,
+}));
+
+function patchRequest(body: Record<string, unknown>) {
+  return new Request("https://heyclau.de/api/admin/listing-leads", {
+    method: "PATCH",
+    headers: {
+      "content-type": "application/json",
+      origin: "https://heyclau.de",
+      authorization: "Bearer leads-admin-token",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockDb(options: {
+  currentStatus: string;
+  updateChanges: number;
+  updateBinds?: unknown[][];
+}) {
+  const updateBinds = options.updateBinds ?? [];
+  return {
+    prepare: (sql: string) => ({
+      bind: (...values: unknown[]) => {
+        if (sql.startsWith("SELECT")) {
+          return {
+            first: async () => ({ id: 42, status: options.currentStatus }),
+          };
+        }
+        updateBinds.push(values);
+        return {
+          run: async () => ({
+            success: true,
+            meta: { changes: options.updateChanges },
+          }),
+        };
+      },
+    }),
+  };
+}
+
+describe("PATCH /api/admin/listing-leads concurrency", () => {
+  beforeEach(() => {
+    getSiteDbMock.mockReset();
+    vi.stubEnv("LEADS_ADMIN_TOKEN", "leads-admin-token");
+  });
+
+  it("conditions the UPDATE on the read status and succeeds when unchanged", async () => {
+    const updateBinds: unknown[][] = [];
+    getSiteDbMock.mockReturnValue(
+      mockDb({
+        currentStatus: "pending_review",
+        updateChanges: 1,
+        updateBinds,
+      }),
+    );
+
+    const { PATCH } = await import("@/routes/api/admin/listing-leads");
+    const response = await PATCH(patchRequest({ id: 42, action: "approve" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      id: 42,
+      status: "approved",
+    });
+    expect(updateBinds).toEqual([["approved", 42, "pending_review"]]);
+  });
+
+  it("returns 409 when a concurrent write changed status between read and update", async () => {
+    getSiteDbMock.mockReturnValue(
+      mockDb({
+        currentStatus: "pending_review",
+        updateChanges: 0,
+      }),
+    );
+
+    const { PATCH } = await import("@/routes/api/admin/listing-leads");
+    const response = await PATCH(patchRequest({ id: 42, action: "reject" }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "conflict" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Condition the admin listing-leads status `UPDATE` on the previously read `status` (`WHERE id = ? AND status = ?`).
- Return `409 conflict` when `meta.changes === 0`.
- Emit `admin.listing_leads.status_conflict` instead of a success audit on conflict.

Closes #5267

## Quality Evidence
- No rendered UI/CSS/page change (admin API concurrency only).
- Reland of #5388 after LoopOver approved then auto-closed for screenshot matrix formatting.

### UI Evidence

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![Desktop · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) | ![Desktop · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) |
| Desktop · Dark | ![Desktop · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) | ![Desktop · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) |
| Tablet · Light | ![Tablet · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) | ![Tablet · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) |
| Tablet · Dark | ![Tablet · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) | ![Tablet · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) |
| Mobile · Light | ![Mobile · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) | ![Mobile · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) |
| Mobile · Dark | ![Mobile · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) | ![Mobile · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) |

Before and after are identical production captures because this PR has no visible UI delta.

## Validation
- [x] `pnpm exec vitest run tests/admin-listing-leads-conflict.test.ts`
- [ ] CI green (draft until green; empty commit retriggers coverage after unrelated registry-artifacts 180s timeout)