### PR TITLE
fix(mcp): bound the category resource with offset/limit pagination

### DIFF
--- a/packages/mcp/src/registry-handlers-lib.js
+++ b/packages/mcp/src/registry-handlers-lib.js
@@ -314,15 +314,19 @@ export function buildCategoryResourcePayload(
   category,
   entries,
   toEntrySummary,
+  { offset = 0, limit = DISCOVERY_RESOURCE_LIMIT } = {},
 ) {
-  const summaries = entries
-    .filter((entry) => entry.category === category)
-    .map(toEntrySummary);
+  const matched = entries.filter((entry) => entry.category === category);
+  const start = Math.max(0, offset);
+  const page = matched.slice(start, start + limit).map(toEntrySummary);
   return {
     ok: true,
     category,
-    total: summaries.length,
-    entries: summaries,
+    total: matched.length,
+    limit,
+    offset: start,
+    count: page.length,
+    entries: page,
   };
 }
 

--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -725,7 +725,21 @@ export async function readRegistryResource(args = {}, options = {}) {
     const entries = unwrapEntries(
       await readJsonArtifact("search-index.json", options),
     );
-    payload = buildCategoryResourcePayload(category, entries, toEntrySummary);
+    // Bound the category resource like every other listing surface. Absent
+    // params fall back to DISCOVERY_RESOURCE_LIMIT (normalizeLimit needs
+    // undefined, not the null that URLSearchParams.get returns, to hit its
+    // fallback); normalizeLimit also hard-caps the page at that limit.
+    const offset = normalizeOffset(
+      parsed.searchParams.get("offset") ?? undefined,
+    );
+    const limit = normalizeLimit(
+      parsed.searchParams.get("limit") ?? undefined,
+      DISCOVERY_RESOURCE_LIMIT,
+    );
+    payload = buildCategoryResourcePayload(category, entries, toEntrySummary, {
+      offset,
+      limit,
+    });
   } else if (parsed.hostname === "entry" && parts.length === 2) {
     const [category, slug] = parts.map(normalizeText);
     // Resource reads return the full document; only the tool defaults to a

--- a/tests/mcp-registry-handlers-lib.test.ts
+++ b/tests/mcp-registry-handlers-lib.test.ts
@@ -575,6 +575,46 @@ describe("registry-handlers-lib response builders", () => {
     );
     expect(payload.total).toBe(1);
   });
+
+  it("buildCategoryResourcePayload paginates and reports the full total", () => {
+    const entries = Array.from({ length: 30 }, (_, index) => ({
+      category: "mcp",
+      slug: `demo-${index}`,
+    }));
+
+    const firstPage = buildCategoryResourcePayload(
+      "mcp",
+      entries,
+      toEntrySummary,
+      { offset: 0, limit: 10 },
+    );
+    expect(firstPage).toMatchObject({
+      total: 30,
+      limit: 10,
+      offset: 0,
+      count: 10,
+    });
+    expect(firstPage.entries).toHaveLength(10);
+
+    const tailPage = buildCategoryResourcePayload(
+      "mcp",
+      entries,
+      toEntrySummary,
+      { offset: 25, limit: 10 },
+    );
+    // Only 5 rows remain past offset 25, but the full total is still reported.
+    expect(tailPage).toMatchObject({ total: 30, offset: 25, count: 5 });
+
+    // With no options the page is capped at DISCOVERY_RESOURCE_LIMIT (bounded).
+    const defaulted = buildCategoryResourcePayload(
+      "mcp",
+      entries,
+      toEntrySummary,
+    );
+    expect(defaulted.limit).toBe(DISCOVERY_RESOURCE_LIMIT);
+    expect(defaulted.count).toBe(DISCOVERY_RESOURCE_LIMIT);
+    expect(defaulted.total).toBe(30);
+  });
   it("buildListRegistryResourcesResponse matrix 0", () => {
     const response = buildListRegistryResourcesResponse({
       manifest: {},

--- a/tests/mcp-registry-tool-orchestration-lib-f.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-f.test.ts
@@ -67,6 +67,45 @@ describe("registry-tool-orchestration readRegistryResource uri routing", () => {
     expect(payload.ok).toBe(true);
     expect(payload.category).toBe("mcp");
   });
+
+  const manyCategoryOptions = {
+    readJsonArtifact: async () => ({
+      entries: Array.from({ length: 30 }, (_, index) => ({
+        category: "mcp",
+        slug: `mcp-${index}`,
+        title: `MCP ${index}`,
+      })),
+    }),
+    readTextArtifact: async () => "",
+  };
+
+  it("bounds the category resource with offset/limit query params", async () => {
+    const payload = resourcePayload(
+      await readRegistryResource(
+        { uri: "heyclaude://category/mcp?limit=5&offset=10" },
+        manyCategoryOptions,
+      ),
+    );
+    expect(payload).toMatchObject({
+      total: 30,
+      limit: 5,
+      offset: 10,
+      count: 5,
+    });
+    expect(payload.entries).toHaveLength(5);
+  });
+
+  it("caps the unbounded category resource at the default limit", async () => {
+    const payload = resourcePayload(
+      await readRegistryResource(
+        { uri: "heyclaude://category/mcp" },
+        manyCategoryOptions,
+      ),
+    );
+    expect(payload.total).toBe(30);
+    expect(payload.entries.length).toBeLessThanOrEqual(25);
+    expect(payload.count).toBe(payload.entries.length);
+  });
 });
 
 describe("registry-tool-orchestration getPlatformAdapter", () => {


### PR DESCRIPTION
Closes #5421

## Problem

`buildCategoryResourcePayload` filtered the full search index by category and returned **every** matching summary with no limit. Every other listing surface in the MCP server is bounded (`registry.list` promises "bounded pagination"; `DISCOVERY_RESOURCE_LIMIT = 25` caps the `recent`/`trending`/`jobs` resources), but `content/mcp` alone has ~481 entries — so reading `heyclaude://category/mcp` returned hundreds of full summaries in one response, defeating the token-efficiency goal of the resource surface.

## Fix

Mirror the existing bounded-resource pattern:

- `registry-handlers-lib.js` — `buildCategoryResourcePayload` now takes `{ offset, limit }` (defaulting `limit` to `DISCOVERY_RESOURCE_LIMIT`), slices the filtered summaries, and reports `total` (full count) alongside `limit`, `offset`, and `count` (page size) — the same total-vs-returned split `registry.list` uses.
- `registry-tool-orchestration-lib.js` — the `heyclaude://category/{category}` branch parses `offset`/`limit` from the resource URI's query string via the existing `normalizeOffset`/`normalizeLimit` helpers and passes them through. (`normalizeLimit` needs `undefined`, not the `null` that `URLSearchParams.get` returns, to fall back to the default; it also hard-caps the page at `DISCOVERY_RESOURCE_LIMIT`, so an oversized `?limit=` can't produce an unbounded payload.)

## Behavior

| URI | Result |
|---|---|
| `heyclaude://category/mcp` | first `25` (`DISCOVERY_RESOURCE_LIMIT`), `total` = full count |
| `heyclaude://category/mcp?limit=5&offset=10` | rows 10–14, `total` = full count |
| `?limit=1000` | still capped at 25 |

## Tests

- `tests/mcp-registry-handlers-lib.test.ts` — `buildCategoryResourcePayload` paginates a 30-entry set (first page, tail page with fewer rows, and the default cap), always reporting the full `total`.
- `tests/mcp-registry-tool-orchestration-lib-f.test.ts` — reading the resource URI with `?limit=5&offset=10` returns a bounded 5-row page, and the unbounded URI is capped at the default limit.

## Validation

```
pnpm exec vitest run tests/mcp-registry-handlers-lib.test.ts tests/mcp-registry-tool-orchestration-lib-f.test.ts   # 1049 passed
pnpm exec vitest run tests/non-ui-branch-matrix.test.ts tests/mcp-server.test.ts   # consumers green (1157)
pnpm exec prettier --check <changed files>
```

Out of scope (already bounded): `registry.list`/`registry.search` and the other `heyclaude://` resources. No generated artifacts touched.