### PR TITLE
fix(web): fall back normalizeRepoStats url to githubUrl

### DIFF
--- a/apps/web/src/lib/entry-normalize-lib.ts
+++ b/apps/web/src/lib/entry-normalize-lib.ts
@@ -348,7 +348,7 @@ export function normalizeRepoStats(entry: RegistryEntry): Entry["repoStats"] {
   const stars = stats?.stars ?? entry.githubStars ?? null;
   const forks = stats?.forks ?? entry.githubForks ?? null;
   const updatedAt = stats?.updatedAt ?? entry.repoUpdatedAt ?? null;
-  const url = stats?.url ?? entry.repoUrl ?? undefined;
+  const url = stats?.url ?? entry.repoUrl ?? entry.githubUrl ?? undefined;
   if (stars == null && forks == null && !updatedAt && !url) return undefined;
   return {
     repository: stats?.repository,

--- a/tests/entry-normalize-lib.test.ts
+++ b/tests/entry-normalize-lib.test.ts
@@ -389,6 +389,23 @@ describe("entry normalize lib helpers", () => {
         appliesTo: "none",
       });
     });
+
+    it("falls back url to githubUrl for GitHub-only entries, like stars/forks", () => {
+      expect(
+        normalizeRepoStats(
+          baseEntry({
+            githubUrl: "https://github.com/example/gh-only",
+            githubStars: 42,
+            githubForks: 7,
+          }),
+        ),
+      ).toMatchObject({
+        url: "https://github.com/example/gh-only",
+        stars: 42,
+        forks: 7,
+        appliesTo: "listing_source_repo",
+      });
+    });
   });
 
   describe("normalizeRelatedEntries", () => {


### PR DESCRIPTION
## Summary

- `normalizeRepoStats` derives `stars`/`forks` with a fallback to `entry.githubStars`/`entry.githubForks`, but its `url` derivation only fell back to `entry.repoUrl` — never `entry.githubUrl`.
- For an entry that sets only `githubUrl` (+ `githubStars`/`githubForks`) and no `repoUrl`, this produced populated `stars`/`forks` but an `undefined` `url`, which then forced `appliesTo` to `"none"` even though the entry has real GitHub repo data.
- Added the `entry.githubUrl` fallback, so `url` is `stats?.url ?? entry.repoUrl ?? entry.githubUrl ?? undefined` — consistent with the `stars`/`forks` fallback in the same function and with `inferSource` (`repoUrl || githubUrl`) and `sourceUrl` (`repoUrl ?? githubUrl ?? …`) elsewhere in the file. `appliesTo` now resolves to `"listing_source_repo"` for these entries.

Closes #5458

## Quality Evidence

- No visual impact by itself, but a real behavior change: **601 of 1385 current registry entries** set `githubUrl` without `repoUrl`/`repoStats.url` (e.g. `agent-skills-framework-engineer`, `ai-code-review-security-agent`). Their repo-stats card now shows a populated `url` and `appliesTo: "listing_source_repo"` instead of an empty card with `appliesTo: "none"`.
- Added a test for a GitHub-only entry (`githubUrl` + `githubStars`/`githubForks`, no `repoUrl`) asserting the fixed `url`/`appliesTo`.
- No change for entries that already set `repoUrl` or `repoStats.url` (existing cases unchanged).

## Validation

- `pnpm exec vitest run tests/entry-normalize.test.ts tests/entry-normalize-lib.test.ts` — pass (33)
- `pnpm type-check` — pass
- `pnpm build` — pass
- `git diff --check` — clean