### PR TITLE
fix(web): copy brandVerifiedAt/brandColors in buildEntryFromRegistry

### DIFF
--- a/apps/web/src/lib/entry-normalize-lib.ts
+++ b/apps/web/src/lib/entry-normalize-lib.ts
@@ -48,6 +48,8 @@ export type RegistryEntry = Record<string, unknown> & {
   brandIconUrl?: string;
   brandLogoUrl?: string;
   brandAssetSource?: string;
+  brandVerifiedAt?: string;
+  brandColors?: string[];
   prerequisites?: string[];
   safetyNotes?: string | string[];
   privacyNotes?: string | string[];
@@ -436,6 +438,8 @@ export function buildEntryFromRegistry(entry: RegistryEntry, attribution: EntryA
     brandIconUrl: entry.brandIconUrl,
     brandLogoUrl: entry.brandLogoUrl,
     brandAssetSource: entry.brandAssetSource,
+    brandVerifiedAt: entry.brandVerifiedAt,
+    brandColors: entry.brandColors,
     tags: entry.tags ?? [],
     keywords: entry.keywords ?? [],
     platforms,

--- a/tests/entry-normalize-lib.test.ts
+++ b/tests/entry-normalize-lib.test.ts
@@ -540,6 +540,20 @@ describe("buildEntryFromRegistry", () => {
     ]);
   });
 
+  it("copies brandVerifiedAt/brandColors from the registry entry", () => {
+    const entry = buildEntryFromRegistry(
+      baseEntry({
+        brandName: "Example",
+        brandVerifiedAt: "2026-05-01T00:00:00.000Z",
+        brandColors: ["#101010", "#f0f0f0"],
+      }),
+      attribution(),
+    );
+
+    expect(entry.brandVerifiedAt).toBe("2026-05-01T00:00:00.000Z");
+    expect(entry.brandColors).toEqual(["#101010", "#f0f0f0"]);
+  });
+
   it("rejects invalid hook triggers and script languages", () => {
     const entry = buildEntryFromRegistry(
       baseEntry({


### PR DESCRIPTION
## Summary

- `brandVerifiedAt`/`brandColors` are a fully wired pipeline (computed in `brand-assets-lib.js`, validated in `content-schema-lib.js`, exported as registry artifacts, present in the API contract, and declared on `Entry` via `BrandInfo`), but `buildEntryFromRegistry` — which constructs the `Entry` objects the app actually consumes — copied `brandName`/`brandDomain`/`brandIconUrl`/`brandLogoUrl`/`brandAssetSource` and never these two.
- As a result the two runtime consumers of `entry.brandVerifiedAt` — `trust-lib.ts`'s freshness reason and `source-citations.tsx`'s citation timestamp — always saw `undefined` and silently fell back to `reviewedAt`/`submittedAt`.
- Copy `brandVerifiedAt`/`brandColors` alongside the other brand fields, declaring them on the local `RegistryEntry` type for parity with the sibling brand fields.

Closes #5456

## Quality Evidence

- No visual impact by itself, but a real behavior change: **59 of 1385 current entries** carry `brandVerifiedAt` (e.g. `angular-repository-contributor-agent`, `ansible-repository-contributor-agent`). Their trust freshness reason and source-citation timestamp now use the real verification date instead of falling back to `reviewedAt`/`submittedAt`. `brandColors` is copied for the same round-trip completeness (no entry currently sets it, but it is a declared, validated, exported field).
- Added a unit test asserting `buildEntryFromRegistry` round-trips both fields from a `RegistryEntry` fixture.

## Validation

- `pnpm exec vitest run tests/entry-normalize.test.ts tests/entry-normalize-lib.test.ts` — pass (33)
- `pnpm type-check` — pass
- `pnpm build` — pass
- `git diff --check` — clean