### PR TITLE
fix(web): paginate admin listing-leads list/CSV export with an offset param

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -6947,6 +6947,12 @@
             "in": "query"
           },
           {
+            "schema": { "type": ["integer", "null"], "minimum": 0, "maximum": 10000, "default": 0 },
+            "required": false,
+            "name": "offset",
+            "in": "query"
+          },
+          {
             "schema": { "type": "string", "default": "" },
             "required": false,
             "name": "format",

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -8134,6 +8134,16 @@ paths:
           name: limit
           in: query
         - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            maximum: 10000
+            default: 0
+          required: false
+          name: offset
+          in: query
+        - schema:
             type: string
             default: ""
           required: false

--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -701,6 +701,7 @@ export const adminListingLeadsQuerySchema = z.object({
     .optional()
     .default(""),
   limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  offset: z.coerce.number().int().min(0).max(10_000).optional().default(0),
   format: z.string().trim().toLowerCase().optional().default(""),
 });
 

--- a/apps/web/src/lib/listing-leads-csv-lib.ts
+++ b/apps/web/src/lib/listing-leads-csv-lib.ts
@@ -22,6 +22,19 @@ const CSV_COLUMNS = [
   "updated_at",
 ] as const;
 
+/** Upper bound on the paginated `offset` (mirrors `adminListingLeadsQuerySchema`). */
+export const LISTING_LEADS_MAX_OFFSET = 10_000;
+
+/**
+ * Clamp a paginated `offset` into `[0, LISTING_LEADS_MAX_OFFSET]`, truncating to
+ * an integer. Keeps the SQL `OFFSET ?` bind well-formed for any coerced input
+ * (negative, fractional, out-of-range, or NaN → 0).
+ */
+export function clampListingLeadsOffset(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(LISTING_LEADS_MAX_OFFSET, Math.trunc(value)));
+}
+
 /** Normalize a lead-kind filter to an allow-listed value, or "" when unknown. */
 export function normalizeKind(value: string | null): string {
   const normalized = String(value ?? "")

--- a/apps/web/src/routes/api/admin/listing-leads.ts
+++ b/apps/web/src/routes/api/admin/listing-leads.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/api/router";
 import { isLeadsAdminAuthorized } from "@/lib/admin-auth";
 import { logApiError, logApiInfo, logApiWarn } from "@/lib/api-logs";
-import { leadsToCsv, normalizeKind } from "@/lib/listing-leads-csv-lib";
+import { clampListingLeadsOffset, leadsToCsv, normalizeKind } from "@/lib/listing-leads-csv-lib";
 import { getSiteDb } from "@/lib/db";
 
 const MAX_LIMIT = 100;
@@ -38,6 +38,7 @@ export const GET = createApiHandler(
     const kind = normalizeKind(query.kind);
     const status = normalizeCommercialStatus(query.status);
     const limit = Math.max(1, Math.min(MAX_LIMIT, Math.trunc(query.limit)));
+    const offset = clampListingLeadsOffset(query.offset);
     const format = query.format;
 
     const where = [];
@@ -71,9 +72,9 @@ export const GET = createApiHandler(
       FROM listing_leads
       ${whereSql}
       ORDER BY created_at DESC
-      LIMIT ?`,
+      LIMIT ? OFFSET ?`,
       )
-      .bind(...values, limit)
+      .bind(...values, limit, offset)
       .all();
 
     if (format === "csv") {

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -8139,6 +8139,16 @@ paths:
           name: limit
           in: query
         - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            maximum: 10000
+            default: 0
+          required: false
+          name: offset
+          in: query
+        - schema:
             type: string
             default: ""
           required: false

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -262,6 +262,17 @@ describe("OpenAPI route coverage", () => {
     expect(schema).toContain("status transition");
   });
 
+  it("paginates the admin listing-leads endpoint with an offset query param", () => {
+    expect(
+      parsedSchema.paths["/api/admin/listing-leads"]?.get?.parameters,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "limit", in: "query" }),
+        expect.objectContaining({ name: "offset", in: "query" }),
+      ]),
+    );
+  });
+
   it("documents platform-aware search and social preview generation", () => {
     expect(parsedSchema.paths["/api/registry/search"]?.get?.parameters).toEqual(
       expect.arrayContaining([

--- a/tests/listing-leads-csv-lib.test.ts
+++ b/tests/listing-leads-csv-lib.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { leadsToCsv, normalizeKind } from "@/lib/listing-leads-csv-lib";
+import {
+  LISTING_LEADS_MAX_OFFSET,
+  clampListingLeadsOffset,
+  leadsToCsv,
+  normalizeKind,
+} from "@/lib/listing-leads-csv-lib";
 
 describe("normalizeKind", () => {
   it("accepts allow-listed kinds, case/space-insensitively", () => {
@@ -12,6 +17,33 @@ describe("normalizeKind", () => {
   it("returns '' for unknown or missing kinds", () => {
     expect(normalizeKind("sponsor")).toBe("");
     expect(normalizeKind(null)).toBe("");
+  });
+});
+
+describe("clampListingLeadsOffset", () => {
+  it("passes through an in-range offset (page 2 reaches lead #101)", () => {
+    // With the newest 100 leads on page 1 (LIMIT 100 OFFSET 0), offset=100 is
+    // what makes lead #101 reachable — the whole point of the pagination fix.
+    expect(clampListingLeadsOffset(100)).toBe(100);
+    expect(clampListingLeadsOffset(0)).toBe(0);
+    expect(clampListingLeadsOffset(LISTING_LEADS_MAX_OFFSET)).toBe(
+      LISTING_LEADS_MAX_OFFSET,
+    );
+  });
+
+  it("floors negatives to 0 and truncates fractionals", () => {
+    expect(clampListingLeadsOffset(-1)).toBe(0);
+    expect(clampListingLeadsOffset(-1000)).toBe(0);
+    expect(clampListingLeadsOffset(100.9)).toBe(100);
+  });
+
+  it("caps above the max and coerces non-finite input to 0", () => {
+    expect(clampListingLeadsOffset(LISTING_LEADS_MAX_OFFSET + 1)).toBe(
+      LISTING_LEADS_MAX_OFFSET,
+    );
+    expect(clampListingLeadsOffset(Number.NaN)).toBe(0);
+    // Non-finite input (±Infinity) is garbage, not "the last page" — floor to 0.
+    expect(clampListingLeadsOffset(Number.POSITIVE_INFINITY)).toBe(0);
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Summary

- `adminListingLeadsQuerySchema` had `limit` (capped at 100) but **no** `offset`. Because the API router parses queries with a non-`.strict()` zod schema, an unknown `?offset=…` key is silently dropped before the handler sees it. Once `listing_leads` exceeds 100 rows, every lead older than the newest 100 is permanently unreachable through both the JSON list and the CSV export — no error, no truncation signal.
- This adds `offset` (mirroring `adminJobsQuerySchema`) and binds it into a `LIMIT ? OFFSET ?` clause on the shared query used by both the JSON and CSV paths.

Closes #5269

## Submission Source

For registry API endpoint PRs:

- [x] Route handler (`listing-leads.ts`) and central API contract (`contracts-lib.ts` schema) changed together.
- [x] Origin-check/rate-limit posture unchanged — token-gated admin endpoint (`isLeadsAdminAuthorized`); no auth/rate-limit behavior touched.
- [x] OpenAPI regenerated via `scripts/generate-openapi.ts` (source-driven, not hand-edited); `--check` passes.
- [x] API contract test added.
- [x] Screenshots included below (route-touching change → matrix of the API documentation surface).

## Quality Evidence

- **Changed routes/endpoints:**
  - `apps/web/src/lib/api/contracts-lib.ts` — `adminListingLeadsQuerySchema` gains `offset: z.coerce.number().int().min(0).max(10_000).optional().default(0)` (identical to `adminJobsQuerySchema`).
  - `apps/web/src/lib/listing-leads-csv-lib.ts` — new pure `clampListingLeadsOffset()` helper + exported `LISTING_LEADS_MAX_OFFSET`.
  - `apps/web/src/routes/api/admin/listing-leads.ts` — `GET` clamps `query.offset` and appends `OFFSET ?` for both the JSON list and CSV export.
  - Generated: `apps/web/public/openapi.json`, `apps/web/public/openapi.yaml`, `cloudflare/api-schema-heyclaude-openapi.yaml`.
- **Expected behavior:** `?offset=100` on `/api/admin/listing-leads` (JSON or `?format=csv`) returns the next page — lead #101 by `created_at DESC` becomes reachable. Omitting `offset` defaults to `0`, so existing callers are unchanged.
- **Edge cases:** `clampListingLeadsOffset` floors negatives to 0, truncates fractionals, caps at 10 000, coerces non-finite to 0 (zod already validates upstream). `limit`/`MAX_LIMIT` untouched (out of scope). Confirmed: install-only, config-only, and neither — the offset path is independent of those filters.

## Screenshot evidence

This is a **backend/API + CSV change** — it modifies the endpoint's OpenAPI schema, the SQL query, and the CSV/JSON handler, none of which render pixels. The public visual surface for this endpoint is the **API documentation page** (`/api-docs`), shown below across every viewport × theme, before (`upstream/main`) and after (this branch), to confirm no visual regression. The new `offset` query param is carried in the linked `OpenAPI JSON`/`YAML` specs (regenerated in this PR); `/api-docs` renders its endpoint list from the curated `ENDPOINTS` dataset, which is unchanged, so the page is intentionally identical before/after.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="apidocs-desktop-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-desktop-light-before.png" /> | <img width="1440" height="900" alt="apidocs-desktop-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-desktop-light-after.png" /> |
| Desktop · Dark | <img width="1440" height="900" alt="apidocs-desktop-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-desktop-dark-before.png" /> | <img width="1440" height="900" alt="apidocs-desktop-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-desktop-dark-after.png" /> |
| Tablet · Light | <img width="768" height="1024" alt="apidocs-tablet-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-tablet-light-before.png" /> | <img width="768" height="1024" alt="apidocs-tablet-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-tablet-light-after.png" /> |
| Tablet · Dark | <img width="768" height="1024" alt="apidocs-tablet-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-tablet-dark-before.png" /> | <img width="768" height="1024" alt="apidocs-tablet-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-tablet-dark-after.png" /> |
| Mobile · Light | <img width="390" height="844" alt="apidocs-mobile-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-mobile-light-before.png" /> | <img width="390" height="844" alt="apidocs-mobile-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-mobile-light-after.png" /> |
| Mobile · Dark | <img width="390" height="844" alt="apidocs-mobile-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-mobile-dark-before.png" /> | <img width="390" height="844" alt="apidocs-mobile-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5435/apidocs-mobile-dark-after.png" /> |

## Validation

Focused checks run locally (all green):
- `pnpm exec vitest run tests/listing-leads-csv-lib.test.ts tests/api-contracts.test.ts` — **23 passed** (new `clampListingLeadsOffset` suite exercises the `offset=100` → lead #101 boundary, plus negative/fractional/over-max/non-finite).
- `pnpm exec vitest run tests/api-router-security.test.ts tests/submission-api.test.ts` — **51 passed**.
- `pnpm exec tsx scripts/generate-openapi.ts --check` — **passes** (committed OpenAPI matches source).
- `pnpm exec prettier --check` on all touched files — clean; `git diff --check` — clean.

## Notes

- Linked issue: Closes #5269.
- Scoped exactly to the issue's Scope list; `adminJobsQuerySchema` (the reference implementation) is untouched. OpenAPI regeneration produced only the `offset` param on this one endpoint.
- Screenshots are hosted on the `pr-assets` branch of the author's fork and referenced by raw URL to keep the PR diff free of binary files.
