### PR TITLE
fix(web): emit custom og:image on job detail pages

### DIFF
--- a/apps/web/src/routes/jobs.$slug.tsx
+++ b/apps/web/src/routes/jobs.$slug.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
@@ -77,6 +79,7 @@ export const Route = createFileRoute("/jobs/$slug")({
     const url = absoluteUrl(`/jobs/${params.slug}`);
     const title = `${job.title} at ${job.company}`;
     const description = job.description || "Source-verified role from the HeyClaude jobs board.";
+    const ogImage = ogImageUrl({ title, eyebrow: "Job", description });
     return {
       meta: [
         { title: `${title} — HeyClaude jobs` },
@@ -84,7 +87,7 @@ export const Route = createFileRoute("/jobs/$slug")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:type", content: "article" },
+        ...ogImageMetaTags(ogImage, "article"),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/tests/jobs-detail-og-meta.test.ts
+++ b/tests/jobs-detail-og-meta.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { ogImageMetaTags } from "../apps/web/src/lib/og-meta-lib";
+import { ogImageUrl } from "../apps/web/src/lib/og-image";
+
+describe("jobs detail OG meta", () => {
+  it("wires job detail head through ogImageUrl + ogImageMetaTags like sibling detail routes", () => {
+    const source = readFileSync(
+      new URL("../apps/web/src/routes/jobs.$slug.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain('from "@/lib/og-image"');
+    expect(source).toContain('from "@/lib/og-meta-lib"');
+    expect(source).toContain(
+      'ogImageUrl({ title, eyebrow: "Job", description })',
+    );
+    expect(source).toContain('...ogImageMetaTags(ogImage, "article")');
+    expect(source).not.toContain('{ property: "og:type", content: "article" }');
+  });
+
+  it("emits the shared article card shape used by sibling detail routes", () => {
+    const ogImage = ogImageUrl({
+      title: "Staff Engineer at Acme",
+      eyebrow: "Job",
+      description: "Build Claude workflows.",
+    });
+    const tags = ogImageMetaTags(ogImage, "article");
+
+    expect(tags).toEqual(
+      expect.arrayContaining([
+        { property: "og:image", content: ogImage },
+        { property: "og:image:type", content: "image/png" },
+        { property: "og:type", content: "article" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
+      ]),
+    );
+    expect(ogImage).toContain("/og?");
+    expect(ogImage).toContain("title=");
+    expect(ogImage).toContain("eyebrow=");
+  });
+});


### PR DESCRIPTION
Closes #5216

## Summary

- Wire `jobs/$slug` `head()` through `ogImageUrl({ title, eyebrow: "Job", description })` and `...ogImageMetaTags(ogImage, "article")`, matching sibling detail routes (`best`, `compare`, `integrations`, etc.).
- Drop the standalone `og:type` tag so `ogImageMetaTags` owns the shared article card shape (image dimensions + twitter card).
- Add a focused source/contract test for the job-detail OG wiring.

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Changed routes/components/endpoints/tools

- `apps/web/src/routes/jobs.$slug.tsx` — `head()` meta
- `tests/jobs-detail-og-meta.test.ts` — source + shape coverage

## Expected behavior

Job detail pages emit bespoke `og:image` / `twitter:image` cards titled `"<role> at <company>"` with eyebrow `Job`, plus width/height/type/twitter card tags consistent with sibling detail routes. Existing title/description/og:title/og:description/og:url remain.

## Quality evidence

Before (`head` meta, truncated):

- `og:title`, `og:description`, `og:url`, `og:type=article`
- no `og:image` / `twitter:card` / `twitter:image`

After:

- same title/description/url fields
- `...ogImageMetaTags(ogImage, "article")` adds `og:image`, `og:image:type`, `og:image:width`, `og:image:height`, `og:type=article`, `twitter:card=summary_large_image`, `twitter:image`
- `ogImage` URL shape: `/og?…` with `title` + `eyebrow=Job` (same generator as other detail routes)

No visual impact on the page body — meta-only change for social crawlers.

## Validation

- [x] `trunk check` clean on changed files
- [x] `pnpm exec vitest run tests/jobs-detail-og-meta.test.ts tests/og-meta-lib.test.ts`
- [x] `pnpm --filter web type-check`

## Notes

- Linked issue: Closes #5216

Made with [Cursor](https://cursor.com)