### PR TITLE
fix(web): derive brief approval send-slot copy

### DIFF
--- a/apps/web/src/lib/brief-schedule-lib.ts
+++ b/apps/web/src/lib/brief-schedule-lib.ts
@@ -13,6 +13,23 @@
 const SEND_DOW = 0; // 0=Sun..6=Sat; Sunday
 const SEND_HOUR_UTC = 16;
 
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/**
+ * Human-readable send slot ("Sunday 16:00 UTC"), derived from the same
+ * SEND_DOW/SEND_HOUR_UTC constants `nextSendSlot` computes from, so display
+ * copy can't drift from the actual schedule.
+ */
+export const SEND_SLOT_LABEL = `${DAY_NAMES[SEND_DOW]} ${String(SEND_HOUR_UTC).padStart(2, "0")}:00 UTC`;
+
 /**
  * The next Sunday 16:00 UTC strictly at or after `from` (today if it's Sunday
  * before 16:00, otherwise the following Sunday). Returned as an ISO string for

--- a/apps/web/src/lib/brief-schedule.ts
+++ b/apps/web/src/lib/brief-schedule.ts
@@ -5,4 +5,4 @@
  * (`@/lib/brief-schedule-lib`). This module re-exports it so existing
  * `@/lib/brief-schedule` importers stay unchanged.
  */
-export { nextSendSlot } from "@/lib/brief-schedule-lib";
+export { nextSendSlot, SEND_SLOT_LABEL } from "@/lib/brief-schedule-lib";

--- a/apps/web/src/routes/brief.approve.tsx
+++ b/apps/web/src/routes/brief.approve.tsx
@@ -10,6 +10,7 @@ import {
   briefApproveEgressAnalyticsEvent,
 } from "@/lib/brief-approve-cta-events";
 import { briefIssueHubDestination } from "@/lib/brief-entry-cta-events";
+import { SEND_SLOT_LABEL } from "@/lib/brief-schedule";
 
 const tokenInput = z.object({ token: z.string() });
 const confirmInput = z.object({
@@ -95,7 +96,7 @@ function ApprovePage() {
   return (
     <Shell heading={`Approve Weekly Brief #${result.number}`}>
       Approving the draft for the week of <strong>{result.periodThrough}</strong> schedules it to
-      send to the newsletter audience at the next Tuesday 15:00 UTC slot. Review the full draft in
+      send to the newsletter audience at the next {SEND_SLOT_LABEL} slot. Review the full draft in
       your preview email first.
       {state.phase === "error" && (
         <p style={{ color: "#b4541f", marginTop: 12 }}>

--- a/tests/brief-schedule-lib.test.ts
+++ b/tests/brief-schedule-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { nextSendSlot } from "../apps/web/src/lib/brief-schedule-lib";
+import {
+  nextSendSlot,
+  SEND_SLOT_LABEL,
+} from "../apps/web/src/lib/brief-schedule-lib";
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -70,5 +73,11 @@ describe("nextSendSlot", () => {
     expect(nextSendSlot(new Date("2026-06-01T00:00:00Z"))).toMatch(
       /^\d{4}-\d{2}-\d{2}T16:00:00\.000Z$/,
     );
+  });
+});
+
+describe("SEND_SLOT_LABEL", () => {
+  it('is exactly "Sunday 16:00 UTC", matching the actual send slot', () => {
+    expect(SEND_SLOT_LABEL).toBe("Sunday 16:00 UTC");
   });
 });


### PR DESCRIPTION
# Pull Request

## Summary

- Briefly describe what changed.

## Submission Source

For direct content PRs:

- [ ] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [ ] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author.
- [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.

For platform/code/docs PRs:

- [ ] This is not a direct content submission.
- [ ] Changed routes/components/endpoints/tools are listed below.
- [ ] Screenshots or `No visual impact` are included when relevant.
- [ ] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

For registry API endpoint PRs:

- [ ] Route handler and central API contract changed together.
- [ ] Origin-check and rate-limit posture is stated below.
- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
- [ ] API contract tests were added or updated.
- [ ] Generator reproducibility was checked or the reason it was not checked is listed.

## Schema and Quality Checks

- [ ] Content PR: `pnpm validate:content:strict` passed, or I am relying on CI.
- [ ] Platform/code PR: focused validation is listed below.
- [ ] Package artifact PR: `pnpm validate:packages` and `pnpm scan:packages` passed.
- [ ] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [ ] Install/use/copy paths are practical and complete.
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`).

## Quality Evidence

- Changed routes/components/endpoints/tools:
- Expected behavior:
- Important edge cases or invariants:
- Backward compatibility notes:
- Screenshots for frontend/page/UI changes:
  - Desktop:
  - Mobile:
- If screenshots do not apply, write `No visual impact` and explain why.
- Accessibility notes for UI changes:
- Focused tests or reason tests are not practical:

## Validation

- [ ] Direct content PR: I did not run generation or commit generated output.
- [ ] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [ ] I ran the focused checks listed above.
- [ ] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

## Notes

- Linked issue or no-issue rationale:
- Any caveats, follow-ups, or reviewer context.

## Screenshot evidence

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="desktop-light-before" src="https://github.com/user-attachments/assets/c22c7c3e-b77c-4e67-81b9-0027a1425dab" /> | <img width="1440" height="900" alt="desktop-light-after" src="https://github.com/user-attachments/assets/7c2af144-cd1c-472f-9fec-d79b4fe77b08" /> |
| Desktop · Dark | <img width="1440" height="900" alt="desktop-dark-before" src="https://github.com/user-attachments/assets/f809b4ca-acd8-493a-a44d-0e70734aabb5" /> | <img width="1440" height="900" alt="desktop-dark-after" src="https://github.com/user-attachments/assets/5c5bbac7-351a-428a-a19b-5118810a8e60" /> |
| Tablet · Light | <img width="768" height="1024" alt="tablet-light-before" src="https://github.com/user-attachments/assets/29d1478c-8274-45f6-b111-3cf23d253cc7" /> | <img width="768" height="1024" alt="tablet-light-after" src="https://github.com/user-attachments/assets/b07b8fae-6d6f-4ddf-a332-97ea64506e09" /> |
| Tablet · Dark | <img width="768" height="1024" alt="tablet-dark-before" src="https://github.com/user-attachments/assets/4508bcc7-37e8-40f1-a5f9-6d748cf69cf7" /> | <img width="768" height="1024" alt="tablet-dark-after" src="https://github.com/user-attachments/assets/bba52fc0-764d-4993-9d79-62d4d6bbb826" /> |
| Mobile · Light | <img width="390" height="844" alt="mobile-light-before" src="https://github.com/user-attachments/assets/3b6aa6c8-93c1-413c-8834-09927d7cd205" /> | <img width="390" height="844" alt="mobile-light-after" src="https://github.com/user-attachments/assets/4bcbb1ca-cc12-43ea-9786-8a00590833f8" /> |
| Mobile · Dark | <img width="390" height="844" alt="mobile-dark-before" src="https://github.com/user-attachments/assets/6fa4b66a-ab16-4030-b50f-07b38b3ab4d1" /> | <img width="390" height="844" alt="mobile-dark-after" src="https://github.com/user-attachments/assets/9eae2e81-f339-4727-8d83-66a9dd6feab4" /> |

## Temporary uploads






