### PR TITLE
fix(web): wire the OpenAPI playground body editor into the curl snippet

### DIFF
--- a/apps/web/src/components/openapi.tsx
+++ b/apps/web/src/components/openapi.tsx
@@ -34,6 +34,9 @@ export function MethodPill({ method }: { method: OpenApiEndpoint["method"] }) {
 }
 
 export function OpenApiEndpointCard({ endpoint }: { endpoint: OpenApiEndpoint }) {
+  // The request-body editor is owned here so the live-edited body flows into both
+  // the playground textarea and the copyable curl snippet (they render as siblings).
+  const [body, setBody] = useState(endpoint.body?.example ?? "");
   return (
     <article id={endpoint.id} className="scroll-mt-24 rounded-xl border border-border bg-surface">
       <header className="flex flex-wrap items-center gap-3 border-b border-border px-5 py-3">
@@ -96,15 +99,15 @@ export function OpenApiEndpointCard({ endpoint }: { endpoint: OpenApiEndpoint })
               <code>{endpoint.responseExample}</code>
             </pre>
           </div>
-          <CurlBlock endpoint={endpoint} />
+          <CurlBlock endpoint={endpoint} body={body} />
         </div>
-        <OpenApiPlayground endpoint={endpoint} />
+        <OpenApiPlayground endpoint={endpoint} body={body} onBodyChange={setBody} />
       </div>
     </article>
   );
 }
 
-function CurlBlock({ endpoint }: { endpoint: OpenApiEndpoint }) {
+function CurlBlock({ endpoint, body }: { endpoint: OpenApiEndpoint; body?: string }) {
   const base = "https://heyclau.de";
   const params =
     endpoint.parameters
@@ -116,10 +119,13 @@ function CurlBlock({ endpoint }: { endpoint: OpenApiEndpoint }) {
     return ex ?? `:${name}`;
   });
   const fullUrl = `${base}${url}${params ? `?${params}` : ""}`;
+  // Prefer the live-edited body; fall back to the documented example. Editing the
+  // playground's Body textarea now visibly updates this curl payload.
+  const bodyPayload = body ?? endpoint.body?.example ?? "";
   const curl =
     endpoint.method === "GET"
       ? `curl '${fullUrl}'`
-      : `curl -X ${endpoint.method} '${fullUrl}' \\\n  -H 'content-type: application/json' \\\n  -d '${endpoint.body?.example.replace(/\n/g, "") ?? ""}'`;
+      : `curl -X ${endpoint.method} '${fullUrl}' \\\n  -H 'content-type: application/json' \\\n  -d '${bodyPayload.replace(/\n/g, "")}'`;
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
@@ -138,13 +144,25 @@ function CurlBlock({ endpoint }: { endpoint: OpenApiEndpoint }) {
   );
 }
 
-export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
+export function OpenApiPlayground({
+  endpoint,
+  body,
+  onBodyChange,
+}: {
+  endpoint: OpenApiEndpoint;
+  body?: string;
+  onBodyChange?: (next: string) => void;
+}) {
   const [values, setValues] = useState<Record<string, string>>(() => {
     const init: Record<string, string> = {};
     endpoint.parameters?.forEach((p) => (init[p.name] = p.example ?? ""));
     return init;
   });
-  const [body, setBody] = useState(endpoint.body?.example ?? "");
+  const [localBody, setLocalBody] = useState(endpoint.body?.example ?? "");
+  // Controlled when a parent owns the body (endpoint card); otherwise self-manage
+  // so the exported component still works standalone.
+  const bodyValue = body ?? localBody;
+  const setBody = onBodyChange ?? setLocalBody;
   const [sending, setSending] = useState(false);
   const [response, setResponse] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -202,7 +220,7 @@ export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
         <div>
           <div className="eyebrow mb-1.5">Body</div>
           <textarea
-            value={body}
+            value={bodyValue}
             onChange={(e) => setBody(e.target.value)}
             rows={6}
             className="w-full rounded-md border border-border bg-background p-3 font-mono text-[11px] text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"


### PR DESCRIPTION
# Pull Request

## Summary

- The OpenAPI playground's request-body textarea was a dead control: its edited value was never read, so CurlBlock always built the curl `-d` payload from the static `endpoint.body.example`. Editing a POST/PATCH body to test a custom payload had zero effect.
- **Chose option (a)** from the issue (make the edit real, not read-only): lift the body state to `OpenApiEndpointCard` and feed it to both the textarea and the curl snippet, so editing the body now visibly updates the copyable curl for every POST/PATCH endpoint.

Closes #5259

## Submission Source

For platform/code PRs:

- [x] Not a direct content submission.
- [x] Changed component listed below.
- [x] Screenshots included (component change → before/after matrix).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed:** `apps/web/src/components/openapi.tsx` only (the issue's exact scope).
  - `OpenApiEndpointCard` now owns the `body` state and passes it to `CurlBlock` and `OpenApiPlayground` (`body` + `onBodyChange`).
  - `CurlBlock` builds the `-d` payload from the live `body` (falling back to `endpoint.body?.example`).
  - `OpenApiPlayground` is controlled when a parent owns the body, and self-manages when used standalone.
- **Option chosen & why:** (a) — a working editable payload is more useful than a read-only field, and the wiring lives in the shared card so it applies to **all** POST/PATCH endpoints, not one.
- **Edge cases:** GET endpoints (no body) unaffected; `\n` is still stripped for a single-line curl.
- **Out of scope (unchanged):** `data/openapi.ts`'s `canTryLive()` / endpoint defs — no live POST/PATCH request support added.

## Screenshot evidence

`/api-docs`, the `POST /api/votes/query` card, all viewport × theme combinations. In each pair the Body textarea is edited to include `EDIT-PROOF-42`; **after** the curl `-d` payload reflects that edit, **before** the curl still shows the static `anon-client-1234` example regardless of the edit.

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="openapi-body-desktop-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-desktop-light-before.png" /> | <img width="1440" height="900" alt="openapi-body-desktop-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-desktop-light-after.png" /> |
| Desktop · Dark | <img width="1440" height="900" alt="openapi-body-desktop-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-desktop-dark-before.png" /> | <img width="1440" height="900" alt="openapi-body-desktop-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-desktop-dark-after.png" /> |
| Tablet · Light | <img width="768" height="1024" alt="openapi-body-tablet-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-tablet-light-before.png" /> | <img width="768" height="1024" alt="openapi-body-tablet-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-tablet-light-after.png" /> |
| Tablet · Dark | <img width="768" height="1024" alt="openapi-body-tablet-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-tablet-dark-before.png" /> | <img width="768" height="1024" alt="openapi-body-tablet-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-tablet-dark-after.png" /> |
| Mobile · Light | <img width="390" height="844" alt="openapi-body-mobile-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-mobile-light-before.png" /> | <img width="390" height="844" alt="openapi-body-mobile-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-mobile-light-after.png" /> |
| Mobile · Dark | <img width="390" height="844" alt="openapi-body-mobile-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-mobile-dark-before.png" /> | <img width="390" height="844" alt="openapi-body-mobile-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5259/openapi-body-mobile-dark-after.png" /> |

## Validation

- `pnpm exec prettier --check apps/web/src/components/openapi.tsx` — clean; `git diff --check` — clean.
- Targeted `tsc` shows no new diagnostics on the changed lines (repo-wide `createFileRoute` errors are the ungenerated-route-tree baseline; CI regenerates it).
- Verified in a local dev build: editing the body of `votes.query`/`votes.toggle` updates the curl snippet live (screenshots above).

## Notes

- Linked issue: Closes #5259. Screenshots hosted on the `pr-assets` fork branch (raw URLs) to keep the diff free of binaries.
