### PR TITLE
fix(api): document preflight honeypot response

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -5314,6 +5314,16 @@
                         "routeSuggestion"
                       ],
                       "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "ok": { "type": "boolean", "enum": [true] },
+                        "valid": { "type": "boolean", "enum": [false] },
+                        "queued": { "type": "boolean", "enum": [false] }
+                      },
+                      "required": ["ok", "valid", "queued"],
+                      "additionalProperties": false
                     }
                   ]
                 }

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -6205,6 +6205,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -616,9 +616,23 @@ const submissionPreflightNonPrResponseSchema = submissionPreflightBaseResponseSc
   })
   .strict();
 
+// The honeypot short-circuit in preflight.ts returns this exact sparse shape
+// instead of the full preflight response - documented here as its own variant
+// so the published contract matches reality. Runtime behavior is unchanged:
+// this must stay a silent `ok: true` discard with no signal that the request
+// was detected as a bot.
+const submissionPreflightHoneypotResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    valid: z.literal(false),
+    queued: z.literal(false),
+  })
+  .strict();
+
 export const submissionPreflightResponseSchema = z.union([
   submissionPreflightPrReadyResponseSchema,
   submissionPreflightNonPrResponseSchema,
+  submissionPreflightHoneypotResponseSchema,
 ]);
 
 export const downloadQuerySchema = z.object({

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -6209,6 +6209,25 @@ paths:
                       - valid
                       - routeSuggestion
                     additionalProperties: false
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
+                    additionalProperties: false
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -532,4 +532,50 @@ describe("website submission preflight API", () => {
       queued: false,
     });
   });
+
+  it("validates the honeypot discard response against the published response schema", async () => {
+    const { submissionPreflightResponseSchema } =
+      await import("@/lib/api/contracts");
+    const { POST } = await import("@/routes/api/submissions/preflight");
+    const response = await POST(
+      preflightRequest({ fields: validFields(), honeypot: "bot" }),
+    );
+    const body = await response.json();
+
+    // The real runtime response must be exactly this shape and validate as a
+    // documented variant of the published contract.
+    expect(body).toEqual({ ok: true, valid: false, queued: false });
+    expect(submissionPreflightResponseSchema.safeParse(body).success).toBe(
+      true,
+    );
+
+    // Near-misses must still be rejected, so the schema stays exact rather
+    // than accidentally loosening to accept any `{ ok, valid }` object.
+    expect(
+      submissionPreflightResponseSchema.safeParse({ ok: true, valid: false })
+        .success,
+    ).toBe(false);
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: true,
+        valid: false,
+        queued: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: false,
+        valid: false,
+        queued: false,
+      }).success,
+    ).toBe(false);
+    expect(
+      submissionPreflightResponseSchema.safeParse({
+        ok: true,
+        valid: false,
+        queued: false,
+        extra: "unexpected",
+      }).success,
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Screenshot evidence

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="desktop-light-before" src="https://github.com/user-attachments/assets/0178b32e-36ae-43ad-b675-fc312e3f62ee" /> | <img width="1440" height="900" alt="desktop-light-after" src="https://github.com/user-attachments/assets/36b608af-ce49-4391-8613-f878b454b2d8" /> |
| Desktop · Dark | <img width="1440" height="900" alt="desktop-dark-before" src="https://github.com/user-attachments/assets/7197ae97-338e-4629-8e46-190b0b258667" /> | <img width="1440" height="900" alt="desktop-dark-after" src="https://github.com/user-attachments/assets/fa2834ea-2ae5-4c2d-82c5-4a7e213a6112" /> |
| Tablet · Light | <img width="768" height="1024" alt="table-light-before" src="https://github.com/user-attachments/assets/a3d45e95-9c0f-4350-ad8f-1cbbfc79e408" /> | <img width="768" height="1024" alt="table-light-after" src="https://github.com/user-attachments/assets/d5df583e-712f-400e-95e7-d85109900f98" /> |
| Tablet · Dark | <img width="768" height="1024" alt="table-dark-before" src="https://github.com/user-attachments/assets/3864fde2-abda-47ad-b65f-66337bed4689" /> | <img width="768" height="1024" alt="table-dark-after" src="https://github.com/user-attachments/assets/a186713e-ade2-4a7d-b795-bc853b27542a" /> |
| Mobile · Light | <img width="390" height="844" alt="mobile-light-before" src="https://github.com/user-attachments/assets/4aa7a8d5-3d83-4c6a-aa06-2052695ee605" /> | <img width="390" height="844" alt="mobile-light-after" src="https://github.com/user-attachments/assets/f71d32a9-fc0a-40e6-9986-e645a6ed6790" /> |
| Mobile · Dark | <img width="390" height="844" alt="mobile-dark-before" src="https://github.com/user-attachments/assets/fe2870fe-16ff-4378-86be-75a9005932eb" /> | <img width="390" height="844" alt="mobile-dark-after" src="https://github.com/user-attachments/assets/9e0b7df6-c8e3-4d6b-9725-9438239ca910" /> |

## Temporary uploads

## Summary

- document the existing preflight honeypot response in the published contract
- preserve silent discard and no-queueing behavior
- validate the real route response against the published schema
- regenerate the official OpenAPI artifacts

Closes #5245

## Contract change

Before, the published response schema did not accept the endpoint's existing
honeypot response.

After, the published contract includes this strict response variant:

```json
{
  "ok": true,
  "valid": false,
  "queued": false
}
```

The schema requires all three properties and rejects additional properties.

The runtime route and honeypot behavior are unchanged.

## Validation

- focused submission and API contract tests: 29 passed
- OpenAPI generation completed
- OpenAPI validation passed
- web type-check passed
- web build passed
- Prettier check passed
- `git diff --check` passed

## Visual-impact note

Issue #5245 has no product UI impact. The screenshots above visualize the real
generated OpenAPI contract before and after the change.