### PR TITLE
fix(web): document the submissions preflight honeypot response variant

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -5314,6 +5314,16 @@
                         "routeSuggestion"
                       ],
                       "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": { "type": "boolean", "enum": [true] },
+                        "valid": { "type": "boolean", "enum": [false] },
+                        "queued": { "type": "boolean", "enum": [false] }
+                      },
+                      "required": ["ok", "valid", "queued"],
+                      "additionalProperties": false
                     }
                   ]
                 }

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -6205,6 +6205,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -616,9 +616,22 @@ const submissionPreflightNonPrResponseSchema = submissionPreflightBaseResponseSc
   })
   .strict();
 
+// The honeypot short-circuit intentionally discards a bot submission and returns
+// this minimal shape (no category/slug/risk/blockers), deliberately giving no
+// signal that it was detected as a bot. It carries none of the base fields the
+// other two variants require, so it is documented as its own strict variant.
+const submissionPreflightHoneypotResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    valid: z.literal(false),
+    queued: z.literal(false),
+  })
+  .strict();
+
 export const submissionPreflightResponseSchema = z.union([
   submissionPreflightPrReadyResponseSchema,
   submissionPreflightNonPrResponseSchema,
+  submissionPreflightHoneypotResponseSchema,
 ]);
 
 export const downloadQuerySchema = z.object({

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -6209,6 +6209,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/tests/api-contracts-lib.test.ts
+++ b/tests/api-contracts-lib.test.ts
@@ -9,6 +9,7 @@ import {
   publicJobsQuerySchema,
   registrySearchQuerySchema,
   route,
+  submissionPreflightResponseSchema,
   votesToggleBodySchema,
 } from "../apps/web/src/lib/api/contracts-lib";
 
@@ -793,6 +794,35 @@ describe("contracts-lib route definitions", () => {
 });
 
 describe("contracts-lib zod schemas", () => {
+  it("submissionPreflightResponseSchema accepts the honeypot short-circuit shape", () => {
+    // The route's honeypot path returns exactly this; it must be a documented,
+    // valid response variant (previously it matched none of the union members).
+    const parsed = submissionPreflightResponseSchema.parse({
+      ok: true,
+      valid: false,
+      queued: false,
+    });
+    expect(parsed).toEqual({ ok: true, valid: false, queued: false });
+
+    // The variant is strict: no leaking extra fields, and the queued flag is
+    // pinned to false so it can't be confused with a real "queued" response.
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: true,
+        valid: false,
+        queued: false,
+        extra: "leak",
+      }).success,
+    ).toBe(false);
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: true,
+        valid: false,
+        queued: true,
+      }).success,
+    ).toBe(false);
+  });
+
   it("publicJobsQuerySchema matrix 0", () => {
     const parsed = publicJobsQuerySchema.parse({ limit: 1, offset: 0 });
     expect(parsed.limit).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #5245

## Problem

`/api/submissions/preflight` is registered with `responseSchema: submissionPreflightResponseSchema` (a union of a PR-ready and a non-PR variant, both requiring `category`/`slug`/`schema`/`risk`/`blockers`/`routeSuggestion`/…). But the honeypot short-circuit returns `{ ok: true, valid: false, queued: false }` — none of those required fields, plus a `queued` field that isn't in the schema at all. So the published OpenAPI contract for this endpoint never described a response the route can actually return; any codegen/consumer relying on it got an inaccurate picture.

## Fix

Schema-only (no route change): add the honeypot shape as a distinct, `.strict()` union variant so the contract documents it accurately.

```ts
const submissionPreflightHoneypotResponseSchema = z
  .object({
    ok: z.literal(true),
    valid: z.literal(false),
    queued: z.literal(false),
  })
  .strict();

export const submissionPreflightResponseSchema = z.union([
  submissionPreflightPrReadyResponseSchema,
  submissionPreflightNonPrResponseSchema,
  submissionPreflightHoneypotResponseSchema,
]);
```

The variant is `.strict()` and pins `queued: false`, so it can't shadow a real response: the PR-ready variant needs `valid: true`, and the non-PR variant is strict and requires the base fields the honeypot shape lacks — the three variants are mutually exclusive.

## Security property preserved

The honeypot's runtime behavior is **unchanged** — the route still silently discards the bot submission and returns the same minimal, uninformative shape, giving no signal it was detected. This PR only makes the schema/contract accurate; it does not touch `preflight.ts` or what triggers the honeypot. `tests/submission-api.test.ts`'s honeypot assertion passes unmodified.

## Generated artifacts

Regenerated the OpenAPI spec (`pnpm generate:openapi`); `pnpm validate:openapi` passes. The diff is limited to the added response variant on `/api/submissions/preflight` (12 lines in `openapi.json`, plus the `.yaml` mirrors).

## Tests

`tests/api-contracts-lib.test.ts`: `submissionPreflightResponseSchema` now parses `{ ok: true, valid: false, queued: false }`, and rejects a leaking extra field or `queued: true` (strictness). Existing PR-ready/non-PR parsing and the honeypot behavior test are unchanged.

## Validation

```
pnpm exec vitest run tests/api-contracts-lib.test.ts tests/api-contracts.test.ts tests/submission-api.test.ts   # 434 passed
pnpm validate:openapi   # passes (spec is fresh)
pnpm --filter web exec tsc --noEmit   # no new type errors in the changed file
```

No visual impact; no route/UI file touched.