### PR TITLE
fix(web): wire /api/og to the real OG card renderer

### DIFF
--- a/apps/web/src/lib/og-api-query-lib.ts
+++ b/apps/web/src/lib/og-api-query-lib.ts
@@ -1,0 +1,62 @@
+/**
+ * Map the documented `/api/og` query contract onto the shared OG card renderer.
+ *
+ * `/og` accepts title/description/eyebrow/accent. The published OpenAPI contract for
+ * `/api/og` uses title/description/label/kind/badge instead — this adapter is the
+ * bridge so the API honors its own schema while reusing resolveOgQueryFields +
+ * renderOgPng unchanged.
+ */
+
+import { OG_TEXT_LIMITS, clampOgText } from "@/lib/og-image";
+import { resolveOgQueryFields } from "@/lib/og-query-fields-lib";
+import type { OgCardOptions } from "@/lib/og-render-lib";
+
+export const OG_API_KIND_ACCENTS = {
+  registry: "#e1f32a",
+  category: "#8aa9ff",
+  entry: "#7cd17c",
+  job: "#f3b85a",
+  tool: "#ff9a7a",
+  platform: "#76d7c4",
+} as const;
+
+export type OgApiKind = keyof typeof OG_API_KIND_ACCENTS;
+
+export type OgApiQuery = {
+  title: string;
+  description: string;
+  label: string;
+  kind: OgApiKind;
+  badge: string;
+};
+
+/**
+ * Resolve `/api/og` query fields into OgCardOptions for renderOgPng.
+ *
+ * Mapping:
+ * - title/description → card title/description (clamped via resolveOgQueryFields)
+ * - label → eyebrow (section label)
+ * - kind → accent color (so kind visibly affects the card)
+ * - badge → author line ("by …")
+ */
+export function resolveApiOgCardOptions(query: OgApiQuery): OgCardOptions {
+  const fields = resolveOgQueryFields(
+    new URLSearchParams({
+      title: query.title,
+      description: query.description,
+      eyebrow: query.label,
+      accent: OG_API_KIND_ACCENTS[query.kind],
+    }),
+    query.description,
+  );
+
+  const author = clampOgText(query.badge, OG_TEXT_LIMITS.author);
+
+  return {
+    title: fields.title,
+    description: fields.description || undefined,
+    eyebrow: fields.eyebrow,
+    accent: fields.accent,
+    author: author || undefined,
+  };
+}

--- a/apps/web/src/routes/api/og.ts
+++ b/apps/web/src/routes/api/og.ts
@@ -1,20 +1,26 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
-import { createApiHandler } from "@/lib/api/router";
+import { ogQuerySchema } from "@/lib/api/contracts";
+import { createApiHandler, type InferApiQuery } from "@/lib/api/router";
+import { resolveApiOgCardOptions } from "@/lib/og-api-query-lib";
+import { renderOgPng } from "@/lib/og-render.server";
 
-const PNG_1X1_TRANSPARENT = Uint8Array.from(
-  atob(
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
-  ),
-  (char) => char.charCodeAt(0),
-);
+/**
+ * Documented `/api/og` social-preview endpoint.
+ *
+ * Wired to the same PNG renderer as the crawlable `/og` route so the published
+ * OpenAPI query params (title, description, label, kind, badge) actually change
+ * the image. Scrapers that need a crawlable URL should still use `/og` (robots
+ * disallows `/api/*`).
+ */
+export const GET = createApiHandler("og.render", async ({ query }) => {
+  const parsed = query as InferApiQuery<typeof ogQuerySchema>;
+  const image = await renderOgPng(resolveApiOgCardOptions(parsed));
 
-export const GET = createApiHandler("og.render", async () => {
-  return new Response(PNG_1X1_TRANSPARENT, {
-    headers: {
-      "content-type": "image/png",
-      "cache-control": "public, max-age=3600, stale-while-revalidate=86400",
-    },
-  });
+  // ImageResponse already sets Content-Type: image/png; keep the documented
+  // cache policy that the stub used (per-query images remain cacheable).
+  const headers = new Headers(image.headers);
+  headers.set("Cache-Control", "public, max-age=3600, stale-while-revalidate=86400");
+  return new Response(image.body, { status: 200, headers });
 });
 
 export const Route = createApiFileRoute("/api/og")({

--- a/tests/og-api-query-lib.test.ts
+++ b/tests/og-api-query-lib.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OG_API_KIND_ACCENTS,
+  resolveApiOgCardOptions,
+} from "@/lib/og-api-query-lib";
+import { buildOgCardHtml } from "@/lib/og-render-lib";
+
+describe("resolveApiOgCardOptions", () => {
+  it("maps title, label→eyebrow, badge→author, and kind→accent", () => {
+    const opts = resolveApiOgCardOptions({
+      title: "Metagraphed MCP",
+      description: "Graph memory for agents",
+      label: "MCP",
+      kind: "entry",
+      badge: "heyclau.de",
+    });
+
+    expect(opts).toEqual({
+      title: "Metagraphed MCP",
+      description: "Graph memory for agents",
+      eyebrow: "MCP",
+      accent: OG_API_KIND_ACCENTS.entry,
+      author: "heyclau.de",
+    });
+  });
+
+  it("uses a distinct accent per documented kind so kind is visible in the card", () => {
+    const accents = new Set(
+      (Object.keys(OG_API_KIND_ACCENTS) as Array<keyof typeof OG_API_KIND_ACCENTS>).map(
+        (kind) =>
+          resolveApiOgCardOptions({
+            title: "T",
+            description: "D",
+            label: "L",
+            kind,
+            badge: "b",
+          }).accent,
+      ),
+    );
+    expect(accents.size).toBe(Object.keys(OG_API_KIND_ACCENTS).length);
+  });
+
+  it("clamps whitespace in title/label/badge before rendering", () => {
+    const opts = resolveApiOgCardOptions({
+      title: "  Hello   World  ",
+      description: "  short  ",
+      label: "  registry  ",
+      kind: "registry",
+      badge: "  badge  ",
+    });
+    expect(opts.title).toBe("Hello World");
+    expect(opts.eyebrow).toBe("registry");
+    expect(opts.author).toBe("badge");
+  });
+
+  it("feeds the shared HTML card so title + kind accent land in the markup", () => {
+    const opts = resolveApiOgCardOptions({
+      title: "Sample Entry Card",
+      description: "Honors documented /api/og query params",
+      label: "Entry",
+      kind: "entry",
+      badge: "heyclau.de",
+    });
+    const html = buildOgCardHtml(opts);
+
+    expect(html).toContain("Sample Entry Card");
+    expect(html).toContain(">ENTRY<");
+    expect(html).toContain(`background:${OG_API_KIND_ACCENTS.entry}`);
+    expect(html).toContain("heyclau.de");
+    expect(html).toContain("Honors documented /api/og query params");
+  });
+});


### PR DESCRIPTION
## Summary
- `/api/og` was fully documented in OpenAPI (`title`, `description`, `label`, `kind`, `badge`) but always returned a hardcoded 1×1 transparent PNG.
- Wire it to the same `renderOgPng` pipeline as `/og`, via a small adapter (`resolveApiOgCardOptions`) that maps the documented API query fields onto `resolveOgQueryFields` + card options.
- Mapping: `label` → eyebrow, `kind` → distinct accent color, `badge` → author, `title`/`description` → card text.

Closes #5241

## Quality evidence
**Before:** `GET /api/og?...` ignored every query param and returned a fixed 68-byte 1×1 transparent PNG (`PNG_1X1_TRANSPARENT`), with cache headers that implied real per-query generation.

**After:** `GET /api/og?title=Sample%20Entry%20Card&description=Honors%20documented%20%2Fapi%2Fog%20query%20params&label=Entry&kind=entry&badge=heyclau.de` resolves to:

```json
{
  "title": "Sample Entry Card",
  "description": "Honors documented /api/og query params",
  "eyebrow": "Entry",
  "accent": "#7cd17c",
  "author": "heyclau.de"
}
```

Those fields feed `buildOgCardHtml` / `renderOgPng` (same 1200×630 card as `/og`). Locally verified the shared card markup contains the title, `ENTRY` eyebrow, entry-green `#7cd17c` rail, description, and `by heyclau.de` author line. (Node cannot load `workers-og` WASM in vitest — same limitation noted in `tests/og-render.test.ts` — so raster PNG generation is exercised by the production Workers path; the card HTML/SVG twin confirms query reflection.)

## Test plan
- [x] `pnpm exec vitest run tests/api-contracts.test.ts tests/og-render.test.ts tests/og-render-lib.test.ts tests/og-api-query-lib.test.ts` (414 passed)
- [x] `pnpm --filter web type-check`
- [ ] Spot-check deployed `/api/og?title=...&kind=entry` returns a real `image/png` whose pixels reflect the query (not a 1×1)

