### PR TITLE
feat(web): suggest which filter to relax in the jobs empty state

### DIFF
--- a/apps/web/src/lib/jobs-empty-state-lib.ts
+++ b/apps/web/src/lib/jobs-empty-state-lib.ts
@@ -1,0 +1,85 @@
+// Pure helper for the jobs board's zero-result empty state: given the active
+// filters and a counter, produce per-filter "relax this to see N roles"
+// suggestions. Split out of the route so the ranking logic is unit-testable
+// without the React component. Mirrors browse.tsx's empty-state guidance.
+
+export type JobsFilterSlice = {
+  q: string;
+  tier: string; // JobTier | "all"
+  remote: string; // "all" | "remote" | "onsite"
+  type: string; // "all" | specific type
+  freshOnly: boolean;
+  featuredOnly: boolean;
+};
+
+export type JobsFilterAxis = keyof JobsFilterSlice;
+
+export type JobsEmptyStateSuggestion = {
+  axis: JobsFilterAxis;
+  /** Human label for the relax action, e.g. `Any tier` or `Clear "rust"`. */
+  label: string;
+  /** How many roles match once this one filter is reset to its default. */
+  count: number;
+  /** The single-axis reset to apply. */
+  patch: Partial<JobsFilterSlice>;
+};
+
+/** Which axes are currently narrowing the result set (i.e. not at their default). */
+export function activeJobsFilters(f: JobsFilterSlice): JobsFilterAxis[] {
+  const axes: JobsFilterAxis[] = [];
+  if (f.q) axes.push("q");
+  if (f.tier !== "all") axes.push("tier");
+  if (f.remote !== "all") axes.push("remote");
+  if (f.type !== "all") axes.push("type");
+  if (f.freshOnly) axes.push("freshOnly");
+  if (f.featuredOnly) axes.push("featuredOnly");
+  return axes;
+}
+
+function labelFor(axis: JobsFilterAxis, f: JobsFilterSlice): string {
+  switch (axis) {
+    case "q":
+      return `Clear "${f.q}"`;
+    case "tier":
+      return "Any tier";
+    case "remote":
+      return "Any location";
+    case "type":
+      return "Any type";
+    case "freshOnly":
+      return "Include older roles";
+    case "featuredOnly":
+      return "Include all tiers";
+  }
+}
+
+const RESET: Record<JobsFilterAxis, Partial<JobsFilterSlice>> = {
+  q: { q: "" },
+  tier: { tier: "all" },
+  remote: { remote: "all" },
+  type: { type: "all" },
+  freshOnly: { freshOnly: false },
+  featuredOnly: { featuredOnly: false },
+};
+
+/**
+ * For each active filter, compute how many roles would match if that one filter
+ * were relaxed, keeping the rest. Only suggestions that actually recover roles
+ * (`count > 0`) are returned, most-recovered first, so the empty state points at
+ * the filter most likely causing the dead end. Returns `[]` when no filter is
+ * active (the caller should not render the enhanced state then).
+ */
+export function jobsEmptyStateSuggestions(
+  filters: JobsFilterSlice,
+  countForFilters: (slice: Partial<JobsFilterSlice>) => number,
+): JobsEmptyStateSuggestion[] {
+  return activeJobsFilters(filters)
+    .map((axis) => ({
+      axis,
+      label: labelFor(axis, filters),
+      count: countForFilters(RESET[axis]),
+      patch: RESET[axis],
+    }))
+    .filter((s) => s.count > 0)
+    .sort((a, b) => b.count - a.count);
+}

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -10,6 +10,7 @@ import { normalizeJobListing } from "@/lib/job-listing-lib";
 import { cn } from "@/lib/utils";
 import { JobCard } from "@/components/job-card";
 import { isFresh, pickDailySpotlight, relativePosted, sortJobs } from "@/lib/jobs-utils";
+import { jobsEmptyStateSuggestions } from "@/lib/jobs-empty-state-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   jobsErrorRetryAnalyticsData,
@@ -238,6 +239,27 @@ function JobsPage() {
     (slice: Partial<JobsFilterState>) => countJobsForFilters(jobs, { ...filterState, ...slice }),
     [filterState, jobs],
   );
+
+  // Per-filter "relax this to see N roles" suggestions for the zero-result state.
+  // RESET values from the lib are all valid filter values, so the cast is safe.
+  const emptySuggestions = useMemo(
+    () =>
+      hasFilters
+        ? jobsEmptyStateSuggestions(filterState, (slice) =>
+            countForFilters(slice as Partial<JobsFilterState>),
+          )
+        : [],
+    [hasFilters, filterState, countForFilters],
+  );
+
+  const applyFilterPatch = useCallback((patch: Partial<JobsFilterState>) => {
+    if (patch.q !== undefined) setQ(patch.q);
+    if (patch.tier !== undefined) setTier(patch.tier);
+    if (patch.remote !== undefined) setRemote(patch.remote);
+    if (patch.type !== undefined) setType(patch.type);
+    if (patch.freshOnly !== undefined) setFreshOnly(patch.freshOnly);
+    if (patch.featuredOnly !== undefined) setFeaturedOnly(patch.featuredOnly);
+  }, []);
 
   const onFilterSelect = useCallback(
     (
@@ -517,11 +539,39 @@ function JobsPage() {
                 }
               />
             ))}
-            {sorted.length === 0 && (
-              <div className="rounded-xl border border-dashed border-border bg-surface px-5 py-12 text-center text-sm text-ink-muted">
-                {loadingJobs ? "Loading active roles..." : "No roles match these filters."}
-              </div>
-            )}
+            {sorted.length === 0 &&
+              (loadingJobs ? (
+                <div className="rounded-xl border border-dashed border-border bg-surface px-5 py-12 text-center text-sm text-ink-muted">
+                  Loading active roles...
+                </div>
+              ) : hasFilters ? (
+                <div className="space-y-3 rounded-xl border border-dashed border-border bg-surface px-5 py-12 text-center text-sm text-ink-muted">
+                  <p>No roles match these filters.</p>
+                  {emptySuggestions.length > 0 && (
+                    <div className="flex flex-wrap items-center justify-center gap-2">
+                      {emptySuggestions.map((s) => (
+                        <button
+                          key={s.axis}
+                          onClick={() => applyFilterPatch(s.patch as Partial<JobsFilterState>)}
+                          className="rounded-full border border-border px-3 py-1 text-xs text-ink transition hover:border-ink-subtle"
+                        >
+                          {s.label} · {s.count} role{s.count === 1 ? "" : "s"}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  <button
+                    onClick={onClearFilters}
+                    className="text-xs font-medium text-ink underline underline-offset-4"
+                  >
+                    Clear all filters
+                  </button>
+                </div>
+              ) : (
+                <div className="rounded-xl border border-dashed border-border bg-surface px-5 py-12 text-center text-sm text-ink-muted">
+                  No roles match these filters.
+                </div>
+              ))}
           </div>
 
           <div className="mt-8">

--- a/tests/jobs-empty-state-lib.test.ts
+++ b/tests/jobs-empty-state-lib.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeJobsFilters,
+  jobsEmptyStateSuggestions,
+  type JobsFilterSlice,
+} from "@/lib/jobs-empty-state-lib";
+
+const NONE: JobsFilterSlice = {
+  q: "",
+  tier: "all",
+  remote: "all",
+  type: "all",
+  freshOnly: false,
+  featuredOnly: false,
+};
+
+describe("activeJobsFilters", () => {
+  it("returns [] when nothing is narrowing the set", () => {
+    expect(activeJobsFilters(NONE)).toEqual([]);
+  });
+
+  it("lists exactly the axes that differ from their default", () => {
+    expect(
+      activeJobsFilters({
+        ...NONE,
+        q: "rust",
+        tier: "featured",
+        freshOnly: true,
+      }),
+    ).toEqual(["q", "tier", "freshOnly"]);
+  });
+});
+
+describe("jobsEmptyStateSuggestions", () => {
+  it("returns [] when no filter is active (caller should skip the enhanced state)", () => {
+    expect(jobsEmptyStateSuggestions(NONE, () => 5)).toEqual([]);
+  });
+
+  it("suggests relaxing each active filter, ranked by roles recovered", () => {
+    const filters: JobsFilterSlice = {
+      ...NONE,
+      q: "rust",
+      tier: "featured",
+      freshOnly: true,
+    };
+    // Relaxing tier recovers the most, then q, then freshOnly.
+    const counts: Record<string, number> = { tier: 9, q: 4, freshOnly: 1 };
+    const out = jobsEmptyStateSuggestions(filters, (slice) => {
+      if ("tier" in slice) return counts.tier;
+      if ("q" in slice) return counts.q;
+      if ("freshOnly" in slice) return counts.freshOnly;
+      return 0;
+    });
+    expect(out.map((s) => s.axis)).toEqual(["tier", "q", "freshOnly"]);
+    expect(out.map((s) => s.count)).toEqual([9, 4, 1]);
+    expect(out[1].label).toBe('Clear "rust"');
+    expect(out[0].patch).toEqual({ tier: "all" });
+  });
+
+  it("drops suggestions that recover zero roles", () => {
+    const filters: JobsFilterSlice = {
+      ...NONE,
+      tier: "featured",
+      remote: "remote",
+    };
+    // Relaxing tier still yields 0 (some other filter is the real cause) → dropped.
+    const out = jobsEmptyStateSuggestions(filters, (slice) =>
+      "remote" in slice ? 3 : 0,
+    );
+    expect(out.map((s) => s.axis)).toEqual(["remote"]);
+    expect(out[0].count).toBe(3);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- The jobs board's zero-result state showed only a static "No roles match these filters." with no guidance on which of its 6 filters caused the dead end — unlike `browse.tsx`, which offers per-filter relax suggestions.
- This adds per-filter "relax this to see N roles" chips plus an inline **Clear all filters** action to the jobs empty state, driven by a new unit-tested pure helper.

Closes #5217

## Submission Source

For platform/code PRs:

- [x] Not a direct content submission.
- [x] Changed route + new lib + test listed below.
- [x] Screenshots included (route-touching change → before/after matrix).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed:**
  - `apps/web/src/lib/jobs-empty-state-lib.ts` (new) — pure `jobsEmptyStateSuggestions(filters, countForFilters)` + `activeJobsFilters()`. For each active filter it computes how many roles a single-axis relaxation recovers, drops the ones that recover nothing, and ranks most-recovered first.
  - `apps/web/src/routes/jobs.index.tsx` — the zero-result state renders the relax chips (label + live count) and an inline `Clear all filters` button, only when a filter is active; reuses the existing `countForFilters()` helper.
  - `tests/jobs-empty-state-lib.test.ts` (new) — 5 cases.
- **Edge cases covered (tests):** zero active filters → `[]` (enhanced state not shown); one filter; multiple filters ranked by roles recovered; a relaxation that still yields 0 is dropped.
- **Out of scope (unchanged):** the filter bar's existing "Clear" button, `browse.tsx`, and any job data/API.
- **Backward compatibility:** additive; the plain "No roles match" text still shows when no filter is active or while loading.

## Screenshot evidence

`/jobs` with an active search filter that yields zero results, all viewport × theme combinations, before (`upstream/main`) and after (this branch). The **after** shows the inline **Clear all filters** action in the empty state (the before has only static text). Note: the dev environment has no seeded job listings, so all single-filter relaxations recover 0 roles and the per-filter chips are correctly suppressed here; the chip ranking itself is locked in by the unit tests (a relaxation is shown only when `count > 0`).

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="jobs-empty-desktop-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-desktop-light-before.png" /> | <img width="1440" height="900" alt="jobs-empty-desktop-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-desktop-light-after.png" /> |
| Desktop · Dark | <img width="1440" height="900" alt="jobs-empty-desktop-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-desktop-dark-before.png" /> | <img width="1440" height="900" alt="jobs-empty-desktop-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-desktop-dark-after.png" /> |
| Tablet · Light | <img width="768" height="1024" alt="jobs-empty-tablet-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-tablet-light-before.png" /> | <img width="768" height="1024" alt="jobs-empty-tablet-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-tablet-light-after.png" /> |
| Tablet · Dark | <img width="768" height="1024" alt="jobs-empty-tablet-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-tablet-dark-before.png" /> | <img width="768" height="1024" alt="jobs-empty-tablet-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-tablet-dark-after.png" /> |
| Mobile · Light | <img width="390" height="844" alt="jobs-empty-mobile-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-mobile-light-before.png" /> | <img width="390" height="844" alt="jobs-empty-mobile-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-mobile-light-after.png" /> |
| Mobile · Dark | <img width="390" height="844" alt="jobs-empty-mobile-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-mobile-dark-before.png" /> | <img width="390" height="844" alt="jobs-empty-mobile-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5217/jobs-empty-mobile-dark-after.png" /> |

## Validation

- `pnpm exec vitest run tests/jobs-empty-state-lib.test.ts` — **5 passed**.
- `pnpm exec prettier --check` on changed files — clean; `git diff --check` — clean; targeted `tsc` shows no new diagnostics on the changed lines (repo-wide `createFileRoute` errors are the ungenerated-route-tree baseline).

## Notes

- Linked issue: Closes #5217. Screenshots hosted on the `pr-assets` fork branch (raw URLs) to keep the diff free of binaries.
