### PR TITLE
fix(web): derive brief approval send-slot copy

### DIFF
--- a/apps/web/src/lib/brief-schedule-lib.ts
+++ b/apps/web/src/lib/brief-schedule-lib.ts
@@ -13,6 +13,23 @@
 const SEND_DOW = 0; // 0=Sun..6=Sat; Sunday
 const SEND_HOUR_UTC = 16;
 
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/**
+ * Human-readable send slot ("Sunday 16:00 UTC"), derived from the same
+ * SEND_DOW/SEND_HOUR_UTC constants `nextSendSlot` computes from, so display
+ * copy can't drift from the actual schedule.
+ */
+export const SEND_SLOT_LABEL = `${DAY_NAMES[SEND_DOW]} ${String(SEND_HOUR_UTC).padStart(2, "0")}:00 UTC`;
+
 /**
  * The next Sunday 16:00 UTC strictly at or after `from` (today if it's Sunday
  * before 16:00, otherwise the following Sunday). Returned as an ISO string for

--- a/apps/web/src/lib/brief-schedule.ts
+++ b/apps/web/src/lib/brief-schedule.ts
@@ -5,4 +5,4 @@
  * (`@/lib/brief-schedule-lib`). This module re-exports it so existing
  * `@/lib/brief-schedule` importers stay unchanged.
  */
-export { nextSendSlot } from "@/lib/brief-schedule-lib";
+export { nextSendSlot, SEND_SLOT_LABEL } from "@/lib/brief-schedule-lib";

--- a/apps/web/src/routes/brief.approve.tsx
+++ b/apps/web/src/routes/brief.approve.tsx
@@ -10,6 +10,7 @@ import {
   briefApproveEgressAnalyticsEvent,
 } from "@/lib/brief-approve-cta-events";
 import { briefIssueHubDestination } from "@/lib/brief-entry-cta-events";
+import { SEND_SLOT_LABEL } from "@/lib/brief-schedule";
 
 const tokenInput = z.object({ token: z.string() });
 const confirmInput = z.object({
@@ -95,7 +96,7 @@ function ApprovePage() {
   return (
     <Shell heading={`Approve Weekly Brief #${result.number}`}>
       Approving the draft for the week of <strong>{result.periodThrough}</strong> schedules it to
-      send to the newsletter audience at the next Tuesday 15:00 UTC slot. Review the full draft in
+      send to the newsletter audience at the next {SEND_SLOT_LABEL} slot. Review the full draft in
       your preview email first.
       {state.phase === "error" && (
         <p style={{ color: "#b4541f", marginTop: 12 }}>

--- a/tests/brief-schedule-lib.test.ts
+++ b/tests/brief-schedule-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { nextSendSlot } from "../apps/web/src/lib/brief-schedule-lib";
+import {
+  nextSendSlot,
+  SEND_SLOT_LABEL,
+} from "../apps/web/src/lib/brief-schedule-lib";
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -70,5 +73,11 @@ describe("nextSendSlot", () => {
     expect(nextSendSlot(new Date("2026-06-01T00:00:00Z"))).toMatch(
       /^\d{4}-\d{2}-\d{2}T16:00:00\.000Z$/,
     );
+  });
+});
+
+describe("SEND_SLOT_LABEL", () => {
+  it('is exactly "Sunday 16:00 UTC", matching the actual send slot', () => {
+    expect(SEND_SLOT_LABEL).toBe("Sunday 16:00 UTC");
   });
 });


### PR DESCRIPTION
## Summary

The brief approval page told the maintainer the brief would send "at the next
Tuesday 15:00 UTC slot" — but the actual send slot is Sunday 16:00 UTC
everywhere else in the codebase (`brief-schedule-lib.ts`'s `SEND_DOW = 0` /
`SEND_HOUR_UTC = 16`, `wrangler.jsonc`'s `"0 16 * * SUN"` cron, `brief.tsx`'s
"Sundays" copy).

Closes #5257

## Fix

Rather than hand-correct the hardcoded string (which could drift again), the
copy is now derived from the same constants `nextSendSlot` already uses:

```ts
const DAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] as const;

export const SEND_SLOT_LABEL =
  `${DAY_NAMES[SEND_DOW]} ${String(SEND_HOUR_UTC).padStart(2, "0")}:00 UTC`;
```

- `brief-schedule-lib.ts`: adds `SEND_SLOT_LABEL`. `SEND_DOW` and
  `SEND_HOUR_UTC` are unchanged and remain private.
- `brief-schedule.ts`: re-exports `SEND_SLOT_LABEL` alongside `nextSendSlot`.
- `brief.approve.tsx`: renders `{SEND_SLOT_LABEL}` instead of the hardcoded
  string.

## Before / after

> …schedules it to send to the newsletter audience at the next
> **~~Tuesday 15:00 UTC~~ → Sunday 16:00 UTC** slot.

## Tests

`tests/brief-schedule-lib.test.ts`: `SEND_SLOT_LABEL` is asserted to equal
`"Sunday 16:00 UTC"`. The existing 6 `nextSendSlot` tests are untouched and
already fully cover the schedule computation itself.

## Validation

- `pnpm exec vitest run tests/brief-schedule-lib.test.ts` — 7/7 pass
- `pnpm --filter web run type-check` — clean
- `pnpm --filter web build` — clean
- `pnpm exec prettier --check` on all changed files — clean
- `git diff --check` — clean

## Evidence note

Per this issue's own acceptance criteria, a clear diff is accepted in place of
a screenshot when the copy is derived from the shared schedule constants
(as done here). I was unable to capture a genuine screenshot of the rendered
approval page: `/brief/approve` renders the sibling `/brief` page's content
instead of its own in every local environment I tried (`vite dev` and the
production-like `vite build` + `wrangler dev` preview), on both an unmodified
`upstream/main` worktree and this branch — a pre-existing, unrelated routing
issue, not something introduced by this change. I've asked about this
directly on the issue: #5257 (comment).

No changes to the actual send schedule, `wrangler.jsonc`, dependencies, or any
other page.