### PR TITLE
fix(registry): generate Raycast copyText/copyTextTruncated preview fields

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -912,8 +912,21 @@ export function buildCursorSkillAdapter(entry) {
     .join("\n");
 }
 
+/**
+ * The canonical "copy payload" preview text for a Raycast entry — the same
+ * `title / description / url` shape the extension's client-side fallback
+ * (`buildSearchResultCopyText`) uses, generated server-side so the feed's
+ * `copyText` fields carry real data instead of being permanently `undefined`.
+ */
+export function buildRaycastCopyText(entry) {
+  const description = entry.cardDescription || entry.description || "";
+  return `${entry.title}\n\n${description}\n\n${entryCanonicalUrl(entry)}`;
+}
+
 export function buildRaycastEntries(entries) {
   return entries.map((entry) => {
+    const fullCopyText = buildRaycastCopyText(entry);
+    const copyText = truncateText(fullCopyText, RAYCAST_COPY_PREVIEW_LIMIT);
     return compactDefinedObject({
       category: entry.category,
       slug: entry.slug,
@@ -931,6 +944,9 @@ export function buildRaycastEntries(entries) {
       documentationUrl: entry.documentationUrl || "",
       downloadTrust: entry.downloadTrust,
       verificationStatus: entry.verificationStatus || "",
+      copyText,
+      copyTextLength: fullCopyText.length,
+      copyTextTruncated: fullCopyText.length > RAYCAST_COPY_PREVIEW_LIMIT,
       ...buildCompactInstallFields(entry),
       platformCompatibility:
         entry.category === "skills"
@@ -979,6 +995,7 @@ export function buildRaycastDetail(entry) {
     ...buildEntryProvenanceFields(entry),
     ...buildEntryBrandFields(entry),
     detailMarkdown: buildRaycastDetailMarkdown(entry),
+    copyText: buildRaycastCopyText(entry),
     webUrl: entryCanonicalUrl(entry),
     canonicalUrl: entryCanonicalUrl(entry),
     llmsUrl: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,

--- a/scripts/validate-raycast-feed.mjs
+++ b/scripts/validate-raycast-feed.mjs
@@ -253,7 +253,7 @@ for (const entry of payload.entries) {
   if (
     entry.copyText !== undefined &&
     entry.copyTextTruncated &&
-    detail.copyText.length <= String(entry.copyText ?? "").length
+    String(detail.copyText ?? "").length <= String(entry.copyText ?? "").length
   ) {
     fail(`${key}: truncated feed entry must have longer detail copyText`);
   }

--- a/tests/artifacts-lib.test.ts
+++ b/tests/artifacts-lib.test.ts
@@ -19,6 +19,7 @@ import {
   buildRaycastDetailMarkdown,
   buildRaycastDetail,
   buildRaycastEntries,
+  buildRaycastCopyText,
   buildRaycastEnvelope,
   buildEntryDetail,
   buildCursorSkillAdapter,
@@ -821,6 +822,36 @@ describe("buildRaycastEntries", () => {
     expect(withoutNotes?.trustSignals).toBeUndefined();
     expect(withNotes?.trustSignals).not.toHaveProperty("platforms");
     expect(withNotes?.trustSignals).not.toHaveProperty("supportLevels");
+  });
+
+  it("generates a non-empty copyText preview that respects the cap", () => {
+    const row = buildRaycastEntries([FIXTURE_MCP])[0];
+    const full = buildRaycastCopyText(FIXTURE_MCP);
+    expect(row?.copyText).toBe(full); // short fixture is not truncated
+    expect(row?.copyText.length).toBeLessThanOrEqual(
+      RAYCAST_COPY_PREVIEW_LIMIT + 3,
+    );
+    expect(row?.copyTextLength).toBe(full.length);
+    expect(row?.copyTextTruncated).toBe(false);
+    // The client-fallback shape: title / description / canonical url.
+    expect(full).toContain(FIXTURE_MCP.title);
+    expect(full).toContain(`${SITE_URL}/entry/mcp/demo-server`);
+  });
+
+  it("truncates copyText past the preview limit and flags it, with a longer detail copyText", () => {
+    const longEntry = syntheticEntry("mcp", "long-copy", {
+      // buildRaycastCopyText prefers cardDescription, so make that the long one.
+      cardDescription: "x".repeat(RAYCAST_COPY_PREVIEW_LIMIT + 500),
+    });
+    const row = buildRaycastEntries([longEntry])[0];
+    const detail = buildRaycastDetail(longEntry);
+    expect(row?.copyTextTruncated).toBe(true);
+    expect(row?.copyText.length).toBeLessThanOrEqual(
+      RAYCAST_COPY_PREVIEW_LIMIT,
+    );
+    // Validator invariant: a truncated feed entry must have a longer detail copyText.
+    expect(detail.copyText.length).toBeGreaterThan(row!.copyText.length);
+    expect(detail.copyText).toBe(buildRaycastCopyText(longEntry));
   });
 });
 


### PR DESCRIPTION
# Pull Request

## Summary

- `buildRaycastEntries`/`buildRaycastDetail` never set `copyText`/`copyTextTruncated`, so every consumer — `scripts/validate-raycast-feed.mjs`'s copyText checks, the extension client's copyText fallback (`integrations/raycast/src/feed.ts`), and the "load full copy text on demand" UI — ran against a permanently `undefined` value.
- This generates real `copyText` from the canonical `title / description / url` payload (the same shape as the client's `buildSearchResultCopyText`) and fixes a latent `TypeError` in the validator.

Closes #5226

## Submission Source

For platform/code PRs:

- [x] Not a direct content submission.
- [x] Changed builder + validator + test listed below.
- [x] `No visual impact` (changes generated JSON + Raycast copy behavior, not the website UI).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed:**
  - `packages/registry/src/artifacts-lib.js` — new exported `buildRaycastCopyText(entry)`; `buildRaycastEntries` now emits `copyText` (capped via the existing `truncateText` + `RAYCAST_COPY_PREVIEW_LIMIT`), `copyTextLength`, and `copyTextTruncated`; `buildRaycastDetail` emits the full `copyText`.
  - `scripts/validate-raycast-feed.mjs` — line ~256 `detail.copyText.length` is now `String(detail.copyText ?? "").length`, so a missing detail copyText produces a clean validation failure instead of a raw `TypeError`.
  - `tests/artifacts-lib.test.ts` — asserts the preview shape/cap, `copyTextTruncated` flagging, and the validator invariant that a truncated feed entry has a longer detail copyText.
- **Expected behavior:** the validator's previously-inert `copyText` checks now exercise real data; the extension's on-demand copy UI has content to load.
- **Out of scope (unchanged):** the client-side fallback in `feed.ts`, `RAYCAST_COPY_PREVIEW_LIMIT`'s value, any other feed field.
- **No committed artifacts:** `apps/web/public/data/raycast*` is gitignored and regenerated by CI `prebuild`. The prior attempt (#5393) was auto-closed for committing stale artifacts that mismatched the new fields — this PR deliberately commits **only** source/validator/test and lets CI regenerate the feed.

## Validation

Run locally, all green:
- `pnpm exec vitest run tests/artifacts-lib.test.ts` — **289 passed** (incl. the new copyText cases).
- `pnpm --filter web run generate:registry` then `pnpm run validate:raycast-feed` — **"Validated 1384 Raycast feed entries."**, exit 0 (the exact `validate-raycast` check that failed on #5393 now passes against freshly generated artifacts carrying the new fields).
- `pnpm exec prettier --check` on all changed files — clean; `git diff --check` — clean.

Sample generated feed entry now carries: `{ copyText: "…", copyTextLength: 234, copyTextTruncated: false }`.

## Notes

- Linked issue: Closes #5226. Supersedes the auto-closed #5393 — the CI-failing cause (committed stale artifacts) is fixed by not committing generated output.
