### PR TITLE
fix(web): rate-limit public npm proxy via Cloudflare binding

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -10045,6 +10045,259 @@
         }
       }
     },
+    "/api/public/npm/{pkg}": {
+      "get": {
+        "tags": ["Dynamic"],
+        "summary": "Read cached npm package metadata",
+        "description": "Proxies npm registry latest metadata and weekly downloads for a package name. Uses the shared dynamic Cloudflare rate-limit binding before any upstream fetch.",
+        "responses": {
+          "200": {
+            "description": "Request accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" },
+                    "version": { "type": "string" },
+                    "publishedAt": { "type": ["string", "null"] },
+                    "weeklyDownloads": { "type": ["number", "null"] },
+                    "homepage": { "type": ["string", "null"] },
+                    "repository": { "type": ["string", "null"] },
+                    "fetchedAt": { "type": "string" }
+                  },
+                  "required": [
+                    "name",
+                    "version",
+                    "publishedAt",
+                    "weeklyDownloads",
+                    "homepage",
+                    "repository",
+                    "fetchedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON, invalid query, invalid payload, or invalid status transition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin token or invalid webhook signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden origin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload too large.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Invalid content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Route-level or Cloudflare-native rate limited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream provider error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Site DB not configured, provider not configured, or endpoint unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/og": {
       "get": {
         "tags": ["Distribution"],

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -11688,6 +11688,295 @@ paths:
                 required:
                   - ok
                   - error
+  /api/public/npm/{pkg}:
+    get:
+      tags:
+        - Dynamic
+      summary: Read cached npm package metadata
+      description:
+        Proxies npm registry latest metadata and weekly downloads for a package name. Uses the
+        shared dynamic Cloudflare rate-limit binding before any upstream fetch.
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  version:
+                    type: string
+                  publishedAt:
+                    type:
+                      - string
+                      - "null"
+                  weeklyDownloads:
+                    type:
+                      - number
+                      - "null"
+                  homepage:
+                    type:
+                      - string
+                      - "null"
+                  repository:
+                    type:
+                      - string
+                      - "null"
+                  fetchedAt:
+                    type: string
+                required:
+                  - name
+                  - version
+                  - publishedAt
+                  - weeklyDownloads
+                  - homepage
+                  - repository
+                  - fetchedAt
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/og:
     get:
       tags:

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -80,6 +80,7 @@ function exampleForPathParam(name: string, path: string) {
   if (name === "kind") return "icon";
   if (name === "domain") return "anthropic.com";
   if (name === "report") return "agent-skills.json";
+  if (name === "pkg") return "@heyclaude/mcp";
   return "example";
 }
 
@@ -425,6 +426,15 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
   "githubStats.read": { ok: true, repo: "jsonbored/awesome-claude", stars: 123 },
   "publicAlerts.read": { ok: true, events: [] },
   "publicFeeds.health": { ok: true, feeds: [] },
+  "publicNpm.read": {
+    name: "@heyclaude/mcp",
+    version: "1.0.0",
+    publishedAt: "2026-01-01T00:00:00.000Z",
+    weeklyDownloads: 123,
+    homepage: "https://heyclau.de",
+    repository: "git+https://github.com/JSONbored/awesome-claude.git",
+    fetchedAt: "2026-07-16T00:00:00.000Z",
+  },
   "static.rss": "RSS XML response.",
   "static.atom": "Atom XML response.",
   "static.feedIndex": { schemaVersion: 1, feeds: [] },

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -661,6 +661,16 @@ export const publicFeedsHealthResponseSchema = z.object({
     .max(100),
 });
 
+export const publicNpmMetaResponseSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  publishedAt: z.string().nullable(),
+  weeklyDownloads: z.number().nullable(),
+  homepage: z.string().nullable(),
+  repository: z.string().nullable(),
+  fetchedAt: z.string(),
+});
+
 export const listingLeadBodySchema = z
   .object({
     kind: z.enum(["job", "tool", "claim"]),
@@ -1453,6 +1463,22 @@ export const apiRouteDefinitions = {
     responseSchema: publicFeedsHealthResponseSchema,
     rateLimit: {
       scope: "public-feeds-health",
+      limit: 120,
+      windowMs: 60_000,
+      binding: "API_DYNAMIC_RATE_LIMIT",
+    },
+  }),
+  "publicNpm.read": route({
+    id: "publicNpm.read",
+    method: "GET",
+    path: "/api/public/npm/{pkg}",
+    summary: "Read cached npm package metadata",
+    description:
+      "Proxies npm registry latest metadata and weekly downloads for a package name. Uses the shared dynamic Cloudflare rate-limit binding before any upstream fetch.",
+    tags: ["Dynamic"],
+    responseSchema: publicNpmMetaResponseSchema,
+    rateLimit: {
+      scope: "public-npm",
       limit: 120,
       windowMs: 60_000,
       binding: "API_DYNAMIC_RATE_LIMIT",

--- a/apps/web/src/routes/api/public/npm/$.ts
+++ b/apps/web/src/routes/api/public/npm/$.ts
@@ -8,6 +8,7 @@ import { createApiFileRoute } from "@/lib/api/file-route";
  *
  * Cached at the edge: s-maxage 600, stale-while-revalidate 3600.
  */
+import { apiJson, createApiHandler } from "@/lib/api/router";
 
 interface NpmMeta {
   name: string;
@@ -101,16 +102,13 @@ export function __resetNpmMetaCacheForTest() {
   cache.clear();
 }
 
-export const Route = createApiFileRoute("/api/public/npm/$")({
-  server: {
-    handlers: {
-      GET,
-    },
-  },
-});
+function packageFromParams(params: unknown) {
+  const record = (params ?? {}) as Record<string, string>;
+  return record._splat ?? record.pkg ?? "";
+}
 
-export async function GET({ params }: { params: Record<string, string> }) {
-  const pkg = params._splat ?? "";
+export const GET = createApiHandler("publicNpm.read", async ({ params }) => {
+  const pkg = packageFromParams(params);
   if (!pkg || !/^@?[a-z0-9][\w./@-]{0,213}$/i.test(pkg)) {
     return new Response(JSON.stringify({ error: "Invalid package name" }), {
       status: 400,
@@ -119,10 +117,8 @@ export async function GET({ params }: { params: Record<string, string> }) {
   }
   try {
     const data = await fetchMeta(pkg);
-    return new Response(JSON.stringify(data), {
-      status: 200,
+    return apiJson(data, {
       headers: {
-        "Content-Type": "application/json",
         "Cache-Control": "public, s-maxage=600, stale-while-revalidate=3600",
       },
     });
@@ -133,4 +129,12 @@ export async function GET({ params }: { params: Record<string, string> }) {
       headers: { "Content-Type": "application/json" },
     });
   }
-}
+});
+
+export const Route = createApiFileRoute("/api/public/npm/$")({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => GET(request, { params }),
+    },
+  },
+});

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -11695,6 +11695,295 @@ paths:
                 required:
                   - ok
                   - error
+  /api/public/npm/{pkg}:
+    get:
+      tags:
+        - Dynamic
+      summary: Read cached npm package metadata
+      description:
+        Proxies npm registry latest metadata and weekly downloads for a package name. Uses the
+        shared dynamic Cloudflare rate-limit binding before any upstream fetch.
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  version:
+                    type: string
+                  publishedAt:
+                    type:
+                      - string
+                      - "null"
+                  weeklyDownloads:
+                    type:
+                      - number
+                      - "null"
+                  homepage:
+                    type:
+                      - string
+                      - "null"
+                  repository:
+                    type:
+                      - string
+                      - "null"
+                  fetchedAt:
+                    type: string
+                required:
+                  - name
+                  - version
+                  - publishedAt
+                  - weeklyDownloads
+                  - homepage
+                  - repository
+                  - fetchedAt
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/og:
     get:
       tags:

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -48,6 +48,7 @@ const apiRoutes = [
   "/api/github-stats",
   "/api/public/alerts",
   "/api/public/feeds/health",
+  "/api/public/npm/{pkg}",
   "/feed.xml",
   "/atom.xml",
   "/data/feeds/index.json",

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -141,6 +141,19 @@ describe("OpenAPI route coverage", () => {
       ]),
     });
     expect(
+      ENDPOINTS.find((endpoint) => endpoint.id === "publicNpm-read"),
+    ).toMatchObject({
+      method: "GET",
+      path: "/api/public/npm/{pkg}",
+      parameters: expect.arrayContaining([
+        expect.objectContaining({
+          name: "pkg",
+          in: "path",
+          example: "@heyclaude/mcp",
+        }),
+      ]),
+    });
+    expect(
       ENDPOINTS.find((endpoint) => endpoint.id === "submissions-preflight"),
     ).toMatchObject({
       liveRequest: false,

--- a/tests/npm-public-api.test.ts
+++ b/tests/npm-public-api.test.ts
@@ -4,6 +4,9 @@ import {
   GET,
   __resetNpmMetaCacheForTest,
 } from "../apps/web/src/routes/api/public/npm/$";
+import { getApiRouteDefinition } from "../apps/web/src/lib/api/contracts";
+
+const globalWithEnv = globalThis as typeof globalThis & { __env__?: unknown };
 
 function pkgFromUrl(input: string) {
   const url = new URL(input);
@@ -24,14 +27,31 @@ function okJson(body: unknown) {
   });
 }
 
+function requestFor(pkg: string, ip = "203.0.113.50") {
+  return new Request(`https://heyclau.de/api/public/npm/${pkg}`, {
+    headers: { "cf-connecting-ip": ip },
+  });
+}
+
 describe("public npm metadata API cache", () => {
   beforeEach(() => {
     __resetNpmMetaCacheForTest();
+    delete globalWithEnv.__env__;
   });
 
   afterEach(() => {
+    delete globalWithEnv.__env__;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("registers a durable Cloudflare rate-limit binding", () => {
+    expect(getApiRouteDefinition("publicNpm.read").rateLimit).toMatchObject({
+      scope: "public-npm",
+      limit: 120,
+      windowMs: 60_000,
+      binding: "API_DYNAMIC_RATE_LIMIT",
+    });
   });
 
   it("serves repeat requests from isolate cache", async () => {
@@ -51,9 +71,13 @@ describe("public npm metadata API cache", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await GET({ params: { _splat: "cacheable-package" } });
+    await GET(requestFor("cacheable-package"), {
+      params: { _splat: "cacheable-package" },
+    });
     const firstCallCount = fetchMock.mock.calls.length;
-    await GET({ params: { _splat: "cacheable-package" } });
+    await GET(requestFor("cacheable-package"), {
+      params: { _splat: "cacheable-package" },
+    });
     expect(fetchMock.mock.calls.length).toBe(firstCallCount);
   });
 
@@ -75,12 +99,34 @@ describe("public npm metadata API cache", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     for (let i = 0; i < 257; i += 1) {
-      await GET({ params: { _splat: `pkg-${i}` } });
+      // Unique IPs so the in-memory fallback limit does not trip mid-loop.
+      await GET(requestFor(`pkg-${i}`, `198.51.100.${i % 250}`), {
+        params: { _splat: `pkg-${i}` },
+      });
     }
     const beforeRefetch = fetchMock.mock.calls.length;
-    await GET({ params: { _splat: "pkg-0" } });
+    await GET(requestFor("pkg-0", "198.51.100.250"), {
+      params: { _splat: "pkg-0" },
+    });
 
     // 3 upstream calls per miss: latest + downloads + packument.
     expect(fetchMock.mock.calls.length - beforeRefetch).toBe(3);
+  });
+
+  it("returns 429 before upstream fetch when the Cloudflare binding denies", async () => {
+    const fetchMock = vi.fn(async () => okJson({ name: "x", version: "1.0.0" }));
+    vi.stubGlobal("fetch", fetchMock);
+    globalWithEnv.__env__ = {
+      API_DYNAMIC_RATE_LIMIT: {
+        limit: async () => ({ success: false }),
+      },
+    };
+
+    const response = await GET(requestFor("rate-limited-package"), {
+      params: { _splat: "rate-limited-package" },
+    });
+
+    expect(response.status).toBe(429);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/npm-public-api.test.ts
+++ b/tests/npm-public-api.test.ts
@@ -131,4 +131,21 @@ describe("public npm metadata API cache", () => {
     expect(response.status).toBe(429);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("rejects invalid package names with 400 before any upstream fetch", async () => {
+    const fetchMock = vi.fn(async () =>
+      okJson({ name: "x", version: "1.0.0" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(requestFor("../evil"), {
+      params: { _splat: "../evil" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid package name",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/npm-public-api.test.ts
+++ b/tests/npm-public-api.test.ts
@@ -114,7 +114,9 @@ describe("public npm metadata API cache", () => {
   });
 
   it("returns 429 before upstream fetch when the Cloudflare binding denies", async () => {
-    const fetchMock = vi.fn(async () => okJson({ name: "x", version: "1.0.0" }));
+    const fetchMock = vi.fn(async () =>
+      okJson({ name: "x", version: "1.0.0" }),
+    );
     vi.stubGlobal("fetch", fetchMock);
     globalWithEnv.__env__ = {
       API_DYNAMIC_RATE_LIMIT: {


### PR DESCRIPTION
## Summary
- Register `publicNpm.read` with `API_DYNAMIC_RATE_LIMIT` (120/60s).
- Enforce via `createApiHandler` before upstream npm fan-out.
- Regenerate OpenAPI contract assets.
- Add tests for `pkg` OpenAPI path example + invalid package `400` (codecov/patch).

Closes #5243

## Quality Evidence
- Reuses existing `API_DYNAMIC_RATE_LIMIT` (no new wrangler binding).
- Success response shape / cache headers unchanged; new `429` when limited.
- Reland of #5394 with stronger patch coverage for `exampleForPathParam('pkg')`.

### UI Evidence

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![Desktop · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) | ![Desktop · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) |
| Desktop · Dark | ![Desktop · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) | ![Desktop · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) |
| Tablet · Light | ![Tablet · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) | ![Tablet · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) |
| Tablet · Dark | ![Tablet · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) | ![Tablet · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) |
| Mobile · Light | ![Mobile · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) | ![Mobile · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) |
| Mobile · Dark | ![Mobile · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) | ![Mobile · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) |

Before/after are identical production captures (rate-limit + OpenAPI sync only; no rendered UI delta).

## Validation
- [x] `pnpm exec vitest run tests/npm-public-api.test.ts tests/api-contracts.test.ts`
- [x] `pnpm validate:openapi`
- [ ] CI green (draft until green + codecov/patch ≥70%)

Made with [Cursor](https://cursor.com)