### PR TITLE
fix(registry): generate Raycast copyText/copyTextTruncated payloads

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -914,11 +914,26 @@ export function buildCursorSkillAdapter(entry) {
 
 export function buildRaycastEntries(entries) {
   return entries.map((entry) => {
+    // Feed rows carry a preview-capped copy payload; the full text lives in the
+    // detail payload (buildRaycastDetail) and is loaded on demand when the
+    // preview was truncated (the extension's copy action prefers
+    // detail.copyText and falls back to this feed preview). `copyTextTruncated`
+    // tells the extension whether it must fetch the full text. `getCopyText`
+    // is the same canonical clipboard payload the website exposes and always
+    // resolves to a non-empty string.
+    const fullCopyText = getCopyText(entry).trim();
+    const copyText = fullCopyText
+      ? truncateText(fullCopyText, RAYCAST_COPY_PREVIEW_LIMIT)
+      : undefined;
     return compactDefinedObject({
       category: entry.category,
       slug: entry.slug,
       title: entry.title,
       description: entry.cardDescription || entry.description,
+      copyText,
+      copyTextTruncated: copyText
+        ? fullCopyText.length > RAYCAST_COPY_PREVIEW_LIMIT
+        : undefined,
       tags: entry.tags,
       author: entry.author || "",
       ...buildEntryProvenanceFields(entry),
@@ -969,6 +984,10 @@ export function buildEntryDetail(entry, params = {}) {
 }
 
 export function buildRaycastDetail(entry) {
+  // Full, untruncated clipboard payload. The feed row only carries a preview
+  // capped at RAYCAST_COPY_PREVIEW_LIMIT, so the extension loads this on demand
+  // when the preview was truncated.
+  const copyText = getCopyText(entry).trim();
   return {
     schemaVersion: RAYCAST_SCHEMA_VERSION,
     key: `${entry.category}:${entry.slug}`,
@@ -979,6 +998,7 @@ export function buildRaycastDetail(entry) {
     ...buildEntryProvenanceFields(entry),
     ...buildEntryBrandFields(entry),
     detailMarkdown: buildRaycastDetailMarkdown(entry),
+    ...(copyText ? { copyText } : {}),
     webUrl: entryCanonicalUrl(entry),
     canonicalUrl: entryCanonicalUrl(entry),
     llmsUrl: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,

--- a/scripts/validate-raycast-feed.mjs
+++ b/scripts/validate-raycast-feed.mjs
@@ -250,12 +250,15 @@ for (const entry of payload.entries) {
       fail(`${key}: detail without copyText must expose llmsUrl`);
     }
   }
-  if (
-    entry.copyText !== undefined &&
-    entry.copyTextTruncated &&
-    detail.copyText.length <= String(entry.copyText ?? "").length
-  ) {
-    fail(`${key}: truncated feed entry must have longer detail copyText`);
+  if (entry.copyText !== undefined && entry.copyTextTruncated) {
+    // A truncated feed preview must be backed by a longer full copyText in the
+    // detail payload. Guard the length access so a missing/non-string
+    // detail.copyText fails cleanly here instead of throwing a raw TypeError.
+    if (typeof detail.copyText !== "string") {
+      fail(`${key}: truncated feed entry requires a string detail copyText`);
+    } else if (detail.copyText.length <= String(entry.copyText ?? "").length) {
+      fail(`${key}: truncated feed entry must have longer detail copyText`);
+    }
   }
   for (const field of [
     "brandName",

--- a/tests/artifacts-lib.test.ts
+++ b/tests/artifacts-lib.test.ts
@@ -41,6 +41,7 @@ import {
   buildCorpusLlmsArtifact,
   buildRegistryArtifactSet,
 } from "../packages/registry/src/artifacts-lib.js";
+import { getCopyText } from "../packages/registry/src/presentation.js";
 import {
   PLATFORM_IDS,
   PLATFORM_LABELS,
@@ -821,6 +822,46 @@ describe("buildRaycastEntries", () => {
     expect(withoutNotes?.trustSignals).toBeUndefined();
     expect(withNotes?.trustSignals).not.toHaveProperty("platforms");
     expect(withNotes?.trustSignals).not.toHaveProperty("supportLevels");
+  });
+});
+
+describe("Raycast copyText generation", () => {
+  it("emits the full copy payload on the detail and a capped preview on the feed", () => {
+    const detail = buildRaycastDetail(FIXTURE_MCP);
+    const [row] = buildRaycastEntries([FIXTURE_MCP]);
+    const expected = getCopyText(FIXTURE_MCP).trim();
+
+    expect(expected.length).toBeGreaterThan(0);
+    // Detail carries the whole payload; the feed row carries a preview capped
+    // at RAYCAST_COPY_PREVIEW_LIMIT (+3 for the truncation ellipsis).
+    expect(detail.copyText).toBe(expected);
+    expect(row?.copyText).toBe(
+      truncateText(expected, RAYCAST_COPY_PREVIEW_LIMIT),
+    );
+    expect(row!.copyText!.length).toBeLessThanOrEqual(
+      RAYCAST_COPY_PREVIEW_LIMIT + 3,
+    );
+    // FIXTURE_MCP's payload is short, so no truncation occurs.
+    expect(expected.length).toBeLessThanOrEqual(RAYCAST_COPY_PREVIEW_LIMIT);
+    expect(row?.copyTextTruncated).toBe(false);
+    expect(row?.copyText).toBe(detail.copyText);
+  });
+
+  it("flags copyTextTruncated and keeps the detail copyText longer when the payload exceeds the cap", () => {
+    const longEntry = syntheticEntry("guides", "very-long-guide", {
+      body: "A".repeat(RAYCAST_COPY_PREVIEW_LIMIT + 500),
+    });
+    const detail = buildRaycastDetail(longEntry);
+    const [row] = buildRaycastEntries([longEntry]);
+
+    expect(row?.copyTextTruncated).toBe(true);
+    expect(row!.copyText!.length).toBeLessThanOrEqual(
+      RAYCAST_COPY_PREVIEW_LIMIT + 3,
+    );
+    // The on-demand detail payload must stay longer than the truncated preview
+    // (the invariant validate-raycast-feed enforces).
+    expect(detail.copyText!.length).toBeGreaterThan(row!.copyText!.length);
+    expect(detail.copyText).toBe(getCopyText(longEntry).trim());
   });
 });
 

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -255,7 +255,9 @@ describe("registry artifacts", () => {
     // These budgets are growth guards, not fixed caps. The public registry
     // grows with curated content, so keep them per-entry to catch runaway
     // artifact bloat without failing every normal catalog expansion.
-    expect(artifactTreeSize(".")).toBeLessThan(2_000_000 + entryCount * 38_500);
+    // Per-entry allowance raised for the Raycast detail `copyText` field (the
+    // full, on-demand clipboard payload now generated for every entry).
+    expect(artifactTreeSize(".")).toBeLessThan(2_000_000 + entryCount * 43_000);
     expect(artifactSize("directory-index.json")).toBeLessThan(
       200_000 + entryCount * 2_150,
     );
@@ -263,9 +265,10 @@ describe("registry artifacts", () => {
       125_000 + entryCount * 1_600,
     );
     expect(artifactSize("raycast-index.json")).toBeLessThan(
-      // Sparse trustSignals note flags (~2 bools/entry when notes exist) need
-      // a slightly higher per-entry allowance than the pre-#5240 feed shape.
-      100_000 + entryCount * 1_150,
+      // Sparse trustSignals note flags (~2 bools/entry when notes exist) plus
+      // the preview-capped `copyText` payload (<= RAYCAST_COPY_PREVIEW_LIMIT per
+      // entry) need a higher per-entry allowance than the pre-copyText shape.
+      100_000 + entryCount * 2_000,
     );
     expect(artifactSize("relation-graph.json")).toBeLessThan(
       150_000 + entryCount * 1_500,
@@ -1392,14 +1395,29 @@ Use this hook after reviewing the notes.`,
         key,
         llmsUrl: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
       });
-      expect(raycastDetail).not.toHaveProperty("copyText");
+      // The detail payload now carries the full clipboard copy text; the feed
+      // row carries a preview capped at RAYCAST_COPY_PREVIEW_LIMIT plus a
+      // truncation flag, while the full text stays out of the (size-sensitive)
+      // feed. getCopyText always resolves to a non-empty payload, so these
+      // fields are present on every generated entry.
+      const detailCopyText = raycastDetail.copyText;
+      expect(typeof detailCopyText).toBe("string");
+      expect((detailCopyText ?? "").length).toBeGreaterThan(0);
+      expect(typeof raycastFeedEntry.copyText).toBe("string");
+      expect(raycastFeedEntry.copyText.length).toBeLessThanOrEqual(
+        RAYCAST_COPY_PREVIEW_LIMIT + 3,
+      );
+      expect(typeof raycastFeedEntry.copyTextTruncated).toBe("boolean");
+      if (raycastFeedEntry.copyTextTruncated) {
+        expect((detailCopyText ?? "").length).toBeGreaterThan(
+          raycastFeedEntry.copyText.length,
+        );
+      }
       expect(raycastFeedEntry.canonicalUrl).toBe(
         `https://heyclau.de/entry/${entry.category}/${entry.slug}`,
       );
       expect(raycastFeedEntry).not.toHaveProperty("llmsUrl");
-      expect(raycastFeedEntry).not.toHaveProperty("copyText");
       expect(raycastFeedEntry).not.toHaveProperty("copyTextLength");
-      expect(raycastFeedEntry).not.toHaveProperty("copyTextTruncated");
       expect(raycastFeedEntry).not.toHaveProperty("detailMarkdown");
     }
     expect(fs.existsSync(path.join(dataRoot, "llms"))).toBe(false);


### PR DESCRIPTION
## Summary

- `buildRaycastEntries` / `buildRaycastDetail` never set `copyText` / `copyTextTruncated`, so every consumer ran against a permanently `undefined` value: `scripts/validate-raycast-feed.mjs`'s four copyText checks (`entry.copyText !== undefined` was always false), the extension client's copyText fallback (`integrations/raycast/src/feed.ts`), and the "Copy payload / Loaded on demand" UI (`integrations/raycast/src/raycast-ui.tsx`, gated on `copyTextTruncated`).
- **Detail** now emits the full clipboard payload from the canonical `getCopyText(entry)` — the same source the website/extension copy action reads (`registry-command.tsx`: `Clipboard.copy(detail.copyText || entry.copyText)`).
- **Feed rows** emit a preview capped at `RAYCAST_COPY_PREVIEW_LIMIT` (800) via the already-exported `truncateText` helper, plus `copyTextTruncated: true` when the full payload exceeds the cap, so the extension knows when to load the full text on demand.
- **Validator hardening:** `validate-raycast-feed.mjs` line ~256 called `detail.copyText.length` unconditionally; it now fails cleanly (clear message) if a truncated feed entry has a missing/non-string detail copyText instead of throwing a raw `TypeError`.

Closes #5226

## Quality Evidence

No visual impact — this changes generated JSON artifacts + the Raycast extension's copy behavior, not the website UI.

`getCopyText` resolves to a non-empty payload for every entry, so `copyText` is now present on all 1385 generated feed + detail entries; 653/1385 exceed the 800-char cap and get `copyTextTruncated: true`.

**Before** (regenerated feed entry / detail — fields absent):
```jsonc
// raycast-index.json entry + raycast/<cat>/<slug>.json detail
{ "category": "rules", "slug": "dotnet-csharp-expert", /* no copyText, no copyTextTruncated */ }
```

**After** (regenerated via `pnpm --filter web run prebuild`):
```jsonc
// feed row (raycast-index.json) — preview capped at 800:
{ "slug": "dotnet-csharp-expert", "copyText": "Install:\n…", "copyTextTruncated": true }   // full length 1200+, preview 799 + "..."
{ "slug": "dotnet-agent-skills", "copyText": "Install:\ncodex plugin marketplace add dotnet/skills\n\nUsage:\n…", "copyTextTruncated": false } // 624 chars, not truncated
// detail (raycast/rules/dotnet-csharp-expert.json) — full, untruncated copyText, longer than the feed preview
```

- `detail.copyText.length > feed.copyText.length` whenever `copyTextTruncated` — the invariant `validate-raycast-feed.mjs` enforces — is asserted in tests and holds across all 1385 entries.

## Validation

- [x] `pnpm --filter web run prebuild` (regenerate artifacts — **not committed**)
- [x] `pnpm validate:raycast-feed` → `Validated 1385 Raycast feed entries.`
- [x] `pnpm test:registry-artifacts` (46 tests) + `pnpm exec vitest run tests/artifacts-lib.test.ts` (289 tests) — green
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — green
- [x] `prettier --check` (3.8.3, repo-pinned) + `git diff --check` — clean
- [x] Coverage on `packages/registry/src/artifacts-lib.js`: 97.7% lines (new copyText paths covered)

Generated `apps/web/public/data/raycast*` artifacts are regenerated by CI's prebuild and are intentionally **not committed**.
