### PR TITLE
fix(web): make inferTrust produce blocked for undisclosed risk categories

### DIFF
--- a/apps/web/src/lib/entry-normalize-lib.ts
+++ b/apps/web/src/lib/entry-normalize-lib.ts
@@ -282,13 +282,23 @@ export function inferSource(entry: RegistryEntry): SourceStatus {
   return "unverified";
 }
 
+/**
+ * Trust posture for a normalized registry entry.
+ *
+ * Risk-bearing categories (mcp / hooks / skills / commands / statuslines) can
+ * execute code, touch the filesystem, or call the network. When neither
+ * safetyNotes nor privacyNotes disclose that behavior, the listing is
+ * `blocked` — the highest caution tier — so install-risk surfaces can warn
+ * "High risk — do not install without human review." Notes present (or a
+ * non-risk category) stay at `review`.
+ */
 export function inferTrust(entry: RegistryEntry, source: SourceStatus): TrustLevel {
   const hasNotes = Boolean(entry.safetyNotes || entry.privacyNotes);
   if (entry.packageVerified && entry.downloadSha256) return "trusted";
   if (entry.trustSignals?.firstPartyEditorial) return "trusted";
   if (source === "unverified") return "limited";
   if (["mcp", "hooks", "skills", "commands", "statuslines"].includes(entry.category) && !hasNotes) {
-    return "review";
+    return "blocked";
   }
   return "review";
 }

--- a/tests/entry-normalize-lib.test.ts
+++ b/tests/entry-normalize-lib.test.ts
@@ -17,6 +17,7 @@ import {
   normalizeSupportLevel,
   type RegistryEntry,
 } from "../apps/web/src/lib/entry-normalize-lib";
+import { installRiskLevel } from "../apps/web/src/lib/trust-lib";
 
 function baseEntry(overrides: Partial<RegistryEntry> = {}): RegistryEntry {
   return {
@@ -195,18 +196,69 @@ describe("entry normalize lib helpers", () => {
 
       expect(inferTrust(baseEntry(), "unverified")).toBe("limited");
 
-      const review = baseEntry({
+      // Risk-bearing category with no safety/privacy notes → blocked.
+      // This is the only path that produces TrustLevel "blocked".
+      const blocked = baseEntry({
         category: "mcp",
         githubUrl: "https://github.com/example/repo",
       });
-      expect(inferTrust(review, inferSource(review))).toBe("review");
+      expect(inferTrust(blocked, inferSource(blocked))).toBe("blocked");
 
+      // Same risk category with mitigating notes stays at review.
       const reviewed = baseEntry({
         category: "mcp",
         githubUrl: "https://github.com/example/repo",
         safetyNotes: "Runs locally only.",
       });
       expect(inferTrust(reviewed, inferSource(reviewed))).toBe("review");
+
+      // Privacy notes alone also clear the blocked gate.
+      const privacyNoted = baseEntry({
+        category: "hooks",
+        githubUrl: "https://github.com/example/hooks",
+        privacyNotes: "Reads local git config only.",
+      });
+      expect(inferTrust(privacyNoted, inferSource(privacyNoted))).toBe(
+        "review",
+      );
+
+      // Non-risk categories without notes are review, not blocked.
+      const guide = baseEntry({
+        category: "guides",
+        githubUrl: "https://github.com/example/guide",
+      });
+      expect(inferTrust(guide, inferSource(guide))).toBe("review");
+    });
+
+    it("can produce blocked for every risk-bearing category without notes", () => {
+      for (const category of [
+        "mcp",
+        "hooks",
+        "skills",
+        "commands",
+        "statuslines",
+      ] as const) {
+        const entry = baseEntry({
+          category,
+          githubUrl: "https://github.com/example/risk",
+        });
+        expect(inferTrust(entry, inferSource(entry))).toBe("blocked");
+      }
+    });
+
+    it("unblocks installRiskLevel high via normalize → blocked cascade", () => {
+      const registry = baseEntry({
+        category: "mcp",
+        slug: "blocked-fixture",
+        title: "Blocked Fixture MCP",
+        githubUrl: "https://github.com/example/blocked-fixture",
+      });
+      const normalized = buildEntryFromRegistry(
+        registry,
+        attribution(registry),
+      );
+      expect(normalized.trust).toBe("blocked");
+      expect(installRiskLevel(normalized)).toBe("high");
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix `inferTrust()` so risk-bearing categories (`mcp` / `hooks` / `skills` / `commands` / `statuslines`) **without** `safetyNotes` or `privacyNotes` return `TrustLevel: "blocked"` instead of falling through to `"review"`.
- That was the existing `hasNotes` gate's intended distinction — both branches previously returned `"review"`, so `"blocked"` was unreachable and the site-wide high-severity install-risk cascade stayed dead.
- Trusted / limited / review paths for previously-tested inputs are unchanged; only the undisclosed risk-category arm changes.
- Regression coverage locks the blocked input, every risk category, note-cleared review behavior, non-risk categories staying at review, and the normalize → `installRiskLevel() === "high"` cascade.

Closes #5271

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `apps/web/src/lib/entry-normalize-lib.ts` (`inferTrust` only)
  - `tests/entry-normalize-lib.test.ts`
- Expected behavior:
  - Risk-bearing listing + no safety/privacy notes → `blocked`
  - Same listing + either note present → `review`
  - Non-risk category without notes → `review`
  - `buildEntryFromRegistry(...)` then `installRiskLevel(entry)` → `"high"` when blocked
- Important edge cases or invariants:
  - `packageVerified && downloadSha256` and `firstPartyEditorial` still short-circuit to `trusted` first
  - `source === "unverified"` still returns `limited` before the risk-category gate
  - Privacy notes alone clear the blocked gate (same as safety notes)
- Backward compatibility notes:
  - Existing `"trusted"` / `"limited"` / noted-risk `"review"` behavior unchanged
  - Listings that were previously labeled `"review"` solely because they are risk-bearing **and** missing notes will now correctly surface as `"blocked"` / High risk
- Screenshots for frontend/page/UI changes:
  - No chrome/CSS changes — this only activates the existing entry-detail High-risk callout and ~15 already-correct `entry.trust === "blocked"` branches.
  - Cascade proof (fixture: mcp without notes → blocked → High risk callout):

    ![High risk callout for blocked fixture](https://litter.catbox.moe/3bt4ht.png)

- If screenshots do not apply, write `No visual impact` and explain why.
  - No visual impact to component markup; visual proof above shows the already-shipped callout now reachable via `inferTrust()`.
- Accessibility notes for UI changes:
  - Existing callout markup / semantics unchanged.
- Focused tests or reason tests are not practical:
  - `pnpm exec vitest run tests/entry-normalize-lib.test.ts tests/trust-lib.test.ts tests/trust.test.ts` (59 passed)
  - Broader related suite also green: adoption-plan / decision-playbook / install-risk-badge / resource-card-trust (122 passed across 7 files)

### Downstream branches that start executing once `inferTrust()` can return `"blocked"`

No edits needed in these files (already correct; previously dead):

1. `apps/web/src/lib/trust-lib.ts` — `getTrustReasons` blocker severity + `installRiskLevel` → `"high"`
2. `apps/web/src/routes/entry.$category.$slug.tsx` — High-risk callout (`risk === "high"`)
3. `apps/web/src/components/badges.tsx` — `InstallRiskBadge` / `TrustBadge` blocked + high styles
4. `apps/web/src/lib/resource-card-trust-decision-lib.ts` — `TRUST_RANK.blocked`
5. `apps/web/src/lib/entry-detail-decision-playbook-lib.ts` — “Do not install before manual review”
6. `apps/web/src/lib/entry-adoption-plan-lib.ts` — blocked blocker + score weight
7. `apps/web/src/lib/entry-evidence-readiness-matrix-lib.ts` — blocked trust weight
8. `apps/web/src/lib/entry-decision-timeline-lib.ts` — blocked trust weight
9. `apps/web/src/lib/entry-compare-benchmark-lib.ts` — blocked penalty
10. `apps/web/src/lib/compare-decision-brief-lib.ts` — tone `"blocked"`
11. `apps/web/src/lib/compare-mitigation-priority-lib.ts` — blocked weight
12. `apps/web/src/lib/compare-scenario-ranking-lib.ts` — blocked score/reasons
13. `apps/web/src/lib/compare-deployment-risk-map-lib.ts` — blocked trust branch
14. `apps/web/src/lib/browse-decision-confidence-lib.ts` — hold-adoption copy
15. `apps/web/src/lib/browse-adoption-queue-lib.ts` — blocked weight
16. Plus trust-order / browse-filter / badge-chrome / stats surfaces that already enumerate `"blocked"`

## Validation

- [x] Platform/code PR: focused checks below (full `pnpm build` / web `type-check` not run — change is a single return-path in a pure helper; CI remains merge source of truth).
- [x] I ran the focused checks listed above.
- [x] Prettier `--check` clean on both touched files.

```sh
pnpm exec vitest run tests/entry-normalize-lib.test.ts tests/trust-lib.test.ts tests/trust.test.ts
```

## Notes

- Linked issue: #5271
- Trigger condition (documented in code comment): risk-bearing category **and** missing both safety and privacy notes. This matches the existing `hasNotes` gate that previously returned `"review"` on both arms, and matches the issue's most-likely intended condition without inventing new AST/fields.
- Out of scope preserved: no edits to the ~15 downstream files; no changes to trusted/limited/review success paths beyond the blocked arm.

