### PR TITLE
fix(web): surface saved-search alerts for removed registry entries

### DIFF
--- a/apps/web/src/lib/saved-search-alerts-lib.ts
+++ b/apps/web/src/lib/saved-search-alerts-lib.ts
@@ -186,12 +186,26 @@ export function buildSavedSearchAlerts(
     const ref = eventRef(event);
     if (!ref || !event.date) continue;
 
-    const entry = entriesByRef.get(ref);
+    const action = eventAction(event);
+    // A removed entry's detail JSON is gone, so `entriesByRef` never has it.
+    // Match "removed" events against the event's own carried fields instead of
+    // requiring a live fetch, so a matching saved search can still surface the
+    // removal. Added/updated events keep needing the live entry (their payload
+    // doesn't carry the fields matching relies on).
+    const liveEntry = entriesByRef.get(ref);
+    const entry: SavedSearchAlertEntry | null =
+      liveEntry ??
+      (action === "removed"
+        ? {
+            category: event.category ?? "",
+            slug: event.slug ?? "",
+            title: event.title ?? "",
+          }
+        : null);
     if (!entry) continue;
 
     for (const search of activeSearches) {
       if (!savedSearchMatchesEntry(search, entry)) continue;
-      const action = eventAction(event);
       const title = event.title || entry.title;
       alerts.push({
         id: `saved-search:${search.id}:${ref}:${event.date}:${action}`,

--- a/tests/saved-search-alerts-lib.test.ts
+++ b/tests/saved-search-alerts-lib.test.ts
@@ -314,6 +314,52 @@ describe("buildSavedSearchAlerts", () => {
     ).toEqual([]);
   });
 
+  it("still alerts on a removed event whose entry detail is already gone", () => {
+    // A removed entry's detail JSON 404s, so it's never in entriesByRef; the
+    // match must fall back to the event's own carried fields.
+    const alerts = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          id: "evt-removed",
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "removed",
+          date: "2026-06-19T10:00:00.000Z",
+          title: "Postgres Memory MCP",
+        },
+      ],
+      new Map(),
+    );
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({
+      severity: "warning",
+      title: "Postgres Memory MCP removed",
+      href: "/entry/mcp/postgres-memory",
+    });
+  });
+
+  it("does not fall back for non-removed events with a missing entry", () => {
+    // The fallback is scoped to "removed"; added/updated still need live data.
+    expect(
+      buildSavedSearchAlerts(
+        [search()],
+        [
+          {
+            kind: "entry",
+            category: "mcp",
+            slug: "postgres-memory",
+            action: "added",
+            date: "2026-06-19T10:00:00.000Z",
+            title: "Postgres Memory MCP",
+          },
+        ],
+        new Map(),
+      ),
+    ).toEqual([]);
+  });
+
   it("returns no alerts when no searches are active in-app", () => {
     expect(
       buildSavedSearchAlerts(


### PR DESCRIPTION
Closes #5422

## Problem

`buildSavedSearchAlerts` models a `"warning"` severity for `action === "removed"`, but that branch was unreachable. It only evaluates events present in `entriesByRef`, which `loadEventEntries` builds by fetching each event's **current** detail JSON (`/data/entries/{category}/{slug}.json`). When an entry is removed, that JSON 404s, `loadEventEntries` returns `null`, and the entry is filtered out — so `if (!entry) continue;` skipped every removed entry before matching. A user with a saved search was never told a matching entry was removed, even though the direct-watch path (`watch-alert-lib.ts`) surfaces "removed" fine (it doesn't need a live fetch).

## Fix

For a `removed` event with no live entry, match against the **event's own carried fields** (`category`/`slug`/`title`) instead of requiring the live fetch:

```ts
const liveEntry = entriesByRef.get(ref);
const entry =
  liveEntry ??
  (action === "removed"
    ? { category: event.category ?? "", slug: event.slug ?? "", title: event.title ?? "" }
    : null);
if (!entry) continue;
```

The existing `savedSearchMatchesEntry` then matches on category + query (the event's title feeds the query text), producing the already-modeled `severity: "warning"` alert.

## Scoping / invariants

- The fallback is **only** for `removed`. `added`/`updated` events with a missing entry still skip (their payload doesn't carry match fields) — the existing "does not alert when the changed entry detail is unavailable" test still passes.
- Lib-only: `watch.tsx` is untouched (the event already carries enough to match, so no `loadEventEntries` change was needed).
- A saved search filtering on trust/source/platform won't match a removed entry (that data is gone) — matching is best-effort on the fields the event actually carries, per the issue.

## Tests

`tests/saved-search-alerts-lib.test.ts`:
- a `removed` event with an **empty** `entriesByRef` now yields a `severity: "warning"` alert;
- an `added` event with a missing entry still yields no alert (fallback stays scoped to `removed`).

## Validation

```
pnpm exec vitest run tests/saved-search-alerts-lib.test.ts tests/saved-search-alerts.test.ts   # 30 passed
pnpm --filter web exec tsc --noEmit   # no new type errors in the changed file
pnpm exec prettier --check apps/web/src/lib/saved-search-alerts-lib.ts tests/saved-search-alerts-lib.test.ts
```

No visual impact; no generated artifacts touched.