### PR TITLE
fix(api): document preflight honeypot response

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -5314,6 +5314,16 @@
                         "routeSuggestion"
                       ],
                       "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": { "type": "boolean", "enum": [true] },
+                        "valid": { "type": "boolean", "enum": [false] },
+                        "queued": { "type": "boolean", "enum": [false] }
+                      },
+                      "required": ["ok", "valid", "queued"],
+                      "additionalProperties": false
                     }
                   ]
                 }

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -6205,6 +6205,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -616,9 +616,23 @@ const submissionPreflightNonPrResponseSchema = submissionPreflightBaseResponseSc
   })
   .strict();
 
+// The honeypot short-circuit in preflight.ts returns this exact sparse shape
+// instead of the full preflight response - documented here as its own variant
+// so the published contract matches reality. Runtime behavior is unchanged:
+// this must stay a silent `ok: true` discard with no signal that the request
+// was detected as a bot.
+const submissionPreflightHoneypotResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    valid: z.literal(false),
+    queued: z.literal(false),
+  })
+  .strict();
+
 export const submissionPreflightResponseSchema = z.union([
   submissionPreflightPrReadyResponseSchema,
   submissionPreflightNonPrResponseSchema,
+  submissionPreflightHoneypotResponseSchema,
 ]);
 
 export const downloadQuerySchema = z.object({

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -6209,6 +6209,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -532,4 +532,44 @@ describe("website submission preflight API", () => {
       queued: false,
     });
   });
+
+  it("validates the honeypot discard response against the published response schema", async () => {
+    const { submissionPreflightResponseSchema } = await import("@/lib/api/contracts");
+    const { POST } = await import("@/routes/api/submissions/preflight");
+    const response = await POST(
+      preflightRequest({ fields: validFields(), honeypot: "bot" }),
+    );
+    const body = await response.json();
+
+    // The real runtime response must validate as a documented variant.
+    expect(submissionPreflightResponseSchema.safeParse(body).success).toBe(true);
+
+    // Near-misses must still be rejected, so the schema stays exact rather
+    // than accidentally loosening to accept any `{ ok, valid }` object.
+    expect(
+      submissionPreflightResponseSchema.safeParse({ ok: true, valid: false }).success,
+    ).toBe(false);
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: true,
+        valid: false,
+        queued: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: false,
+        valid: false,
+        queued: false,
+      }).success,
+    ).toBe(false);
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: true,
+        valid: false,
+        queued: false,
+        extra: "unexpected",
+      }).success,
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- document the preflight honeypot response as a distinct schema variant
- preserve the existing silent-discard and no-queueing behavior
- add strict regression coverage
- regenerate OpenAPI artifacts

Closes #5245

## Runtime invariants

- runtime route behavior is unchanged
- silent discard remains unchanged
- detected submissions are not queued
- no bot-detection signal is exposed

## Validation

- `pnpm exec vitest run tests/submission-api.test.ts tests/api-contracts.test.ts`
- `pnpm validate:openapi`
- `pnpm build`
- `git diff --check`

## Visual impact

No visual impact.
