### PR TITLE
fix(raycast): show install/config snippet actions via feed flags + detail fetch

### DIFF
--- a/integrations/raycast/src/create-snippet-actions.tsx
+++ b/integrations/raycast/src/create-snippet-actions.tsx
@@ -1,0 +1,164 @@
+import {
+  Action,
+  ActionPanel,
+  Cache,
+  Detail,
+  Icon,
+  Toast,
+  showToast,
+} from "@raycast/api";
+import { usePromise } from "@raycast/utils";
+import { type RaycastEntry } from "./feed";
+import { entrySnippetKeyword } from "./raycast-ui";
+import { loadEntryDetail } from "./runtime";
+
+type SnippetKind = "install" | "config";
+
+type CreateSnippetFromDetailProps = {
+  entry: RaycastEntry;
+  cache: Cache;
+  feedUrl: string;
+  kind: SnippetKind;
+  onVisit?: () => void | Promise<void>;
+};
+
+function snippetCopy(kind: SnippetKind, entry: RaycastEntry, text: string) {
+  if (kind === "install") {
+    return {
+      title: "Create Install Snippet",
+      name: `${entry.title} install`,
+      keyword: entrySnippetKeyword(entry),
+      text,
+      emptyError: "No install command is available for this entry.",
+    };
+  }
+  return {
+    title: "Create Config Snippet",
+    name: `${entry.title} config`,
+    keyword: `${entrySnippetKeyword(entry)}-config`.slice(0, 40),
+    text,
+    emptyError: "No config snippet is available for this entry.",
+  };
+}
+
+function resolveSnippetText(
+  kind: SnippetKind,
+  entry: RaycastEntry,
+  detail: { installCommand?: string; configSnippet?: string } | undefined,
+) {
+  if (kind === "install") {
+    return String(detail?.installCommand || entry.installCommand || "").trim();
+  }
+  return String(detail?.configSnippet || entry.configSnippet || "").trim();
+}
+
+function CreateSnippetFromDetailView(props: CreateSnippetFromDetailProps) {
+  const { entry, cache, feedUrl, kind, onVisit } = props;
+  // Fresh Push target per entry — capture props in the closure; no arg deps needed.
+  const { data, isLoading, error } = usePromise(() =>
+    loadEntryDetail({ entry, cache, feedUrl }),
+  );
+
+  const text = resolveSnippetText(kind, entry, data);
+  const copy = snippetCopy(kind, entry, text);
+
+  return (
+    <Detail
+      isLoading={isLoading}
+      markdown={
+        error
+          ? `Could not load entry detail:\n\n${error instanceof Error ? error.message : "Unknown error"}`
+          : text
+            ? `\`\`\`\n${text}\n\`\`\``
+            : isLoading
+              ? "Loading entry detail…"
+              : copy.emptyError
+      }
+      actions={
+        text ? (
+          <ActionPanel>
+            <Action.CreateSnippet
+              title={copy.title}
+              icon={Icon.Snippets}
+              snippet={{
+                name: copy.name,
+                text: copy.text,
+                keyword: copy.keyword,
+              }}
+            />
+            <Action.CopyToClipboard
+              title={
+                kind === "install" ? "Copy Install Command" : "Copy Config"
+              }
+              content={text}
+              onCopy={() => {
+                void onVisit?.();
+              }}
+            />
+          </ActionPanel>
+        ) : error ? (
+          <ActionPanel>
+            <Action
+              title="Show Error"
+              icon={Icon.Warning}
+              onAction={() =>
+                void showToast({
+                  style: Toast.Style.Failure,
+                  title: copy.title,
+                  message:
+                    error instanceof Error ? error.message : "Unknown error",
+                })
+              }
+            />
+          </ActionPanel>
+        ) : null
+      }
+    />
+  );
+}
+
+export function CreateInstallSnippetAction(props: {
+  entry: RaycastEntry;
+  cache: Cache;
+  feedUrl: string;
+  onVisit?: () => void | Promise<void>;
+}) {
+  return (
+    <Action.Push
+      title="Create Install Snippet"
+      icon={Icon.Snippets}
+      target={
+        <CreateSnippetFromDetailView
+          entry={props.entry}
+          cache={props.cache}
+          feedUrl={props.feedUrl}
+          kind="install"
+          onVisit={props.onVisit}
+        />
+      }
+    />
+  );
+}
+
+export function CreateConfigSnippetAction(props: {
+  entry: RaycastEntry;
+  cache: Cache;
+  feedUrl: string;
+  onVisit?: () => void | Promise<void>;
+}) {
+  return (
+    <Action.Push
+      title="Create Config Snippet"
+      icon={Icon.Snippets}
+      target={
+        <CreateSnippetFromDetailView
+          entry={props.entry}
+          cache={props.cache}
+          feedUrl={props.feedUrl}
+          kind="config"
+          onVisit={props.onVisit}
+        />
+      }
+    />
+  );
+}

--- a/integrations/raycast/src/discovery-command.tsx
+++ b/integrations/raycast/src/discovery-command.tsx
@@ -22,6 +22,8 @@ import {
   buildEntrySummary,
   buildSuggestChangeUrl,
   categoryLabel,
+  entryHasConfigSnippet,
+  entryHasInstallCommand,
   entryKey,
   filterDiscoveryEntries,
   parseFavoriteKeys,
@@ -32,6 +34,10 @@ import {
   type RaycastEntry,
 } from "./feed";
 import {
+  CreateConfigSnippetAction,
+  CreateInstallSnippetAction,
+} from "./create-snippet-actions";
+import {
   fetchFreshFeed,
   fetchFreshRecentUpdates,
   fetchFreshTrending,
@@ -41,7 +47,7 @@ import {
   loadEntryDetail,
 } from "./runtime";
 import { markdownLink, withRaycastUtm } from "./links";
-import { entryDetailMetadata, entrySnippetKeyword } from "./raycast-ui";
+import { entryDetailMetadata } from "./raycast-ui";
 
 const cache = new Cache();
 
@@ -339,6 +345,54 @@ export function createDiscoveryCommand(options: DiscoveryCommandOptions) {
       }
     }
 
+    async function copyInstallCommand(entry: RaycastDiscoveryEntry) {
+      try {
+        const detail = await loadEntryDetail({
+          entry,
+          cache,
+          feedUrl: configuredFeed.feedUrl,
+        });
+        const installCommand = detail.installCommand || entry.installCommand;
+        if (!installCommand.trim()) {
+          throw new Error("No install command is available for this entry.");
+        }
+        await Clipboard.copy(installCommand);
+        await showHUD(`Copied ${entry.title} install command`, {
+          popToRootType: PopToRootType.Immediate,
+        });
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Could not copy install command",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
+    async function copyConfigSnippet(entry: RaycastDiscoveryEntry) {
+      try {
+        const detail = await loadEntryDetail({
+          entry,
+          cache,
+          feedUrl: configuredFeed.feedUrl,
+        });
+        const configSnippet = detail.configSnippet || entry.configSnippet;
+        if (!configSnippet.trim()) {
+          throw new Error("No config snippet is available for this entry.");
+        }
+        await Clipboard.copy(configSnippet);
+        await showHUD(`Copied ${entry.title} config`, {
+          popToRootType: PopToRootType.Immediate,
+        });
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Could not copy config",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
     async function toggleFavorite(entry: RaycastDiscoveryEntry) {
       const key = entryKey(entry);
       const next = new Set(favorites);
@@ -386,8 +440,8 @@ export function createDiscoveryCommand(options: DiscoveryCommandOptions) {
       >
         {displayedEntries.map((entry) => {
           const isFavorite = favorites.has(entryKey(entry));
-          const hasInstallCommand = Boolean(entry.installCommand.trim());
-          const hasConfig = Boolean(entry.configSnippet.trim());
+          const hasInstallCommand = entryHasInstallCommand(entry);
+          const hasConfig = entryHasConfigSnippet(entry);
           const webUrl = withRaycastUtm(entry.webUrl, options.kind);
 
           return (
@@ -428,17 +482,19 @@ export function createDiscoveryCommand(options: DiscoveryCommandOptions) {
                       onAction={() => void pasteFullAsset(entry)}
                     />
                     {hasInstallCommand ? (
-                      <Action.CopyToClipboard
+                      <Action
                         title="Copy Install Command"
-                        content={entry.installCommand}
+                        icon={Icon.Terminal}
                         shortcut={{ modifiers: ["cmd"], key: "i" }}
+                        onAction={() => void copyInstallCommand(entry)}
                       />
                     ) : null}
                     {hasConfig ? (
-                      <Action.CopyToClipboard
+                      <Action
                         title="Copy Config"
-                        content={entry.configSnippet}
+                        icon={Icon.Code}
                         shortcut={{ modifiers: ["cmd"], key: "." }}
+                        onAction={() => void copyConfigSnippet(entry)}
                       />
                     ) : null}
                     <Action.OpenInBrowser
@@ -489,26 +545,17 @@ export function createDiscoveryCommand(options: DiscoveryCommandOptions) {
                       }}
                     />
                     {hasInstallCommand ? (
-                      <Action.CreateSnippet
-                        title="Create Install Snippet"
-                        snippet={{
-                          name: `${entry.title} install`,
-                          text: entry.installCommand,
-                          keyword: entrySnippetKeyword(entry),
-                        }}
+                      <CreateInstallSnippetAction
+                        entry={entry}
+                        cache={cache}
+                        feedUrl={configuredFeed.feedUrl}
                       />
                     ) : null}
                     {hasConfig ? (
-                      <Action.CreateSnippet
-                        title="Create Config Snippet"
-                        snippet={{
-                          name: `${entry.title} config`,
-                          text: entry.configSnippet,
-                          keyword: `${entrySnippetKeyword(entry)}-config`.slice(
-                            0,
-                            40,
-                          ),
-                        }}
+                      <CreateConfigSnippetAction
+                        entry={entry}
+                        cache={cache}
+                        feedUrl={configuredFeed.feedUrl}
                       />
                     ) : null}
                   </ActionPanel.Section>

--- a/integrations/raycast/src/feed.ts
+++ b/integrations/raycast/src/feed.ts
@@ -1087,6 +1087,30 @@ export function fallbackDetail(entry: RaycastEntry): RaycastDetail {
   };
 }
 
+/**
+ * Compact Raycast feeds omit raw install/config text and only ship boolean
+ * flags (`hasInstallCommand` / `hasConfigSnippet`). Detail payloads may still
+ * carry the text. Gate UI actions on either signal so list rows from the
+ * compact feed still expose install/config actions.
+ */
+export function entryHasInstallCommand(
+  entry: Pick<RaycastEntry, "hasInstallCommand" | "installCommand">,
+): boolean {
+  return (
+    Boolean(entry.hasInstallCommand) ||
+    Boolean(String(entry.installCommand ?? "").trim())
+  );
+}
+
+export function entryHasConfigSnippet(
+  entry: Pick<RaycastEntry, "hasConfigSnippet" | "configSnippet">,
+): boolean {
+  return (
+    Boolean(entry.hasConfigSnippet) ||
+    Boolean(String(entry.configSnippet ?? "").trim())
+  );
+}
+
 export function sortedCategoryOptions(
   entries: RaycastEntry[],
 ): CategoryOption[] {

--- a/integrations/raycast/src/registry-command.tsx
+++ b/integrations/raycast/src/registry-command.tsx
@@ -26,6 +26,8 @@ import {
   buildContributeEntryUrl,
   buildSuggestChangeUrl,
   categoryLabel,
+  entryHasConfigSnippet,
+  entryHasInstallCommand,
   entryKey,
   filterEntriesBySearchText,
   parseFavoriteKeys,
@@ -35,13 +37,17 @@ import {
   type RaycastEntry,
 } from "./feed";
 import {
+  CreateConfigSnippetAction,
+  CreateInstallSnippetAction,
+} from "./create-snippet-actions";
+import {
   fetchFreshFeed,
   fetchRegistrySearch,
   loadCachedFeed as loadCachedFeedFromRuntime,
   loadEntryDetail,
 } from "./runtime";
 import { markdownLink, withRaycastUtm } from "./links";
-import { entryDetailMetadata, entrySnippetKeyword } from "./raycast-ui";
+import { entryDetailMetadata } from "./raycast-ui";
 import {
   MCP_INSTALL_TARGETS,
   buildMcpInstallPlan,
@@ -938,10 +944,8 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
           <List.Section key={section.title} title={section.title}>
             {section.entries.map((entry) => {
               const isFavorite = favorites.has(entryKey(entry));
-              const hasInstallCommand =
-                entry.hasInstallCommand || Boolean(entry.installCommand.trim());
-              const hasConfig =
-                entry.hasConfigSnippet || Boolean(entry.configSnippet.trim());
+              const hasInstallCommand = entryHasInstallCommand(entry);
+              const hasConfig = entryHasConfigSnippet(entry);
               const installTargets =
                 entry.category === "mcp"
                   ? MCP_INSTALL_TARGETS.filter((target) =>
@@ -1107,28 +1111,20 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
                             icon: categoryIcons[entry.category] ?? Icon.Link,
                           }}
                         />
-                        {entry.installCommand.trim() ? (
-                          <Action.CreateSnippet
-                            title="Create Install Snippet"
-                            snippet={{
-                              name: `${entry.title} install`,
-                              text: entry.installCommand,
-                              keyword: entrySnippetKeyword(entry),
-                            }}
+                        {hasInstallCommand ? (
+                          <CreateInstallSnippetAction
+                            entry={entry}
+                            cache={cache}
+                            feedUrl={configuredFeed.feedUrl}
+                            onVisit={() => visitItem(entry)}
                           />
                         ) : null}
-                        {entry.configSnippet.trim() ? (
-                          <Action.CreateSnippet
-                            title="Create Config Snippet"
-                            snippet={{
-                              name: `${entry.title} config`,
-                              text: entry.configSnippet,
-                              keyword:
-                                `${entrySnippetKeyword(entry)}-config`.slice(
-                                  0,
-                                  40,
-                                ),
-                            }}
+                        {hasConfig ? (
+                          <CreateConfigSnippetAction
+                            entry={entry}
+                            cache={cache}
+                            feedUrl={configuredFeed.feedUrl}
+                            onVisit={() => visitItem(entry)}
                           />
                         ) : null}
                       </ActionPanel.Section>

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -1506,7 +1506,17 @@ describe("Raycast feed helpers", () => {
     assert.doesNotMatch(registrySource, /\{ text: "Full on demand" \}/);
     assert.match(registrySource, /metadata=\{entryDetailMetadata/);
     assert.match(registrySource, /Action\.CreateQuicklink/);
-    assert.match(registrySource, /Action\.CreateSnippet/);
+    assert.match(registrySource, /CreateInstallSnippetAction/);
+    assert.match(registrySource, /CreateConfigSnippetAction/);
+    assert.match(registrySource, /entryHasInstallCommand/);
+    assert.match(registrySource, /entryHasConfigSnippet/);
+
+    const createSnippetSource = fs.readFileSync(
+      path.join(process.cwd(), "src", "create-snippet-actions.tsx"),
+      "utf8",
+    );
+    assert.match(createSnippetSource, /Action\.CreateSnippet/);
+    assert.match(createSnippetSource, /loadEntryDetail/);
 
     assert.doesNotMatch(jobsSource, /\n\s+title=\{job\.company\}/);
     assert.match(jobsSource, /\n\s+title=\{job\.title\}/);

--- a/tests/raycast-feed-detail-helpers.test.ts
+++ b/tests/raycast-feed-detail-helpers.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 // it to the TypeScript source.
 import {
   categoryLabel,
+  entryHasConfigSnippet,
+  entryHasInstallCommand,
   isRaycastDetail,
   fallbackDetail,
   hasValidDiscoveryEntries,
@@ -91,5 +93,62 @@ describe("hasValidDiscoveryEntries", () => {
 
   it("throws on malformed JSON (callers pass trusted feed payloads)", () => {
     expect(() => hasValidDiscoveryEntries("not json")).toThrow();
+  });
+});
+
+describe("entryHasInstallCommand / entryHasConfigSnippet", () => {
+  it("gates on compact-feed boolean flags when raw text is empty", () => {
+    expect(
+      entryHasInstallCommand(
+        entry({ hasInstallCommand: true, installCommand: "" }),
+      ),
+    ).toBe(true);
+    expect(
+      entryHasConfigSnippet(
+        entry({ hasConfigSnippet: true, configSnippet: "" }),
+      ),
+    ).toBe(true);
+    expect(
+      entryHasInstallCommand(
+        entry({ hasInstallCommand: false, installCommand: "" }),
+      ),
+    ).toBe(false);
+    expect(
+      entryHasConfigSnippet(
+        entry({ hasConfigSnippet: false, configSnippet: "" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still gates on non-empty detail text when flags are false", () => {
+    expect(
+      entryHasInstallCommand(
+        entry({
+          hasInstallCommand: false,
+          installCommand: "npx heyclaude-skill",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      entryHasConfigSnippet(
+        entry({
+          hasConfigSnippet: false,
+          configSnippet: '{ "mcpServers": {} }',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats whitespace-only text as absent", () => {
+    expect(
+      entryHasInstallCommand(
+        entry({ hasInstallCommand: false, installCommand: "   " }),
+      ),
+    ).toBe(false);
+    expect(
+      entryHasConfigSnippet(
+        entry({ hasConfigSnippet: false, configSnippet: "\n\t" }),
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
# Pull Request

## Summary

- Gate Raycast "Create Install/Config Snippet" and discovery "Copy Install Command/Copy Config" actions on `hasInstallCommand` / `hasConfigSnippet` (compact feeds omit the raw text).
- Load the entry detail payload via the existing `loadEntryDetail` pattern before copying text or opening Create Snippet, so actions appear and resolve real install/config content.
- Extract shared `CreateInstallSnippetAction` / `CreateConfigSnippetAction` helpers that fetch detail then expose `Action.CreateSnippet`.

Closes #5239.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `integrations/raycast/src/discovery-command.tsx` (Trending / Recent Updates)
  - `integrations/raycast/src/registry-command.tsx` (Search + category search commands)
  - `integrations/raycast/src/feed.ts` (`entryHasInstallCommand` / `entryHasConfigSnippet`)
  - `integrations/raycast/src/create-snippet-actions.tsx` (detail-fetch → Create Snippet)
- Expected behavior:
  - Entries with `hasInstallCommand` / `hasConfigSnippet` true show the matching Copy and Create Snippet actions.
  - Entries with neither flag (and no inline text) hide those actions.
  - Activating Copy or Create Snippet loads `/data/raycast/<category>/<slug>.json` and uses the detail's `installCommand` / `configSnippet`.
- Important edge cases or invariants:
  - Install-only entry: install actions visible; config actions hidden.
  - Config-only entry: config actions visible; install actions hidden.
  - Neither: no install/config copy or snippet actions.
  - Compact feed rows keep `installCommand` / `configSnippet` empty; boolean flags alone are enough to show actions.
  - Detail fetch failure surfaces a toast (copy) or error detail (snippet push) instead of creating an empty snippet.
- Backward compatibility notes:
  - Detail payloads that still embed raw install/config text continue to work via the flag-or-text helper.
  - Website / feed generators are unchanged (preferred detail-fetch approach from #5239).
- Screenshots for frontend/page/UI changes:
  - Desktop: N/A (Raycast macOS extension; no website UI change)
  - Mobile: N/A
- If screenshots do not apply, write `No visual impact` and explain why.
  - **No visual impact** on the website. This is a Raycast extension ActionPanel fix only. A live Raycast screen recording was not available in this Linux CI/dev environment; validation is covered by unit/extension tests and `ray build`.
- Accessibility notes for UI changes:
  - Action titles unchanged; actions now correctly appear/disappear based on capability flags.
- Focused tests or reason tests are not practical:
  - Added helper coverage in `tests/raycast-feed-detail-helpers.test.ts`
  - Updated `integrations/raycast/test/feed.test.ts` source guard for the new snippet helpers

## Validation

- [x] Platform/code PR: focused Raycast build passed (`cd integrations/raycast && npm run build`).
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected integration surface via tests (Raycast GUI not available here).

Focused commands run:

```sh
pnpm exec vitest run tests/raycast-entry-filters.test.ts tests/raycast-feed-detail-helpers.test.ts
cd integrations/raycast && npm test && npm run build
```

All passed (vitest 16/16, raycast node tests 52/52, `ray build` ready).

## Notes

- Linked issue: Closes #5239
- Follows the issue's preferred detail-fetch approach (does not enlarge compact feed payloads).
