### PR TITLE
fix(registry): generate Raycast copyText preview fields

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -99,6 +99,24 @@ function raycastPackageTrust(entry) {
   return "no package download";
 }
 
+function buildRaycastCopyFields(entry, { preview = false } = {}) {
+  const full = String(getCopyText(entry) || "").trim();
+  if (!full) return {};
+
+  if (!preview) {
+    return {
+      copyText: full,
+      copyTextTruncated: false,
+    };
+  }
+
+  const copyText = truncateText(full, RAYCAST_COPY_PREVIEW_LIMIT);
+  return {
+    copyText,
+    copyTextTruncated: full.length > RAYCAST_COPY_PREVIEW_LIMIT,
+  };
+}
+
 function pushRaycastTrustSection(lines, entry) {
   const source =
     entry.repoUrl || entry.documentationUrl
@@ -918,6 +936,7 @@ export function buildRaycastEntries(entries) {
       downloadTrust: entry.downloadTrust,
       verificationStatus: entry.verificationStatus || "",
       ...buildCompactInstallFields(entry),
+      ...buildRaycastCopyFields(entry, { preview: true }),
       platformCompatibility:
         entry.category === "skills"
           ? buildSkillPlatformCompatibility(entry)
@@ -979,6 +998,7 @@ export function buildRaycastDetail(entry) {
     packageVerified: Boolean(entry.packageVerified),
     trustSignals: buildEntryTrustSignals(entry),
     ...buildRaycastInstallDetailFields(entry),
+    ...buildRaycastCopyFields(entry, { preview: false }),
   };
 }
 

--- a/scripts/validate-raycast-feed.mjs
+++ b/scripts/validate-raycast-feed.mjs
@@ -253,6 +253,7 @@ for (const entry of payload.entries) {
   if (
     entry.copyText !== undefined &&
     entry.copyTextTruncated &&
+    typeof detail.copyText === "string" &&
     detail.copyText.length <= String(entry.copyText ?? "").length
   ) {
     fail(`${key}: truncated feed entry must have longer detail copyText`);

--- a/tests/artifacts-lib.test.ts
+++ b/tests/artifacts-lib.test.ts
@@ -781,6 +781,13 @@ describe("buildRaycastDetail", () => {
     expect(detail.safetyNotes).toEqual(FIXTURE_MCP.safetyNotes);
     expect(detail.privacyNotes).toEqual(FIXTURE_MCP.privacyNotes);
   });
+
+  it("includes full copyText for detail payloads", () => {
+    const detail = buildRaycastDetail(FIXTURE_MCP);
+    expect(typeof detail.copyText).toBe("string");
+    expect(detail.copyText?.length).toBeGreaterThan(0);
+    expect(detail.copyTextTruncated).toBe(false);
+  });
 });
 
 describe("buildRaycastEntries", () => {
@@ -801,6 +808,41 @@ describe("buildRaycastEntries", () => {
     );
     expect(mcpRow?.platformCompatibility).toEqual(
       buildEntryTrustSignals(FIXTURE_MCP).platforms,
+    );
+  });
+
+  it("includes preview-capped copyText on feed rows", () => {
+    const longBody = "x".repeat(RAYCAST_COPY_PREVIEW_LIMIT + 50);
+    const row = buildRaycastEntries([
+      {
+        ...FIXTURE_MCP,
+        body: longBody,
+        installCommand: "",
+        configSnippet: "",
+        copySnippet: "",
+        usageSnippet: "",
+        documentationUrl: "",
+        repoUrl: "",
+      },
+    ])[0];
+    const detail = buildRaycastDetail({
+      ...FIXTURE_MCP,
+      body: longBody,
+      installCommand: "",
+      configSnippet: "",
+      copySnippet: "",
+      usageSnippet: "",
+      documentationUrl: "",
+      repoUrl: "",
+    });
+
+    expect(row?.copyText).toBeDefined();
+    expect(String(row?.copyText).length).toBeLessThanOrEqual(
+      RAYCAST_COPY_PREVIEW_LIMIT,
+    );
+    expect(row?.copyTextTruncated).toBe(true);
+    expect(detail.copyText?.length).toBeGreaterThan(
+      String(row?.copyText ?? "").length,
     );
   });
 });

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -255,7 +255,7 @@ describe("registry artifacts", () => {
     // These budgets are growth guards, not fixed caps. The public registry
     // grows with curated content, so keep them per-entry to catch runaway
     // artifact bloat without failing every normal catalog expansion.
-    expect(artifactTreeSize(".")).toBeLessThan(2_000_000 + entryCount * 38_500);
+    expect(artifactTreeSize(".")).toBeLessThan(2_000_000 + entryCount * 41_500);
     expect(artifactSize("directory-index.json")).toBeLessThan(
       200_000 + entryCount * 2_150,
     );
@@ -263,7 +263,7 @@ describe("registry artifacts", () => {
       125_000 + entryCount * 1_600,
     );
     expect(artifactSize("raycast-index.json")).toBeLessThan(
-      100_000 + entryCount * 1_100,
+      100_000 + entryCount * 1_900,
     );
     expect(artifactSize("relation-graph.json")).toBeLessThan(
       150_000 + entryCount * 1_500,
@@ -1390,14 +1390,30 @@ Use this hook after reviewing the notes.`,
         key,
         llmsUrl: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
       });
-      expect(raycastDetail).not.toHaveProperty("copyText");
+      const fullCopyText = getCopyText(entry).trim();
+      if (fullCopyText) {
+        expect(raycastDetail.copyText).toBe(fullCopyText);
+        expect(raycastDetail.copyTextTruncated).toBe(false);
+        expect(typeof raycastFeedEntry.copyText).toBe("string");
+        expect(String(raycastFeedEntry.copyText).length).toBeLessThanOrEqual(
+          RAYCAST_COPY_PREVIEW_LIMIT,
+        );
+        expect(typeof raycastFeedEntry.copyTextTruncated).toBe("boolean");
+        if (raycastFeedEntry.copyTextTruncated) {
+          expect(String(raycastDetail.copyText).length).toBeGreaterThan(
+            String(raycastFeedEntry.copyText).length,
+          );
+        }
+      } else {
+        expect(raycastDetail).not.toHaveProperty("copyText");
+        expect(raycastFeedEntry).not.toHaveProperty("copyText");
+        expect(raycastFeedEntry).not.toHaveProperty("copyTextTruncated");
+      }
       expect(raycastFeedEntry.canonicalUrl).toBe(
         `https://heyclau.de/entry/${entry.category}/${entry.slug}`,
       );
       expect(raycastFeedEntry).not.toHaveProperty("llmsUrl");
-      expect(raycastFeedEntry).not.toHaveProperty("copyText");
       expect(raycastFeedEntry).not.toHaveProperty("copyTextLength");
-      expect(raycastFeedEntry).not.toHaveProperty("copyTextTruncated");
       expect(raycastFeedEntry).not.toHaveProperty("detailMarkdown");
     }
     expect(fs.existsSync(path.join(dataRoot, "llms"))).toBe(false);


### PR DESCRIPTION
## Summary
- ``buildRaycastEntries`` / ``buildRaycastDetail`` now emit ``copyText`` / ``copyTextTruncated`` via ``getCopyText`` + ``RAYCAST_COPY_PREVIEW_LIMIT``.
- Feed rows are preview-capped; detail payloads keep the full copy text.
- ``validate-raycast-feed.mjs`` guards the truncated-feed check so a missing ``detail.copyText`` cannot throw.

Closes #5226

## Quality Evidence
- Sample (unit fixture): feed ``copyText`` length ≤ 800 with ``copyTextTruncated: true`` when source copy exceeds the preview cap; detail ``copyText`` is longer and untruncated.
- Generated ``apps/web/public/data/raycast*`` artifacts are left for maintainer regeneration (source builder + validator + tests only).
- **No visual impact.** ``packages/registry`` + ``scripts`` + tests only — no ``apps/web`` route/UI/OpenAPI changes.

## Validation
- [x] ``pnpm exec vitest run tests/artifacts-lib.test.ts``
- [x] ``pnpm run validate:raycast-feed`` (against current committed feed; new fields appear on next artifact regen)
- [ ] CI green (draft until green)

Made with [Cursor](https://cursor.com)