### PR TITLE
fix(web): emit a bespoke og:image on job detail pages

### DIFF
--- a/apps/web/src/routes/jobs.$slug.tsx
+++ b/apps/web/src/routes/jobs.$slug.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { absoluteUrl } from "@/lib/seo";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
+import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { NewsletterInline } from "@/components/newsletter-inline";
@@ -77,6 +79,7 @@ export const Route = createFileRoute("/jobs/$slug")({
     const url = absoluteUrl(`/jobs/${params.slug}`);
     const title = `${job.title} at ${job.company}`;
     const description = job.description || "Source-verified role from the HeyClaude jobs board.";
+    const ogImage = ogImageUrl({ title, eyebrow: "Job", description });
     return {
       meta: [
         { title: `${title} — HeyClaude jobs` },
@@ -84,7 +87,7 @@ export const Route = createFileRoute("/jobs/$slug")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:type", content: "article" },
+        ...ogImageMetaTags(ogImage, "article"),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [


### PR DESCRIPTION
## Summary

- Wire `jobs/$slug`'s `head()` through `ogImageUrl({ title, eyebrow: "Job", description })` and spread `...ogImageMetaTags(ogImage, "article")`, matching the sibling per-item detail routes (`best`, `compare`, `integrations`, `contributors`, `entry`, `tags`, `for.$platform`).
- Drop the standalone `og:type` tag so `ogImageMetaTags` owns the shared article-card shape (`og:image` + `og:image:type/width/height` + `twitter:card`/`twitter:image` + `og:type`), keeping the emitted meta identical in shape to the siblings.

Closes #5216

## Quality Evidence

Before this change, every job detail page fell back to the sitewide default `og-image.png` (1200×630) — confirmed live on production:

```
$ curl -s https://heyclau.de/jobs/1sphere-ai-engineer | grep og:image
<meta property="og:image" content="https://heyclau.de/og-image.png"/>   # generic sitewide default
```

After this change, `head()` emits a bespoke per-role card via `/og?title=<job.title> at <job.company>&eyebrow=Job&description=<description>`, exactly like `best.$slug.tsx:42,55` and the other detail routes. Both endpoints verified rendering a real PNG on production:

| | OG card (live-rendered) |
| --- | --- |
| **Before** — generic sitewide default (`HTTP 200`, `image/png`, 14 KB) | ![before](https://heyclau.de/og-image.png) |
| **After** — bespoke job card (`HTTP 200`, `image/png`, 63 KB) | ![after](https://heyclau.de/og?title=AI+Engineer+at+1Sphere+AI&eyebrow=Job&description=Build+enterprise+AI+systems+at+1Sphere%2C+working+across+product%2C+engineering%2C+and+applied+AI+for+large-company+use+cases.) |

Emitted meta tag shape matches the sibling routes (no missing width/height/card type): `og:image`, `og:image:type=image/png`, `og:image:width=1200`, `og:image:height=630`, `og:type=article`, `twitter:card=summary_large_image`, `twitter:image` — all produced by the shared, unit-tested `ogImageMetaTags()` helper (`tests/og-meta-lib.test.ts`). The existing `og:title`/`og:description`/`og:url`/`title` meta and the canonical link / breadcrumb / JobPosting JSON-LD scripts are unchanged.

### UI Evidence

This is a `<head>` meta-tag-only change — the rendered job detail page is byte-identical before/after (the OG card only affects social/link-unfurl previews, shown in the table above). The required viewport × theme rows are included for completeness; each before/after pair is intentionally identical because there is no on-page visual delta.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![Desktop · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=1440&h=900&theme=light&themeStorageKey=hc-theme) | ![Desktop · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=1440&h=900&theme=light&themeStorageKey=hc-theme) |
| Desktop · Dark | ![Desktop · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) | ![Desktop · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) |
| Tablet · Light | ![Tablet · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=768&h=1024&theme=light&themeStorageKey=hc-theme) | ![Tablet · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=768&h=1024&theme=light&themeStorageKey=hc-theme) |
| Tablet · Dark | ![Tablet · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) | ![Tablet · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) |
| Mobile · Light | ![Mobile · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=390&h=844&theme=light&themeStorageKey=hc-theme) | ![Mobile · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=390&h=844&theme=light&themeStorageKey=hc-theme) |
| Mobile · Dark | ![Mobile · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=390&h=844&theme=dark&themeStorageKey=hc-theme) | ![Mobile · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2Fjobs%2F1sphere-ai-engineer&w=390&h=844&theme=dark&themeStorageKey=hc-theme) |

## Validation

- [x] `pnpm exec vitest run tests/og-meta-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] `pnpm test` (full suite — 765 files / 39,747 tests pass)
- [x] `pnpm exec prettier --check` on the changed route
- [x] `git diff --check` (no whitespace errors)
