### PR TITLE
fix(web): emit ItemList JSON-LD on jobs and compare index pages

### DIFF
--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { createFileRoute, Link, stripSearchParams } from "@tanstack/react-router";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { z } from "zod";
 import { X, ArrowRight, ExternalLink, Plus, Search as SearchIcon } from "lucide-react";
 import { ENTRIES } from "@/data/entries";
@@ -114,6 +115,19 @@ export const Route = createFileRoute("/compare/")({
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/compare") }],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Compare", path: "/compare" },
+      ]),
+      itemListScript(
+        COMPARISONS.map((comparison) => ({
+          name: comparison.title,
+          path: `/compare/${comparison.slug}`,
+        })),
+        { name: "HeyClaude comparisons" },
+      ),
+    ],
   }),
   component: ComparePage,
 });

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { PageContainer } from "@/components/page-container";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { createServerFn } from "@tanstack/react-start";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowUpRight, Search, Sparkles, X } from "lucide-react";
@@ -44,7 +45,7 @@ export const Route = createFileRoute("/jobs/")({
       jobs: (await loadPublicJobs()).map(normalizeJobListing).filter((job) => job.slug),
     };
   },
-  head: () => ({
+  head: ({ loaderData }) => ({
     meta: [
       { title: "Claude & AI workflow jobs — HeyClaude" },
       {
@@ -59,6 +60,19 @@ export const Route = createFileRoute("/jobs/")({
       { property: "og:url", content: absoluteUrl("/jobs") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/jobs") }],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Jobs", path: "/jobs" },
+      ]),
+      itemListScript(
+        (loaderData?.jobs ?? []).map((job) => ({
+          name: `${job.title} at ${job.company}`,
+          path: `/jobs/${job.slug}`,
+        })),
+        { name: "Claude & AI workflow jobs" },
+      ),
+    ],
   }),
   errorComponent: ({ error, reset }: ErrorComponentProps) => (
     <div className="mx-auto max-w-xl px-4 py-16 text-center">


### PR DESCRIPTION
# Pull Request

## Summary

- `jobs.index.tsx` and `compare.index.tsx` were the only two index-style routes whose `head()` emitted **no** `scripts:` (ItemList/breadcrumb JSON-LD), unlike `best.index.tsx`, `integrations.index.tsx`, `tags.index.tsx`, `for.index.tsx`, and `contributors.index.tsx`. This adds the missing structured data to both, closing the SEO gap.

Closes #5423

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots are included below (route-touching change → full before/after matrix).
- [x] This PR links the issue it resolves.

## Quality Evidence

- **Changed routes:**
  - `apps/web/src/routes/compare.index.tsx` — `head()` gains `scripts:` (breadcrumb + ItemList over the static `COMPARISONS`).
  - `apps/web/src/routes/jobs.index.tsx` — `head()` gains `scripts:` (breadcrumb + ItemList over the loader's `jobs`); signature changes from `head: () =>` to `head: ({ loaderData }) =>`, matching `jobs.$slug.tsx` which already reads `loaderData` in `head()`.
- **Expected behavior:** both index pages emit a `BreadcrumbList` (`Directory → Compare` / `Directory → Jobs`) plus an `ItemList` of the visible comparisons/jobs, via the same `breadcrumbScript`/`itemListScript` helpers from `@/lib/seo-jsonld` that `best.index.tsx` and `integrations.index.tsx` use.
- **Edge cases / invariants:** `jobs.index.tsx` guards with `loaderData?.jobs ?? []`; existing `meta`/`og:*`/canonical are untouched; job item names use `"{title} at {company}"`, consistent with `jobs.$slug.tsx`.
- **Backward compatibility:** additive only — no existing tag changed, no visual/layout change.

## Screenshot evidence

Structured data (JSON-LD) is injected into `<head>` and is **not visually rendered**, so the rendered pages are identical before and after — the matrices below document that there is no visual regression at any breakpoint or theme. Captured against a local dev build at the exact PR commit (before = `upstream/main`, after = this branch). The local jobs board is empty because there is no jobs DB in the dev environment; the `/compare` page renders its full static list.

### `/compare`

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="compare-desktop-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-desktop-light-before.png" /> | <img width="1440" height="900" alt="compare-desktop-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-desktop-light-after.png" /> |
| Desktop · Dark | <img width="1440" height="900" alt="compare-desktop-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-desktop-dark-before.png" /> | <img width="1440" height="900" alt="compare-desktop-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-desktop-dark-after.png" /> |
| Tablet · Light | <img width="768" height="1024" alt="compare-tablet-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-tablet-light-before.png" /> | <img width="768" height="1024" alt="compare-tablet-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-tablet-light-after.png" /> |
| Tablet · Dark | <img width="768" height="1024" alt="compare-tablet-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-tablet-dark-before.png" /> | <img width="768" height="1024" alt="compare-tablet-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-tablet-dark-after.png" /> |
| Mobile · Light | <img width="390" height="844" alt="compare-mobile-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-mobile-light-before.png" /> | <img width="390" height="844" alt="compare-mobile-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-mobile-light-after.png" /> |
| Mobile · Dark | <img width="390" height="844" alt="compare-mobile-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-mobile-dark-before.png" /> | <img width="390" height="844" alt="compare-mobile-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/compare-mobile-dark-after.png" /> |

### `/jobs`

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="jobs-desktop-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-desktop-light-before.png" /> | <img width="1440" height="900" alt="jobs-desktop-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-desktop-light-after.png" /> |
| Desktop · Dark | <img width="1440" height="900" alt="jobs-desktop-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-desktop-dark-before.png" /> | <img width="1440" height="900" alt="jobs-desktop-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-desktop-dark-after.png" /> |
| Tablet · Light | <img width="768" height="1024" alt="jobs-tablet-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-tablet-light-before.png" /> | <img width="768" height="1024" alt="jobs-tablet-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-tablet-light-after.png" /> |
| Tablet · Dark | <img width="768" height="1024" alt="jobs-tablet-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-tablet-dark-before.png" /> | <img width="768" height="1024" alt="jobs-tablet-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-tablet-dark-after.png" /> |
| Mobile · Light | <img width="390" height="844" alt="jobs-mobile-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-mobile-light-before.png" /> | <img width="390" height="844" alt="jobs-mobile-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-mobile-light-after.png" /> |
| Mobile · Dark | <img width="390" height="844" alt="jobs-mobile-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-mobile-dark-before.png" /> | <img width="390" height="844" alt="jobs-mobile-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5423/jobs-mobile-dark-after.png" /> |

## Validation

- [x] Focused checks: `pnpm exec prettier --check` on both files — clean; `git diff --check` — clean; targeted `tsc` shows no diagnostics on the changed lines (repo-wide `createFileRoute` "type undefined" errors are the ungenerated-route-tree baseline; CI regenerates it). Full `validate-web` passed green on the original run of this PR.

## Notes

- Linked issue: Closes #5423.
- Scoped to the two `head()` blocks named in the issue; no other route, no `og:image` work, no layout change.
- Screenshots are hosted on the `pr-assets` branch of the author's fork and referenced by raw URL to keep the PR diff free of binary files.
