### PR TITLE
fix(web): wire OpenAPI playground body edits into the curl snippet

### DIFF
--- a/apps/web/src/components/openapi.tsx
+++ b/apps/web/src/components/openapi.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Send, Loader2, ChevronDown } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import type { OpenApiEndpoint, OpenApiParam } from "@/data/openapi";
-import { buildRequestUrl } from "@/lib/openapi-request-lib";
+import { buildCurlCommand, buildRequestUrl } from "@/lib/openapi-request-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
   openApiAdvancedToggleAnalyticsData,
@@ -34,6 +34,9 @@ export function MethodPill({ method }: { method: OpenApiEndpoint["method"] }) {
 }
 
 export function OpenApiEndpointCard({ endpoint }: { endpoint: OpenApiEndpoint }) {
+  // Lift body state so playground edits drive the left-column curl snippet.
+  const [body, setBody] = useState(endpoint.body?.example ?? "");
+
   return (
     <article id={endpoint.id} className="scroll-mt-24 rounded-xl border border-border bg-surface">
       <header className="flex flex-wrap items-center gap-3 border-b border-border px-5 py-3">
@@ -96,30 +99,16 @@ export function OpenApiEndpointCard({ endpoint }: { endpoint: OpenApiEndpoint })
               <code>{endpoint.responseExample}</code>
             </pre>
           </div>
-          <CurlBlock endpoint={endpoint} />
+          <CurlBlock endpoint={endpoint} body={body} />
         </div>
-        <OpenApiPlayground endpoint={endpoint} />
+        <OpenApiPlayground endpoint={endpoint} body={body} onBodyChange={setBody} />
       </div>
     </article>
   );
 }
 
-function CurlBlock({ endpoint }: { endpoint: OpenApiEndpoint }) {
-  const base = "https://heyclau.de";
-  const params =
-    endpoint.parameters
-      ?.filter((p) => p.in === "query" && p.example)
-      .map((p) => `${p.name}=${p.example}`)
-      .join("&") ?? "";
-  const url = endpoint.path.replace(/\{(\w+)\}/g, (_m, name) => {
-    const ex = endpoint.parameters?.find((p) => p.in === "path" && p.name === name)?.example;
-    return ex ?? `:${name}`;
-  });
-  const fullUrl = `${base}${url}${params ? `?${params}` : ""}`;
-  const curl =
-    endpoint.method === "GET"
-      ? `curl '${fullUrl}'`
-      : `curl -X ${endpoint.method} '${fullUrl}' \\\n  -H 'content-type: application/json' \\\n  -d '${endpoint.body?.example.replace(/\n/g, "") ?? ""}'`;
+function CurlBlock({ endpoint, body }: { endpoint: OpenApiEndpoint; body: string }) {
+  const curl = buildCurlCommand(endpoint, body);
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
@@ -138,13 +127,20 @@ function CurlBlock({ endpoint }: { endpoint: OpenApiEndpoint }) {
   );
 }
 
-export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
+export function OpenApiPlayground({
+  endpoint,
+  body,
+  onBodyChange,
+}: {
+  endpoint: OpenApiEndpoint;
+  body: string;
+  onBodyChange: (body: string) => void;
+}) {
   const [values, setValues] = useState<Record<string, string>>(() => {
     const init: Record<string, string> = {};
     endpoint.parameters?.forEach((p) => (init[p.name] = p.example ?? ""));
     return init;
   });
-  const [body, setBody] = useState(endpoint.body?.example ?? "");
   const [sending, setSending] = useState(false);
   const [response, setResponse] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -203,8 +199,10 @@ export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
           <div className="eyebrow mb-1.5">Body</div>
           <textarea
             value={body}
-            onChange={(e) => setBody(e.target.value)}
+            onChange={(e) => onBodyChange(e.target.value)}
             rows={6}
+            spellCheck={false}
+            aria-label="Request body"
             className="w-full rounded-md border border-border bg-background p-3 font-mono text-[11px] text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"
           />
         </div>

--- a/apps/web/src/lib/openapi-request-lib.ts
+++ b/apps/web/src/lib/openapi-request-lib.ts
@@ -28,3 +28,29 @@ export function buildRequestUrl(endpoint: OpenApiEndpoint, values: Record<string
   if (query) path = `${path}?${query}`;
   return path;
 }
+
+const CURL_BASE = "https://heyclau.de";
+
+/**
+ * Build the copyable curl snippet shown beside the OpenAPI playground.
+ *
+ * Path/query examples come from the endpoint's documented parameter examples.
+ * For non-GET methods, `body` is the live playground textarea value (falling
+ * back to the documented body example) so edits visibly change the snippet.
+ */
+export function buildCurlCommand(endpoint: OpenApiEndpoint, body?: string): string {
+  const params =
+    endpoint.parameters
+      ?.filter((p) => p.in === "query" && p.example)
+      .map((p) => `${p.name}=${p.example}`)
+      .join("&") ?? "";
+  const url = endpoint.path.replace(/\{(\w+)\}/g, (_m, name) => {
+    const ex = endpoint.parameters?.find((p) => p.in === "path" && p.name === name)?.example;
+    return ex ?? `:${name}`;
+  });
+  const fullUrl = `${CURL_BASE}${url}${params ? `?${params}` : ""}`;
+  if (endpoint.method === "GET") return `curl '${fullUrl}'`;
+
+  const payload = (body ?? endpoint.body?.example ?? "").replace(/\n/g, "");
+  return `curl -X ${endpoint.method} '${fullUrl}' \\\n  -H 'content-type: application/json' \\\n  -d '${payload}'`;
+}

--- a/tests/openapi-request-lib.test.ts
+++ b/tests/openapi-request-lib.test.ts
@@ -4,7 +4,10 @@ import type {
   OpenApiEndpoint,
   OpenApiParam,
 } from "../apps/web/src/data/openapi";
-import { buildRequestUrl } from "../apps/web/src/lib/openapi-request-lib";
+import {
+  buildCurlCommand,
+  buildRequestUrl,
+} from "../apps/web/src/lib/openapi-request-lib";
 
 const param = (
   over: Partial<OpenApiParam> & Pick<OpenApiParam, "name" | "in">,
@@ -73,5 +76,63 @@ describe("buildRequestUrl", () => {
       ],
     });
     expect(buildRequestUrl(ep, {})).toBe("/api/v1/subnets/7");
+  });
+});
+
+describe("buildCurlCommand", () => {
+  it("builds a simple GET curl from documented path/query examples", () => {
+    const ep = endpoint({
+      method: "GET",
+      path: "/api/v1/entries",
+      parameters: [param({ name: "category", in: "query", example: "mcp" })],
+    });
+    expect(buildCurlCommand(ep)).toBe(
+      "curl 'https://heyclau.de/api/v1/entries?category=mcp'",
+    );
+  });
+
+  it("uses the live playground body for POST curl -d payload", () => {
+    const ep = endpoint({
+      id: "votes.toggle",
+      method: "POST",
+      path: "/api/v1/votes/toggle",
+      body: {
+        contentType: "application/json",
+        example: '{\n  "key": "mcp:old",\n  "vote": true\n}',
+      },
+    });
+    const edited =
+      '{"key":"mcp:github-mcp-server","clientId":"anon","vote":false}';
+    expect(buildCurlCommand(ep, edited)).toBe(
+      'curl -X POST \'https://heyclau.de/api/v1/votes/toggle\' \\\n  -H \'content-type: application/json\' \\\n  -d \'{"key":"mcp:github-mcp-server","clientId":"anon","vote":false}\'',
+    );
+  });
+
+  it("falls back to the documented body example when no live body is passed", () => {
+    const ep = endpoint({
+      method: "PATCH",
+      path: "/api/v1/example",
+      body: {
+        contentType: "application/json",
+        example: '{\n  "status": "active"\n}',
+      },
+    });
+    expect(buildCurlCommand(ep)).toBe(
+      "curl -X PATCH 'https://heyclau.de/api/v1/example' \\\n  -H 'content-type: application/json' \\\n  -d '{  \"status\": \"active\"}'",
+    );
+  });
+
+  it("strips newlines from the live body the same way the static example did", () => {
+    const ep = endpoint({
+      method: "POST",
+      path: "/api/v1/newsletter/subscribe",
+      body: {
+        contentType: "application/json",
+        example: '{"email":"a@b.c"}',
+      },
+    });
+    expect(buildCurlCommand(ep, '{\n  "email": "reader@example.com"\n}')).toBe(
+      "curl -X POST 'https://heyclau.de/api/v1/newsletter/subscribe' \\\n  -H 'content-type: application/json' \\\n  -d '{  \"email\": \"reader@example.com\"}'",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Choose **option (a)** from #5259: wire the playground Body textarea into the generated curl snippet so edits have a visible effect.
- Lift `body` state to `OpenApiEndpointCard` and pass it to both `OpenApiPlayground` and `CurlBlock`.
- Extract `buildCurlCommand()` into `openapi-request-lib.ts` (same pure-helper pattern as `buildRequestUrl`) and cover live-body / fallback / GET cases with unit tests.
- Do **not** add live POST/PATCH `send()` support (explicitly out of scope).

Closes #5259

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `apps/web/src/components/openapi.tsx` (`OpenApiEndpointCard`, `CurlBlock`, `OpenApiPlayground`)
  - `apps/web/src/lib/openapi-request-lib.ts` (`buildCurlCommand`)
  - `tests/openapi-request-lib.test.ts`
- Expected behavior:
  - Editing the Body textarea on any POST/PATCH playground updates the left-column curl `-d` payload immediately.
  - GET curl snippets are unchanged.
  - Documented body example is still used when no live body is supplied to `buildCurlCommand`.
- Important edge cases or invariants:
  - Newlines are stripped from the live body the same way the previous static example path did.
  - Sample / live-GET Send behavior is unchanged (no live non-GET requests added).
- Backward compatibility notes:
  - Curl shape (`curl -X METHOD … -H content-type … -d '…'`) preserved; only the `-d` source becomes the live textarea value.
- Screenshots for frontend/page/UI changes:
  - Desktop · Light — `votes.toggle` after editing Body (`vote: false` appears in curl):

    ![Desktop: edited body drives curl](https://litter.catbox.moe/sxcirt.png)

- Option chosen and why:
  - **Option (a)**. The control is already rendered as an editable textarea; making it read-only (option b) would discard an existing interaction surface. Wiring it to curl matches visitor expectation and keeps Send out of scope for non-GET.
- Accessibility notes for UI changes:
  - Added `aria-label="Request body"` and `spellCheck={false}` on the textarea; keyboard edit path unchanged.
- Focused tests or reason tests are not practical:
  - `pnpm exec vitest run tests/openapi-request-lib.test.ts tests/openapi-cta-events-lib.test.ts` (12 passed)

## Validation

- [x] Platform/code PR: `pnpm --filter web build` passed.
- [x] `pnpm --filter web type-check` passed.
- [x] Prettier `--check` clean on all touched files.
- [x] I ran the focused checks listed above.

```sh
pnpm exec vitest run tests/openapi-request-lib.test.ts tests/openapi-cta-events-lib.test.ts
pnpm --filter web type-check
pnpm --filter web build
```

## Notes

- Linked issue: #5259 (direction commented on the issue before implementation: option a).
- Applied consistently for every endpoint that renders the body textarea (shared `OpenApiEndpointCard` / playground path), not a single endpoint special-case.

