### PR TITLE
fix(registry): add multiline flag to hasPrerequisites heading regex

### DIFF
--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -430,7 +430,7 @@ export function inferSectionBooleans(body = "") {
 
   return {
     hasPrerequisites:
-      /^##\s+Prerequisites\b|^##\s+Prerequisites\s+&|^##\s+Prerequisites\s+and\b/i.test(
+      /^##\s+Prerequisites\b|^##\s+Prerequisites\s+&|^##\s+Prerequisites\s+and\b/im.test(
         normalized,
       ),
     hasTroubleshooting:

--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -692,7 +692,13 @@ describe("inferSectionBooleans", () => {
     ],
     [
       "## Troubleshooting\n\n## Prerequisites",
-      { hasPrerequisites: false, hasTroubleshooting: true },
+      { hasPrerequisites: true, hasTroubleshooting: true },
+    ],
+    // hasPrerequisites must detect the heading anywhere in the body, not only
+    // as the first line — matching hasTroubleshooting's multiline behavior.
+    [
+      "## Overview\n\nIntro text.\n\n## Prerequisites\n\nNeed tool",
+      { hasPrerequisites: true, hasTroubleshooting: false },
     ],
   ])("detects guide sections in %j", (body, expected) => {
     expect(inferSectionBooleans(body)).toEqual(expected);


### PR DESCRIPTION
## Summary

- `inferSectionBooleans`' `hasPrerequisites` heading regex used only the `/i` flag, so `^` anchored to the start of the whole body string — it detected `## Prerequisites` only when that heading was literally the first line of the body.
- Its sibling `hasTroubleshooting` in the same function uses `/im`, so `^` matches the start of any line and the heading is detected anywhere.
- Added the `m` flag to `hasPrerequisites` for parity. Any entry with an intro sentence or an `## Overview` section before its Prerequisites heading now reports `hasPrerequisites: true` as intended.

Closes #5459

## Quality Evidence

- No visual impact (a derived content boolean).
- Added a test case with content before the heading (`## Overview` … then `## Prerequisites`) asserting `hasPrerequisites` is now `true`, and updated the existing `## Troubleshooting\n\n## Prerequisites` case — which previously encoded the bug (`hasPrerequisites: false`) — to the corrected `true`.
- Existing first-line cases remain `true`; `hasTroubleshooting` (the reference implementation) is unchanged.

## Validation

- `pnpm exec vitest run tests/content-schema-heading.test.ts tests/content-schema.test.ts tests/content-schema-lib.test.ts tests/registry-content-schema.test.ts` — pass (also ran the other `inferSectionBooleans` consumers: `non-ui-branch-matrix`, `content-builder-lib`, `submission-lib` — 844 pass)
- `pnpm type-check` — pass
- `pnpm build` — pass
- `git diff --check` — clean