### PR TITLE
fix(web): count browse bands over full scored population

### DIFF
--- a/apps/web/src/lib/browse-adoption-queue-lib.ts
+++ b/apps/web/src/lib/browse-adoption-queue-lib.ts
@@ -237,8 +237,8 @@ export function browseAdoptionQueueState(
     summary: summary(scored, scored.length),
     scannedCount: entries.length,
     rows,
-    readyCount: rows.filter((row) => row.tier === "ready").length,
-    cautionCount: rows.filter((row) => row.tier === "caution").length,
-    holdCount: rows.filter((row) => row.tier === "hold").length,
+    readyCount: scored.filter((row) => row.tier === "ready").length,
+    cautionCount: scored.filter((row) => row.tier === "caution").length,
+    holdCount: scored.filter((row) => row.tier === "hold").length,
   };
 }

--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -210,9 +210,9 @@ export function browseDecisionConfidenceState(
     heading: headingForPreset(preset),
     summary: summary(scored, scored.length),
     scannedCount: entries.length,
-    highCount: mapped.filter((row) => row.band === "high").length,
-    mediumCount: mapped.filter((row) => row.band === "medium").length,
-    lowCount: mapped.filter((row) => row.band === "low").length,
+    highCount: scored.filter((row) => row.band === "high").length,
+    mediumCount: scored.filter((row) => row.band === "medium").length,
+    lowCount: scored.filter((row) => row.band === "low").length,
     entries: mapped,
     lowRefs: mapped.filter((row) => row.band === "low").map((row) => row.entryRef),
   };

--- a/tests/browse-adoption-queue-lib.test.ts
+++ b/tests/browse-adoption-queue-lib.test.ts
@@ -218,4 +218,16 @@ describe("summary population", () => {
     expect(Number(denominator)).toBe(state.scannedCount);
     expect(Number(numerator)).toBeLessThanOrEqual(Number(denominator));
   });
+
+  it("counts tiers over the full scored population, not the display slice", () => {
+    const state = browseAdoptionQueueState(population(8, 12), "balanced");
+
+    // The 12 weak entries are hold-tier and sort below the top-8 display slice;
+    // the tier counts must still see them (previously reported 0).
+    expect(state.rows).toHaveLength(8);
+    expect(state.holdCount).toBe(12);
+    expect(state.readyCount + state.cautionCount + state.holdCount).toBe(
+      state.scannedCount,
+    );
+  });
 });

--- a/tests/browse-decision-confidence-lib.test.ts
+++ b/tests/browse-decision-confidence-lib.test.ts
@@ -250,4 +250,16 @@ describe("summary population", () => {
     expect(Number(denominator)).toBe(state.scannedCount);
     expect(Number(numerator)).toBeLessThanOrEqual(Number(denominator));
   });
+
+  it("counts bands over the full scored population, not the display slice", () => {
+    const state = browseDecisionConfidenceState(population(8, 12), "balanced");
+
+    // The 12 weak entries are low-confidence and sort below the top-8 display
+    // slice; the band counts must still see them (previously reported 0).
+    expect(state.entries).toHaveLength(8);
+    expect(state.lowCount).toBe(12);
+    expect(state.highCount + state.mediumCount + state.lowCount).toBe(
+      state.scannedCount,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Finishes the fix from #5214. That issue moved both functions' `summary()` text to describe the full scored population (and left a comment in each file documenting exactly that), but the per-band count fields returned alongside the summary still filtered the display-sliced array.
- `browseDecisionConfidenceState`'s `highCount`/`mediumCount`/`lowCount` filtered `mapped = scored.slice(0, maxEntries)`, and `browseAdoptionQueueState`'s `readyCount`/`cautionCount`/`holdCount` filtered `rows = scored.slice(0, maxRows)`. A low/hold entry outside the top-8 slice made the summary say "12 low-confidence entries" while `lowCount` showed `0`.
- Changed all six count fields to filter the full `scored` array, matching what `summary()` already does. The `mapped`/`rows` display slice is unchanged, and `lowRefs` (deliberately display-only, per the issue's out-of-scope note) is left as-is.

Closes #5457

## Quality Evidence

- No visual impact unless the displayed badge numbers change — which they do whenever the scored population exceeds `maxEntries`/`maxRows` (8). Before: a band count could read `0` while the summary sentence reported a nonzero count for the same band (the exact #5214 class of bug). After: `highCount + mediumCount + lowCount === scannedCount` and `readyCount + cautionCount + holdCount === scannedCount`, so badge counts and summary always agree.
- Added a test to each `*.test.ts` file reusing the existing `population(8, 12)` fixture (12 low/hold entries sorted below the top-8 slice): asserts `lowCount`/`holdCount` is `12` (was `0` before the fix) and that the three band counts sum to `scannedCount`.

## Validation

- `pnpm exec vitest run tests/browse-decision-confidence-lib.test.ts tests/browse-adoption-queue-lib.test.ts` — pass (37)
- `pnpm type-check` — pass
- `pnpm build` — pass
- `git diff --check` — clean