### PR TITLE
fix(web): emit ItemList JSON-LD on jobs and compare index pages

### DIFF
--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { createFileRoute, Link, stripSearchParams } from "@tanstack/react-router";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { z } from "zod";
 import { X, ArrowRight, ExternalLink, Plus, Search as SearchIcon } from "lucide-react";
 import { ENTRIES } from "@/data/entries";
@@ -114,6 +115,19 @@ export const Route = createFileRoute("/compare/")({
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/compare") }],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Compare", path: "/compare" },
+      ]),
+      itemListScript(
+        COMPARISONS.map((comparison) => ({
+          name: comparison.title,
+          path: `/compare/${comparison.slug}`,
+        })),
+        { name: "HeyClaude comparisons" },
+      ),
+    ],
   }),
   component: ComparePage,
 });

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { PageContainer } from "@/components/page-container";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { createServerFn } from "@tanstack/react-start";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowUpRight, Search, Sparkles, X } from "lucide-react";
@@ -44,7 +45,7 @@ export const Route = createFileRoute("/jobs/")({
       jobs: (await loadPublicJobs()).map(normalizeJobListing).filter((job) => job.slug),
     };
   },
-  head: () => ({
+  head: ({ loaderData }) => ({
     meta: [
       { title: "Claude & AI workflow jobs — HeyClaude" },
       {
@@ -59,6 +60,19 @@ export const Route = createFileRoute("/jobs/")({
       { property: "og:url", content: absoluteUrl("/jobs") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/jobs") }],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Jobs", path: "/jobs" },
+      ]),
+      itemListScript(
+        (loaderData?.jobs ?? []).map((job) => ({
+          name: `${job.title} at ${job.company}`,
+          path: `/jobs/${job.slug}`,
+        })),
+        { name: "Claude & AI workflow jobs" },
+      ),
+    ],
   }),
   errorComponent: ({ error, reset }: ErrorComponentProps) => (
     <div className="mx-auto max-w-xl px-4 py-16 text-center">


### PR DESCRIPTION
# Pull Request

## Summary

- `jobs.index.tsx` and `compare.index.tsx` were the only two index-style routes whose `head()` emitted **no** `scripts:` (ItemList/breadcrumb JSON-LD), unlike `best.index.tsx`, `integrations.index.tsx`, `tags.index.tsx`, `for.index.tsx`, and `contributors.index.tsx`. This adds the missing structured data to both, closing the SEO gap.

Closes #5423

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves.

## Quality Evidence

- **Changed routes/components/endpoints/tools:**
  - `apps/web/src/routes/compare.index.tsx` — `head()` gains `scripts:` (breadcrumb + ItemList over the static `COMPARISONS`).
  - `apps/web/src/routes/jobs.index.tsx` — `head()` gains `scripts:` (breadcrumb + ItemList over the loader's `jobs`); the signature changes from `head: () =>` to `head: ({ loaderData }) =>`, matching the existing `jobs.$slug.tsx` pattern that already reads `loaderData` in `head()`.
- **Expected behavior:** both index pages now emit a `BreadcrumbList` (`Directory → Compare` / `Directory → Jobs`) plus an `ItemList` of the visible comparisons/jobs, using the same `breadcrumbScript`/`itemListScript` helpers from `@/lib/seo-jsonld` that `best.index.tsx` and `integrations.index.tsx` use — no new pattern invented.
- **Important edge cases or invariants:**
  - `jobs.index.tsx` guards with `loaderData?.jobs ?? []`, so a pending/error render (no loader data) emits a well-formed, empty `ItemList` rather than throwing — same defensive shape `jobs.$slug.tsx` uses (`loaderData?.job`).
  - Existing `meta`/`og:*`/`links` (canonical) on both pages are untouched.
  - Job item names use `"{title} at {company}"`, consistent with how `jobs.$slug.tsx` builds its title.
- **Backward compatibility notes:** additive only — no existing tag changed, no data source added, no visual/layout change.
- **Screenshots for frontend/page/UI changes:** `No visual impact` — JSON-LD lives in `<script type="application/ld+json">` and is never rendered visibly (the issue calls this out explicitly).
- **Focused tests or reason tests are not practical:** these are route `head()` blocks (`.tsx`), which are excluded from the vitest node coverage denominator per `vitest.config.ts` (`**/*.tsx` in `coverage.exclude`); they reuse the already-tested `itemListScript`/`breadcrumbScript` helpers and `@heyclaude/registry/seo` builders that `best.index.tsx` exercises in production, so no new lib logic was introduced to test.

## Validation

- [x] Platform/code PR: focused validation listed below.
- Focused checks run locally:
  - `pnpm exec prettier --check apps/web/src/routes/jobs.index.tsx apps/web/src/routes/compare.index.tsx` — **passed** (both files match Prettier style).
  - `git diff --check` — clean.
  - `pnpm --filter web exec tsc --noEmit` — the changed lines (the `scripts:` arrays, `loaderData` destructure, and `itemListScript`/`breadcrumbScript` calls) produce **no** diagnostics. The only errors reported for these files are the repo-wide `createFileRoute("/…")` "type undefined" baseline that hits every route when the generated route tree is absent locally; CI regenerates it before type-checking.

## Notes

- Linked issue: Closes #5423.
- Scoped exactly to the two `head()` blocks named in the issue; no other route, no `og:image` work (tracked separately), no layout/content change.
