### PR TITLE
fix(registry): drop unread category-spec capability flags

### DIFF
--- a/packages/registry/src/category-spec.json
+++ b/packages/registry/src/category-spec.json
@@ -80,10 +80,6 @@
       "contentRequired": ["title", "slug", "description", "cardDescription"],
       "contentRecommended": ["usageSnippet", "copySnippet"],
       "submissionRequired": ["full_copyable_content"],
-      "requiresUsageSnippet": false,
-      "requiresAssetContent": true,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
       "quickstart": [
         "Open the full asset and review the role boundaries.",
         "Copy the complete prompt into your Claude agent definition.",
@@ -104,10 +100,6 @@
         "configSnippet"
       ],
       "submissionRequired": ["install_command", "usage_snippet"],
-      "requiresUsageSnippet": true,
-      "requiresAssetContent": false,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": true,
       "quickstart": [
         "Run the install command from a trusted source.",
         "Copy the Claude config into your MCP configuration.",
@@ -135,11 +127,6 @@
         "operatingSystem"
       ],
       "submissionRequired": [],
-      "requiresUsageSnippet": false,
-      "requiresAssetContent": false,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
-      "commercialSubmission": true,
       "quickstart": [
         "Open the website and verify the product matches your use case.",
         "Review pricing, source links, and any sponsorship disclosure.",
@@ -171,10 +158,6 @@
         "skill_level",
         "verification_status"
       ],
-      "requiresUsageSnippet": true,
-      "requiresAssetContent": false,
-      "supportsSkillMetadata": true,
-      "supportsDownloadUrl": true,
       "quickstart": [
         "Review the source, install command, or full copyable content.",
         "Review retrieval sources and tested platforms.",
@@ -190,10 +173,6 @@
       "contentRequired": ["title", "slug", "description", "cardDescription"],
       "contentRecommended": ["copySnippet"],
       "submissionRequired": ["full_copyable_content"],
-      "requiresUsageSnippet": false,
-      "requiresAssetContent": true,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
       "quickstart": [
         "Read the rule for scope and caveats.",
         "Copy the full rule into CLAUDE.md or your rule system.",
@@ -213,10 +192,6 @@
         "usage_snippet",
         "full_copyable_content"
       ],
-      "requiresUsageSnippet": true,
-      "requiresAssetContent": true,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
       "quickstart": [
         "Copy the command syntax.",
         "Paste the full command asset into your command registry.",
@@ -242,10 +217,6 @@
         "usage_snippet",
         "full_copyable_content"
       ],
-      "requiresUsageSnippet": true,
-      "requiresAssetContent": true,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
       "quickstart": [
         "Copy the hook script into your repo.",
         "Add the config under the listed Claude Code trigger.",
@@ -261,10 +232,6 @@
       "contentRequired": ["title", "slug", "description", "cardDescription"],
       "contentRecommended": ["usageSnippet"],
       "submissionRequired": ["guide_content"],
-      "requiresUsageSnippet": false,
-      "requiresAssetContent": true,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
       "quickstart": [
         "Scan prerequisites first.",
         "Follow the guide steps in order.",
@@ -280,10 +247,6 @@
       "contentRequired": ["title", "slug", "description", "cardDescription"],
       "contentRecommended": ["items"],
       "submissionRequired": ["items"],
-      "requiresUsageSnippet": false,
-      "requiresAssetContent": false,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
       "quickstart": [
         "Review the included entries.",
         "Follow the recommended installation order when present.",
@@ -309,10 +272,6 @@
         "usage_snippet",
         "full_copyable_content"
       ],
-      "requiresUsageSnippet": true,
-      "requiresAssetContent": true,
-      "supportsSkillMetadata": false,
-      "supportsDownloadUrl": false,
       "quickstart": [
         "Copy the statusline config.",
         "Install or adapt the script asset.",

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -370,10 +370,6 @@ export type RegistryCategorySpecEntry = {
   usageHint: string;
   quickstart?: string[];
   template: string;
-  requiresAssetContent: boolean;
-  requiresUsageSnippet: boolean;
-  supportsSkillMetadata: boolean;
-  supportsDownloadUrl: boolean;
 };
 
 export type RegistryCategorySpec = {


### PR DESCRIPTION
## Summary
- Remove unused per-category flags from `category-spec.json`: `requiresUsageSnippet`, `requiresAssetContent`, `supportsSkillMetadata`, `supportsDownloadUrl`, `commercialSubmission`.
- Drop the matching fields from `RegistryCategorySpecEntry`.
- Validation still uses existing hardcoded category checks in `content-schema-lib.js` (unchanged behavior).

Closes #5248

## Decision
**Option (b)** — remove until wired. Option (a) would be a larger refactor replacing scattered `category === ...` checks; these fields currently misrepresent the source of truth.

## Quality Evidence
- Packages/registry only — no `apps/web` routes, OpenAPI, or UI.
- Left as-is: category-name string checks in `content-schema-lib.js` (still the real drivers for usage/asset/skill/download/commercial rules).
- `contentRequired` / `contentRecommended` untouched.

### UI Evidence

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![Desktop · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) | ![Desktop · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) |
| Desktop · Dark | ![Desktop · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) | ![Desktop · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) |
| Tablet · Light | ![Tablet · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) | ![Tablet · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) |
| Tablet · Dark | ![Tablet · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) | ![Tablet · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) |
| Mobile · Light | ![Mobile · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) | ![Mobile · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) |
| Mobile · Dark | ![Mobile · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) | ![Mobile · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) |

Before/after identical (spec cleanup only; no rendered UI delta).

## Validation
- [x] `pnpm exec vitest run tests/content-schema-lib.test.ts tests/content-schema.test.ts`
- [ ] CI green (draft until green)

Made with [Cursor](https://cursor.com)