### PR TITLE
chore(deps): drop unused named imports across registry, mcp, and scripts

### DIFF
--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -7,12 +7,7 @@ import {
   normalizeEndpointUrl,
 } from "./endpoint-url.js";
 import { packageName, packageVersion } from "./package-metadata.js";
-import {
-  formatZodError,
-  jsonSchemaForTool,
-  jsonSchemaForToolOutput,
-  parseToolArguments,
-} from "./schemas.js";
+import { formatZodError, parseToolArguments } from "./schemas.js";
 import {
   buildSubmissionUrlsFromSpec,
   getSubmissionExamplesFromSpec,
@@ -59,16 +54,9 @@ import {
 } from "./registry-handlers-lib.js";
 
 import {
-  LOCAL_DRAFT_TOOL_NAMES,
   MCP_PUBLIC_POLICY,
   READ_ONLY_TOOL_NAMES,
-  TOOL_DEFINITIONS,
 } from "./registry-tools-lib.js";
-import {
-  PROMPT_DEFINITIONS,
-  getRegistryPrompt,
-  listRegistryPrompts,
-} from "./registry-prompts-lib.js";
 import {
   normalizeLimit,
   normalizeOffset,
@@ -83,11 +71,7 @@ import {
   unavailable,
   withPublicPolicy,
 } from "./registry-response-lib.js";
-import {
-  DISCOVERY_RESOURCES,
-  RESOURCE_TEMPLATES,
-  listRegistryResourceTemplates,
-} from "./registry-resource-metadata-lib.js";
+import { DISCOVERY_RESOURCES } from "./registry-resource-metadata-lib.js";
 import {
   normalizeDateFloor,
   parsedTrustArgs,

--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -10,7 +10,6 @@
  */
 import crypto from "node:crypto";
 
-import { getCopyText } from "./presentation.js";
 import categorySpec from "./category-spec.json" with { type: "json" };
 import {
   buildEntryQuality,

--- a/scripts/gittensor-impact-card.mjs
+++ b/scripts/gittensor-impact-card.mjs
@@ -12,12 +12,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import {
-  bucketWeekly,
-  compact,
-  escapeXml,
-  WEEKS,
-} from "./lib/impact-card-core.mjs";
+import { bucketWeekly, compact, escapeXml } from "./lib/impact-card-core.mjs";
 import { meter, sparkline } from "./lib/impact-card-svg.mjs";
 
 const THEME = {


### PR DESCRIPTION
## What

Eleven imported bindings were never referenced by the modules importing them:

| file | unused bindings |
|---|---|
| `packages/mcp/src/registry-tool-orchestration-lib.js` | `jsonSchemaForTool`, `jsonSchemaForToolOutput`, `LOCAL_DRAFT_TOOL_NAMES`, `TOOL_DEFINITIONS`, `PROMPT_DEFINITIONS`, `getRegistryPrompt`, `listRegistryPrompts`, `RESOURCE_TEMPLATES`, `listRegistryResourceTemplates` |
| `packages/registry/src/artifacts-lib.js` | `getCopyText` |
| `scripts/gittensor-impact-card.mjs` | `WEEKS` |

Each was verified to occur **exactly once** in its file — the import itself — so none is referenced, re-exported, or used in a template.

## The part that needed care

Two import *statements* disappear entirely, which removes those modules from the importer's load graph. I checked both rather than assuming it was harmless:

- **`./registry-prompts-lib.js`** (dropped from `registry-tool-orchestration-lib`) — pure module, no top-level calls or global mutation. Still imported by `registry.js`, so the prompt surface is unaffected. Verified at runtime: `listRegistryPrompts` and `getRegistryPrompt` are still exported from `registry.js`.
- **`./presentation.js`** (dropped from `artifacts-lib`) — pure module. Still imported by `quality-lib.js` and re-exported via the registry `index.js`. Verified at runtime: `getCopyText` is still exported from the registry index.

The other three statements are only trimmed, keeping their still-used bindings (`formatZodError`/`parseToolArguments`, `MCP_PUBLIC_POLICY`/`READ_ONLY_TOOL_NAMES`, `DISCOVERY_RESOURCES`).

## Why it's worth doing

Dead imports in `@heyclaude/mcp` aren't free: an unused import still resolves and evaluates the module at startup. `registry-tool-orchestration-lib` is on the hot path for every tool call, and it was pulling in the prompts module purely to discard it.

## Validation

- Re-ran the unused-import scan over `packages/registry/src`, `packages/mcp/src`, and `scripts` — **0 remaining**
- All four affected modules import cleanly (`artifacts-lib`, `registry-tool-orchestration-lib`, `registry.js`, registry `index.js`)
- `pnpm run test:mcp` — 72/72 pass
- `vitest run tests/mcp-registry-tool-orchestration-lib-a.test.ts tests/artifacts-lib.test.ts tests/mcp-server-lib-handlers.test.ts` — 1024/1024 pass
- `scripts/gittensor-impact-card.mjs` exits identically to unmodified `main`
- `prettier --check` on all three files — clean (it collapsed the now-three-name import in the impact-card script onto one line; that is the only formatting change)
- `node scripts/validate-codebase-clean.mjs` — output byte-identical to baseline

No linked issue — found while working in these packages; per CONTRIBUTING.md a PR with no linked issue is fine. No visual impact, no public surface change.
