### PR TITLE
fix(scripts): resolve validate-tasks repoRoot with fileURLToPath

### DIFF
--- a/scripts/validate-tasks.mjs
+++ b/scripts/validate-tasks.mjs
@@ -1,7 +1,15 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = path.resolve(new URL("..", import.meta.url).pathname);
+// `new URL(...).pathname` yields a leading-slash path ("/C:/...") on Windows,
+// which resolves to "C:\C:\..." and never matches the repo - the gate then
+// reports "TASKS.md is not present" and exits 0 even for an invalid tracker.
+// Every sibling script uses fileURLToPath for exactly this reason.
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
 const tasksPath = path.join(repoRoot, "TASKS.md");
 const requireTasks =
   String(process.env.REQUIRE_TASKS ?? "")


### PR DESCRIPTION
## The bug

`scripts/validate-tasks.mjs` built its repo root from:

```js
const repoRoot = path.resolve(new URL("..", import.meta.url).pathname);
```

`URL.pathname` on a `file:` URL is a **leading-slash** path — `/C:/repo/...` on Windows. Resolving that produces `C:\C:\repo\...`, which never exists, so `fs.existsSync(tasksPath)` was always false. The script then took its "optional tracker" branch, printed *"TASKS.md is not present; skipping"*, and **exited 0 for every tracker, valid or invalid**. The gate was silently disabled on Windows.

Measured with two fixtures (sections present, one with a `- [ ]` item falsely claiming `Evidence:`, one valid):

| fixture | before | after |
|---|---|---|
| invalid tracker | exit **0** — *"TASKS.md is not present; skipping"* | exit **1** — `TASKS.md has no completed items with evidence.` |
| valid tracker | exit **0** — *"TASKS.md is not present; skipping"* | exit **0** — `Validated 1 completed TASKS.md items.` |

Before the fix both fixtures "passed" for the same wrong reason. After, the invalid one is correctly rejected and the valid one correctly validated.

## The fix

Use `fileURLToPath`, which is what **every other script in `scripts/`** already does (`build-content-index.mjs`, `audit-coverage-gaps.mjs`, `check-submission-gate-prod-config.mjs`, …):

```js
const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
```

This also fixes a second latent defect: `.pathname` leaves percent-escapes encoded, so a checkout path containing a space resolved to `...\my%20repo\...`. `fileURLToPath` decodes it:

| | old | new |
|---|---|---|
| plain | `C:\C:\repo\awesome-claude` | `C:\repo\awesome-claude` |
| with space | `C:\C:\my%20repo\awesome-claude` | `C:\my repo\awesome-claude` |

## Invariants

- **No behavior change on Linux/CI.** On POSIX, `fileURLToPath("file:///a/b")` and `new URL(...).pathname` both yield `/a/b`, so `repoRoot` is identical and the workflow's existing `pnpm validate:tasks` result is unchanged. The fix only corrects hosts where the two diverge (Windows drive letters, and any path with percent-escapes).
- **Blast radius is one value:** `repoRoot` feeds only `tasksPath`. Nothing else in the script reads it.
- The "TASKS.md is optional" behavior is preserved — with no tracker present the script still prints the skip message and exits 0 (verified).

## Validation

- Fixture matrix above (invalid/valid tracker, before/after)
- `node scripts/validate-tasks.mjs` with no `TASKS.md` — exits 0, skip message intact
- `prettier --check scripts/validate-tasks.mjs` — clean
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to the unmodified baseline

No linked issue — found while working in `scripts/`, and per CONTRIBUTING.md a PR with no linked issue is fine. No visual impact.
