### PR TITLE
fix(web): emit a bespoke og:image on job detail pages

### DIFF
--- a/apps/web/src/routes/jobs.$slug.tsx
+++ b/apps/web/src/routes/jobs.$slug.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { absoluteUrl } from "@/lib/seo";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
+import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { NewsletterInline } from "@/components/newsletter-inline";
@@ -77,6 +79,7 @@ export const Route = createFileRoute("/jobs/$slug")({
     const url = absoluteUrl(`/jobs/${params.slug}`);
     const title = `${job.title} at ${job.company}`;
     const description = job.description || "Source-verified role from the HeyClaude jobs board.";
+    const ogImage = ogImageUrl({ title, eyebrow: "Job", description });
     return {
       meta: [
         { title: `${title} — HeyClaude jobs` },
@@ -84,7 +87,7 @@ export const Route = createFileRoute("/jobs/$slug")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:type", content: "article" },
+        ...ogImageMetaTags(ogImage, "article"),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [


### PR DESCRIPTION
# Pull Request

## Summary

- Job detail pages (`jobs.$slug.tsx`) set title/description/og:* but never called `ogImageUrl()`/`ogImageMetaTags()`, so job postings fell back to the generic sitewide social card — unlike every sibling per-item detail route (best/compare/integrations/contributors/entry/tags/for).
- This emits a bespoke `og:image` (+ og:image:width/height, twitter:card, twitter:image, og:type) for each role, mirroring the siblings.

Closes #5216

## Submission Source

For platform/code PRs:

- [x] Not a direct content submission.
- [x] Changed route listed below.
- [x] Screenshots included (route change → before/after matrix).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed:** `apps/web/src/routes/jobs.$slug.tsx` only (the issue's scope). Builds `ogImageUrl({ title: "<title> at <company>", eyebrow: "Job", description })` and spreads `ogImageMetaTags(ogImage, "article")` into `head().meta`. That helper also emits `og:type=article`, so the prior manual `og:type` tag was removed (no duplicate) — matching `compare.$slug.tsx` et al.
- **Expected head output (after):** `og:image`, `og:image:type`, `og:image:width`, `og:image:height`, `og:type=article`, `twitter:card=summary_large_image`, `twitter:image` — verified live in the rendered DOM: `og:image = https://heyclau.de/og?title=Staff+Platform+Engineer+at+Acme+AI...`, `twitter:card = summary_large_image`, `og:type = article`. Before: no og:image / twitter:image (generic default).
- **Out of scope (unchanged):** `jobs.index.tsx` / hub pages keep the sitewide default; the `og-meta-lib.ts` helper is untouched.
- **Edge case:** the not-found path (`!job`) is unchanged — no canonical / og:image for a dead URL.

## Screenshot evidence

`og:image`/`twitter:*` are `<head>` meta tags and are **not rendered on the page**, so the job detail page is visually identical before/after (the value is what changes, verified in the DOM above). The matrix below documents no visual regression across every viewport × theme. Rendered against a local dev build with a fixture role (the dev environment has no jobs DB).

| Viewport · Theme | Before | After |
|---|---|---|
| Desktop · Light | <img width="1440" height="900" alt="jobdetail-desktop-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-desktop-light-before.png" /> | <img width="1440" height="900" alt="jobdetail-desktop-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-desktop-light-after.png" /> |
| Desktop · Dark | <img width="1440" height="900" alt="jobdetail-desktop-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-desktop-dark-before.png" /> | <img width="1440" height="900" alt="jobdetail-desktop-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-desktop-dark-after.png" /> |
| Tablet · Light | <img width="768" height="1024" alt="jobdetail-tablet-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-tablet-light-before.png" /> | <img width="768" height="1024" alt="jobdetail-tablet-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-tablet-light-after.png" /> |
| Tablet · Dark | <img width="768" height="1024" alt="jobdetail-tablet-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-tablet-dark-before.png" /> | <img width="768" height="1024" alt="jobdetail-tablet-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-tablet-dark-after.png" /> |
| Mobile · Light | <img width="390" height="844" alt="jobdetail-mobile-light-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-mobile-light-before.png" /> | <img width="390" height="844" alt="jobdetail-mobile-light-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-mobile-light-after.png" /> |
| Mobile · Dark | <img width="390" height="844" alt="jobdetail-mobile-dark-before" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-mobile-dark-before.png" /> | <img width="390" height="844" alt="jobdetail-mobile-dark-after" src="https://raw.githubusercontent.com/galuis116/awesome-claude/pr-assets/5216/jobdetail-mobile-dark-after.png" /> |

## Validation

- `pnpm exec vitest run tests/og-meta-lib.test.ts` — **5 passed**.
- `pnpm exec prettier --check apps/web/src/routes/jobs.$slug.tsx` — clean; `git diff --check` — clean; targeted `tsc` shows no new diagnostics on the changed lines (repo-wide `createFileRoute` errors are the ungenerated-route-tree baseline).

## Notes

- Linked issue: Closes #5216. Supersedes the auto-closed #5409 (which was closed only for an incomplete screenshot matrix — now provided in full). Screenshots hosted on the `pr-assets` fork branch (raw URLs) to keep the diff free of binaries.
