### PR TITLE
fix(registry): narrow destructive root removal detection

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1117,13 +1117,17 @@ function isMutableGithubSourceUrl(value) {
  * spelling: any option cluster carrying both recursive and force counts,
  * whether written `-rf`, `-fr`, `-r -f`, or `--recursive --force`.
  *
- * Targets stay deliberately narrow (root, `~`, `$HOME`). Relative paths like
- * `./build` are ordinary cleanup and must not flag.
+ * Targets stay deliberately narrow (`/`, `/etc`, `~`, `$HOME`, and
+ * `${HOME}`). Relative paths like `./build` are ordinary cleanup and must
+ * not flag. Each target alternative ends in a delimiter/end-of-command
+ * lookahead so `/tmp/scratch`, `~/cache`, and `$HOME/tmp` aren't swallowed
+ * as a matching prefix of `/`, `~`, or `$HOME` - only the bare target
+ * itself (optionally with one trailing `/`) is destructive.
  */
 function referencesDestructiveRootRemoval(value) {
   const text = String(value || "");
   const pattern =
-    /\brm\b((?:\s+-{1,2}[a-z][a-z-]*)+)\s+(?:\/[^\s;&|)'"`]*|~[^\s;&|)'"`]*|\$home\b|\$\{home\})/gi;
+    /\brm\b((?:\s+-{1,2}[a-z][a-z-]*)+)\s+(?:\/etc\/?(?=[\s;&|)'"`]|$)|\/\/?(?=[\s;&|)'"`]|$)|~\/?(?=[\s;&|)'"`]|$)|\$home\/?(?=[\s;&|)'"`]|$)|\$\{home\}\/?(?=[\s;&|)'"`]|$))/gi;
 
   for (const match of text.matchAll(pattern)) {
     const flags = match[1].toLowerCase().split(/\s+/).filter(Boolean);

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -655,6 +655,11 @@ describe("destructive rm detection", () => {
     "rm -Rf /",
     "rm -rf /etc",
     "sudo rm -rf / --no-preserve-root",
+    // Regression: the trailing-slash form of the home target must flag the
+    // same as the bare form, matching how `/` and `~` already accept one
+    // optional trailing slash.
+    "rm -rf $HOME/",
+    "rm -rf ${HOME}/",
   ])("flags %s", (command) => {
     expect(flagged(command)).toBe(true);
   });
@@ -667,6 +672,15 @@ describe("destructive rm detection", () => {
     "git rm -r --cached .",
     "npm run rm-rf-helper",
     "npm install acme",
+    // Regression: the target regex used to match any string starting with
+    // `/`, `~`, or `$HOME`, so ordinary subpaths under those roots were
+    // misflagged as critical alongside the real root/home targets.
+    "rm -rf /tmp/scratch",
+    "rm -rf /tmp/build-cache",
+    "rm -rf /var/tmp/build-workdir",
+    "rm -rf $HOME/tmp",
+    "rm -rf ${HOME}/tmp",
+    "rm -rf ~/cache",
   ])("does not flag %s", (command) => {
     expect(flagged(command)).toBe(false);
   });


### PR DESCRIPTION
## Summary

- narrow destructive-root removal detection to exact sensitive targets
- stop treating ordinary subpaths as destructive root deletion
- preserve detection for exact home targets with an optional trailing slash
- add focused regression coverage

Closes #5405

## Behavior

Still flagged:

- `rm -rf /`
- `rm -rf /etc`
- `rm -rf ~`
- `rm -rf $HOME`
- `rm -rf ${HOME}`
- `rm -rf $HOME/`
- `rm -rf ${HOME}/`

No longer incorrectly flagged:

- `rm -rf /tmp/scratch`
- `rm -rf /tmp/build-cache`
- `rm -rf /var/tmp/build-workdir`
- `rm -rf ~/cache`
- `rm -rf $HOME/tmp`
- `rm -rf ${HOME}/tmp`

## Validation

- `pnpm exec vitest run tests/submission-risk-invariants.test.ts`
- `pnpm build`
- `git diff --check`

## Visual impact

No visual impact.
