### PR TITLE
fix(web): use theme-aware text-trust-review for the watch/caution tier (dark-mode WCAG)

### DIFF
--- a/apps/web/src/components/compare-decision-brief-panel.tsx
+++ b/apps/web/src/components/compare-decision-brief-panel.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 const TONE_BADGE: Record<CompareBriefTone, string> = {
   ready: "border-trust-trusted/30 bg-trust-trusted/10 text-trust-trusted",
   review: "border-accent/30 bg-accent/10 text-ink",
-  caution: "border-amber-500/30 bg-amber-500/10 text-amber-900",
+  caution: "border-amber-500/30 bg-amber-500/10 text-trust-review",
   blocked: "border-trust-blocked/30 bg-trust-blocked/10 text-trust-blocked",
 };
 
@@ -68,7 +68,7 @@ export function CompareDecisionBriefPanel({
           <div className="flex items-start gap-2">
             <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-700" aria-hidden />
             <div className="min-w-0">
-              <p className="text-amber-900">
+              <p className="text-trust-review">
                 Divergence detected
                 {state.divergingLabels.length > 0
                   ? ` on ${state.divergingLabels.slice(0, 4).join(", ")}`
@@ -184,7 +184,7 @@ export function CompareDecisionBriefPanel({
               )}
 
               {compact && brief.checklist.some((item) => item.required && !item.done) ? (
-                <div className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-900">
+                <div className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] text-trust-review">
                   <AlertTriangle className="h-3 w-3" aria-hidden />
                   Required checks still pending
                 </div>

--- a/apps/web/src/components/compare-rollout-readiness-panel.tsx
+++ b/apps/web/src/components/compare-rollout-readiness-panel.tsx
@@ -134,7 +134,7 @@ export function CompareRolloutReadinessPanel({
                       item.tone === "complete" &&
                         "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted",
                       item.tone === "warning" &&
-                        "border-amber-500/30 bg-amber-500/5 text-amber-900",
+                        "border-amber-500/30 bg-amber-500/5 text-trust-review",
                       item.tone === "blocked" &&
                         "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked",
                     )}

--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -167,7 +167,7 @@ export function ComparisonTray() {
               {tray.count}/{tray.maxCount}
             </span>
             {trustDivergenceBadge ? (
-              <span className="rounded-full border border-amber-300/60 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-900">
+              <span className="rounded-full border border-amber-300/60 bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-trust-review">
                 {trustDivergenceBadge}
               </span>
             ) : null}

--- a/apps/web/src/components/entry-adoption-plan-panel.tsx
+++ b/apps/web/src/components/entry-adoption-plan-panel.tsx
@@ -8,7 +8,7 @@ function RiskBadge({ score }: { score: number }) {
     score >= 60
       ? "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked"
       : score >= 30
-        ? "border-amber-500/40 bg-amber-500/10 text-amber-900"
+        ? "border-amber-500/40 bg-amber-500/10 text-trust-review"
         : "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
   return (
     <span

--- a/apps/web/src/components/entry-safety-surface-panel.tsx
+++ b/apps/web/src/components/entry-safety-surface-panel.tsx
@@ -87,7 +87,7 @@ export function EntrySafetySurfacePanel({
                 active
                   ? "border-accent bg-accent/10 text-ink"
                   : sensitive
-                    ? "border-amber-500/40 bg-amber-500/5 text-amber-900 hover:border-amber-500/60"
+                    ? "border-amber-500/40 bg-amber-500/5 text-trust-review hover:border-amber-500/60"
                     : "border-border bg-background text-ink-muted hover:text-ink",
               )}
             >

--- a/apps/web/src/components/entry-setup-snapshot-panel.tsx
+++ b/apps/web/src/components/entry-setup-snapshot-panel.tsx
@@ -32,7 +32,7 @@ type StatTone = "good" | "watch" | "risk" | "muted";
 
 function toneText(tone: StatTone): string {
   if (tone === "good") return "text-trust-trusted";
-  if (tone === "watch") return "text-amber-900";
+  if (tone === "watch") return "text-trust-review";
   if (tone === "risk") return "text-trust-blocked";
   return "text-ink-muted";
 }

--- a/apps/web/src/lib/browse-adoption-queue-lib.ts
+++ b/apps/web/src/lib/browse-adoption-queue-lib.ts
@@ -197,7 +197,7 @@ function summary(rows: BrowseAdoptionQueueRow[], scannedCount: number): string {
 
 export function browseAdoptionTierClass(tier: BrowseAdoptionTier): string {
   if (tier === "ready") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
-  if (tier === "caution") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  if (tier === "caution") return "border-amber-500/35 bg-amber-500/5 text-trust-review";
   return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
 }
 

--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -170,7 +170,7 @@ function summary(rows: BrowseConfidenceEntry[], scannedCount: number): string {
 
 export function browseConfidenceBandClass(band: BrowseConfidenceBand): string {
   if (band === "high") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
-  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-trust-review";
   return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
 }
 

--- a/apps/web/src/lib/browse-rollout-tone-lib.ts
+++ b/apps/web/src/lib/browse-rollout-tone-lib.ts
@@ -4,6 +4,6 @@
 /** Border/background/text classes for a rollout signal tone. */
 export function toneClass(tone: "good" | "watch" | "risk"): string {
   if (tone === "good") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
-  if (tone === "watch") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+  if (tone === "watch") return "border-amber-500/30 bg-amber-500/5 text-trust-review";
   return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
 }

--- a/apps/web/src/lib/compare-deployment-risk-map-lib.ts
+++ b/apps/web/src/lib/compare-deployment-risk-map-lib.ts
@@ -6,7 +6,7 @@ export type DeploymentRiskBand = "low" | "medium" | "high";
 /** Tailwind border/background/text classes for a deployment risk band chip. */
 export function deploymentRiskBandClass(band: DeploymentRiskBand): string {
   if (band === "high") return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
-  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-trust-review";
   return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
 }
 

--- a/apps/web/src/lib/compare-evidence-severity-lib.ts
+++ b/apps/web/src/lib/compare-evidence-severity-lib.ts
@@ -4,6 +4,6 @@
 /** Border/background/text classes for an evidence-gap severity. */
 export function severityClass(severity: "low" | "medium" | "high"): string {
   if (severity === "high") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
-  if (severity === "medium") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+  if (severity === "medium") return "border-amber-500/30 bg-amber-500/5 text-trust-review";
   return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
 }

--- a/apps/web/src/lib/compare-mitigation-priority-lib.ts
+++ b/apps/web/src/lib/compare-mitigation-priority-lib.ts
@@ -176,7 +176,7 @@ function summary(entries: MitigationPriorityEntry[]): string {
 
 export function mitigationPriorityTierClass(tier: MitigationPriorityTier): string {
   if (tier === "urgent") return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
-  if (tier === "watch") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  if (tier === "watch") return "border-amber-500/35 bg-amber-500/5 text-trust-review";
   return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
 }
 

--- a/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
+++ b/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
@@ -6,7 +6,7 @@ export type OperationalFitTone = "strong" | "mixed" | "weak";
 /** Tailwind border/background/text classes for an operational-fit tone chip. */
 export function operationalFitToneClass(tone: OperationalFitTone): string {
   if (tone === "strong") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
-  if (tone === "mixed") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  if (tone === "mixed") return "border-amber-500/35 bg-amber-500/5 text-trust-review";
   return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
 }
 

--- a/apps/web/src/lib/compare-rollout-tier-lib.ts
+++ b/apps/web/src/lib/compare-rollout-tier-lib.ts
@@ -5,5 +5,5 @@
 export function tierClass(tier: "ready" | "review" | "hold"): string {
   if (tier === "ready") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
   if (tier === "hold") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
-  return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+  return "border-amber-500/30 bg-amber-500/5 text-trust-review";
 }

--- a/apps/web/src/lib/entry-decision-timeline-lib.ts
+++ b/apps/web/src/lib/entry-decision-timeline-lib.ts
@@ -15,7 +15,7 @@ export function decisionStepToneClass(tone: DecisionTimelineStepTone): string {
 /** Tailwind chip classes for a decision-timeline risk score (0-100). */
 export function decisionRiskClass(score: number): string {
   if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
-  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
+  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-trust-review";
   return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
 }
 

--- a/apps/web/src/lib/entry-evidence-tone-lib.ts
+++ b/apps/web/src/lib/entry-evidence-tone-lib.ts
@@ -4,7 +4,7 @@
 /** Border/background/text classes for a risk score (higher = worse). */
 export function riskTone(score: number): string {
   if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
-  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
+  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-trust-review";
   return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
 }
 

--- a/apps/web/src/lib/resource-card-trust-decision-lib.ts
+++ b/apps/web/src/lib/resource-card-trust-decision-lib.ts
@@ -42,8 +42,8 @@ export type ResourceCardTrustHintKind =
 const TRUST_HINT_TONE_CLASS: Record<ResourceCardTrustHintKind, string> = {
   aligns: "border-border bg-surface text-ink-muted",
   stronger: "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted",
-  weaker: "border-trust-review/30 bg-trust-review/5 text-amber-900",
-  diverges: "border-amber-500/30 bg-amber-500/5 text-amber-900",
+  weaker: "border-trust-review/30 bg-trust-review/5 text-trust-review",
+  diverges: "border-amber-500/30 bg-amber-500/5 text-trust-review",
   "mixed-trust": "border-accent/30 bg-accent/5 text-ink",
 };
 

--- a/tests/browse-rollout-tone-lib.test.ts
+++ b/tests/browse-rollout-tone-lib.test.ts
@@ -5,7 +5,7 @@ import { toneClass } from "../apps/web/src/lib/browse-rollout-tone-lib";
 describe("toneClass", () => {
   it("maps good/watch/risk to distinct trust/amber/blocked classes", () => {
     expect(toneClass("good")).toContain("text-trust-trusted");
-    expect(toneClass("watch")).toContain("text-amber-900");
+    expect(toneClass("watch")).toContain("text-trust-review");
     expect(toneClass("risk")).toContain("text-trust-blocked");
   });
 });

--- a/tests/compare-deployment-risk-map-lib.test.ts
+++ b/tests/compare-deployment-risk-map-lib.test.ts
@@ -208,7 +208,7 @@ describe("compare deployment risk map lib", () => {
 describe("deploymentRiskBandClass", () => {
   it("maps each band to its chip classes", () => {
     expect(deploymentRiskBandClass("high")).toContain("text-trust-blocked");
-    expect(deploymentRiskBandClass("medium")).toContain("text-amber-900");
+    expect(deploymentRiskBandClass("medium")).toContain("text-trust-review");
     expect(deploymentRiskBandClass("low")).toContain("text-trust-trusted");
   });
 });

--- a/tests/compare-evidence-severity-lib.test.ts
+++ b/tests/compare-evidence-severity-lib.test.ts
@@ -5,7 +5,7 @@ import { severityClass } from "../apps/web/src/lib/compare-evidence-severity-lib
 describe("severityClass", () => {
   it("maps high/medium/low to blocked/amber/trusted classes", () => {
     expect(severityClass("high")).toContain("text-trust-blocked");
-    expect(severityClass("medium")).toContain("text-amber-900");
+    expect(severityClass("medium")).toContain("text-trust-review");
     expect(severityClass("low")).toContain("text-trust-trusted");
   });
 });

--- a/tests/compare-operational-fit-heatmap-lib.test.ts
+++ b/tests/compare-operational-fit-heatmap-lib.test.ts
@@ -209,7 +209,7 @@ describe("compare operational fit heatmap lib", () => {
 describe("operationalFitToneClass", () => {
   it("maps each tone to its chip classes", () => {
     expect(operationalFitToneClass("strong")).toContain("text-trust-trusted");
-    expect(operationalFitToneClass("mixed")).toContain("text-amber-900");
+    expect(operationalFitToneClass("mixed")).toContain("text-trust-review");
     expect(operationalFitToneClass("weak")).toContain("text-trust-blocked");
   });
 });

--- a/tests/compare-rollout-tier-lib.test.ts
+++ b/tests/compare-rollout-tier-lib.test.ts
@@ -6,6 +6,6 @@ describe("tierClass", () => {
   it("maps ready/hold/review to trusted/blocked/amber classes", () => {
     expect(tierClass("ready")).toContain("text-trust-trusted");
     expect(tierClass("hold")).toContain("text-trust-blocked");
-    expect(tierClass("review")).toContain("text-amber-900");
+    expect(tierClass("review")).toContain("text-trust-review");
   });
 });

--- a/tests/entry-decision-timeline-lib.test.ts
+++ b/tests/entry-decision-timeline-lib.test.ts
@@ -225,7 +225,7 @@ describe("decisionStepToneClass", () => {
 describe("decisionRiskClass", () => {
   it("bands the risk score into chip classes", () => {
     expect(decisionRiskClass(60)).toContain("text-trust-blocked");
-    expect(decisionRiskClass(30)).toContain("text-amber-900");
+    expect(decisionRiskClass(30)).toContain("text-trust-review");
     expect(decisionRiskClass(29)).toContain("text-trust-trusted");
   });
 });

--- a/tests/entry-evidence-tone-lib.test.ts
+++ b/tests/entry-evidence-tone-lib.test.ts
@@ -8,7 +8,7 @@ import {
 describe("riskTone", () => {
   it("maps score bands to blocked / amber / trusted classes", () => {
     expect(riskTone(60)).toContain("text-trust-blocked");
-    expect(riskTone(30)).toContain("text-amber-900");
+    expect(riskTone(30)).toContain("text-trust-review");
     expect(riskTone(29)).toContain("text-trust-trusted");
   });
 });


### PR DESCRIPTION
# Pull Request

## Summary

- `text-amber-900` (`#78350f`) is a static light-mode color. Against dark-mode `--background` (`#0c0c0c`) / `--surface` (`#171717`) it measures **~2.16:1 / ~1.98:1** — well under WCAG AA (4.5:1) — making the "watch/caution/medium" tier text illegible in dark mode across browse, compare, and entry decision-support surfaces.
- This swaps every `text-amber-900` occurrence for the existing, WCAG-AA-tuned `--trust-review` token (`text-trust-review`), already used correctly in `alerts-dropdown.tsx` / `trust-drilldown.tsx`.

Closes #5404

## Submission Source

For platform/code PRs:

- [x] Not a direct content submission.
- [x] Changed components/libs listed below.
- [x] Screenshots included (route/component-touching change → before/after matrix).
- [x] Links the issue it resolves.

## Quality Evidence

- **Scope:** 17 source files (6 components + 11 libs) — every `text-amber-900` → `text-trust-review`; 7 affected `*-lib` test files updated to assert the new class. `grep -rn "text-amber-900" apps/web/src/` now returns nothing.
- **Expected behavior:** the watch/caution/medium tier text (trust snapshot, adoption/rollout queues, compare drawer/table, entry safety/adoption panels, evidence-severity badges) uses the theme-aware token, staying WCAG-AA-legible in dark mode. Light mode is materially unchanged (the token's light OKLCH renders visually close to the previous amber).
- **Out of scope (untouched):** `border-amber-500`/`bg-amber-500` classes, other tone tiers (red/emerald), the `--trust-review` token values in `styles.css`, and `alerts-dropdown.tsx`/`trust-drilldown.tsx` (already correct).
- **Backward compatibility:** pure class-name swap, no logic/layout change.

## Screenshot evidence

`/browse` (which renders the watch-tier text in the Trust Snapshot + Adoption Queue), all viewport × theme combinations, before (`upstream/main`, `text-amber-900`) and after (this branch, `text-trust-review`). The improvement is clearest in the **dark rows**: the "1 trust signal differs… Package trust" line and the "CAUTION" card text go from a dark, low-contrast brown to the legible gold token.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="browse-desktop-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-desktop-light-before.png" /> | <img width="1440" height="900" alt="browse-desktop-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-desktop-light-after.png" /> |
| Desktop · Dark | <img width="1440" height="900" alt="browse-desktop-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-desktop-dark-before.png" /> | <img width="1440" height="900" alt="browse-desktop-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-desktop-dark-after.png" /> |
| Tablet · Light | <img width="768" height="1024" alt="browse-tablet-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-tablet-light-before.png" /> | <img width="768" height="1024" alt="browse-tablet-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-tablet-light-after.png" /> |
| Tablet · Dark | <img width="768" height="1024" alt="browse-tablet-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-tablet-dark-before.png" /> | <img width="768" height="1024" alt="browse-tablet-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-tablet-dark-after.png" /> |
| Mobile · Light | <img width="390" height="844" alt="browse-mobile-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-mobile-light-before.png" /> | <img width="390" height="844" alt="browse-mobile-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-mobile-light-after.png" /> |
| Mobile · Dark | <img width="390" height="844" alt="browse-mobile-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-mobile-dark-before.png" /> | <img width="390" height="844" alt="browse-mobile-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5404/browse-mobile-dark-after.png" /> |

## Validation

- `pnpm exec vitest run` on the 7 affected lib tests — **60 passed** (assert the new `text-trust-review` class).
- `pnpm exec prettier --check` on all changed files — clean; `git diff --check` — clean.

## Notes

- Linked issue: Closes #5404. Screenshots hosted on the `pr-assets` fork branch (raw URLs) to keep the diff free of binaries.
