### PR TITLE
fix(web): drop the duplicate up-next job when only one job is spotlit

### DIFF
--- a/apps/web/src/lib/jobs-utils-lib.ts
+++ b/apps/web/src/lib/jobs-utils-lib.ts
@@ -95,6 +95,10 @@ export function pickDailySpotlight(
   if (pool.length === 0) return { current: null, next: null };
   const dayIndex = Math.floor(now / DAY);
   const i = ((dayIndex % pool.length) + pool.length) % pool.length;
-  const j = (i + 1) % pool.length;
-  return { current: pool[i] ?? null, next: pool[j] ?? null };
+  const current = pool[i] ?? null;
+  // With a single-job pool, `(i + 1) % 1 === i` would alias `next` to `current`
+  // (the jobs page would show the same job as both spotlighted and "up next").
+  // There is nothing else to rotate to, so there is no "up next" job.
+  const next = pool.length > 1 ? (pool[(i + 1) % pool.length] ?? null) : null;
+  return { current, next };
 }

--- a/tests/jobs-utils-lib.test.ts
+++ b/tests/jobs-utils-lib.test.ts
@@ -131,6 +131,28 @@ describe("pickDailySpotlight", () => {
     });
   });
 
+  it("has no 'up next' job when exactly one job qualifies", () => {
+    const solo = [
+      job({ slug: "solo", lastVerifiedAt: iso(0), postedAt: iso(1) }),
+    ];
+    expect(pickDailySpotlight(solo, NOW)).toEqual({
+      current: expect.objectContaining({ slug: "solo" }),
+      next: null,
+    });
+  });
+
+  it("never returns next === current for any pool size or day", () => {
+    for (const size of [1, 2, 3, 4]) {
+      const jobs = Array.from({ length: size }, (_, k) =>
+        job({ slug: `j-${k}`, lastVerifiedAt: iso(0), postedAt: iso(1) }),
+      );
+      for (let day = 0; day < size + 2; day += 1) {
+        const { current, next } = pickDailySpotlight(jobs, NOW + day * DAY);
+        if (next) expect(next.slug).not.toBe(current?.slug);
+      }
+    }
+  });
+
   it("rotates deterministically by day: same day → same pick, next day → next", () => {
     const today = pickDailySpotlight(pool, NOW);
     expect(pickDailySpotlight(pool, NOW + DAY - 1)).toEqual(today); // same UTC day slot


### PR DESCRIPTION
Closes #5424

## Problem

`pickDailySpotlight` picks `current = pool[i]` and `next = pool[(i + 1) % pool.length]` from the high-signal job pool. When exactly one job qualifies (`pool.length === 1`), `(i + 1) % 1 === i`, so `next` becomes an alias of `current`. `jobs.index.tsx` renders "Up next: {spotlight.next.title}" whenever `next` is truthy — so on any day where only one job clears the spotlight threshold, the page shows the **same** job as both currently spotlighted and "up next."

## Fix

`lib`-only change to `pickDailySpotlight`: only compute `next` when there's actually something else to rotate to.

```ts
const current = pool[i] ?? null;
const next = pool.length > 1 ? (pool[(i + 1) % pool.length] ?? null) : null;
return { current, next };
```

The `pool.length === 0` early return and the 2+‑job rotation are unchanged. No change needed in `jobs.index.tsx` — the existing `spotlight.next && …` guard omits the line once `next` is `null`.

## Invariant

`next` is never `=== current` for any pool size: for a single-job pool it's `null`; for 2+ jobs `(i + 1) % n !== i`.

## Tests

`tests/jobs-utils-lib.test.ts`:
- a single qualifying job returns `{ current: <that job>, next: null }`;
- `next.slug` is never equal to `current.slug` across pool sizes 1–4 and several days.

## Validation

```
pnpm exec vitest run tests/jobs-utils-lib.test.ts   # 16 passed
pnpm --filter web exec tsc --noEmit   # no new type errors in the changed file
pnpm exec prettier --check apps/web/src/lib/jobs-utils-lib.ts tests/jobs-utils-lib.test.ts
```

No visual impact beyond the "Up next" line correctly disappearing for a single-job pool. No route/UI file touched; no generated artifacts.