### PR TITLE
fix(mcp): fall back to commandSyntax for entry.asset install command

### DIFF
--- a/packages/mcp/src/registry-copyable-asset-lib.js
+++ b/packages/mcp/src/registry-copyable-asset-lib.js
@@ -107,7 +107,7 @@ export function buildCopyableAssetResponse({
     requestedAssetType: requestedType || "",
     primaryAsset: primary,
     assets,
-    installCommand: entry.installCommand || "",
+    installCommand: entry.installCommand || entry.commandSyntax || "",
     configSnippet: entry.configSnippet || "",
     usageSnippet: entry.usageSnippet || "",
     downloadUrl: entry.downloadUrl || "",

--- a/tests/mcp-registry-copyable-asset-lib.test.ts
+++ b/tests/mcp-registry-copyable-asset-lib.test.ts
@@ -2286,6 +2286,52 @@ describe("registry-copyable-asset-lib buildCopyableAssetResponse", () => {
     expect(response.ok).toBe(true);
     expect(response.key).toBe("mcp:browser-bridge");
   });
+
+  it("falls back to commandSyntax for the install command, like sibling tools", () => {
+    // commands-category entries carry their invocation in commandSyntax, not
+    // installCommand — the entry.asset tool must apply the same fallback the
+    // other install-command builders already do.
+    const entry = makeEntry({
+      category: "commands",
+      slug: "review-pr",
+      installCommand: undefined,
+      commandSyntax: "/review-pr --full",
+    });
+    const assets = buildEntryContentAssets(entry);
+    const response = buildCopyableAssetResponse({
+      entry,
+      platform: "",
+      requestedType: "",
+      assets,
+      primary: assets[0] ?? null,
+      compatibility: [],
+      source: sourceSummary(entry),
+      trust: entryTrustSummary(entry),
+      canonicalUrl: entryCanonicalUrl(entry),
+    });
+    expect(response.installCommand).toBe("/review-pr --full");
+  });
+
+  it("prefers installCommand over commandSyntax when both are set", () => {
+    const entry = makeEntry({
+      installCommand: "npx -y browser-bridge",
+      commandSyntax: "/should-not-win",
+    });
+    const assets = buildEntryContentAssets(entry);
+    const response = buildCopyableAssetResponse({
+      entry,
+      platform: "",
+      requestedType: "",
+      assets,
+      primary: assets[0] ?? null,
+      compatibility: [],
+      source: sourceSummary(entry),
+      trust: entryTrustSummary(entry),
+      canonicalUrl: entryCanonicalUrl(entry),
+    });
+    expect(response.installCommand).toBe("npx -y browser-bridge");
+  });
+
   it("buildCopyableAssetResponse churn 0", () => {
     const entry = makeEntry({ slug: "slug-0", body: "body-0" });
     const assets = buildEntryContentAssets(entry);


### PR DESCRIPTION
Closes #5481

## Problem

For `commands`-category entries the install command lives in `commandSyntax`, not `installCommand`. The `entry.installCommand || entry.commandSyntax` fallback is applied everywhere that builds install-command output — `registry-handlers-lib.js:374` (`install.guidance`), `registry-toolbox-lib.js` (`registry.plan`/`registry.recommend`), and 7 places in `artifacts-lib.js` — **except** `registry-copyable-asset-lib.js`, which backs the `entry.asset` MCP tool. So a `commands` entry with only `commandSyntax` set shows a real install command via every tool but `entry.asset`, which returned `""`.

## Fix

One line, matching every sibling:

```js
-    installCommand: entry.installCommand || "",
+    installCommand: entry.installCommand || entry.commandSyntax || "",
```

The other fields (`configSnippet`/`usageSnippet`/`downloadUrl`) have no `commandSyntax`-equivalent and are unchanged.

## Tests

`tests/mcp-registry-copyable-asset-lib.test.ts`:
- a `commands` entry with only `commandSyntax` now returns that as `installCommand`;
- an entry with `installCommand` set still wins over `commandSyntax`.

## Validation

```
pnpm exec vitest run tests/mcp-registry-copyable-asset-lib.test.ts   # 415 passed
pnpm exec prettier --check packages/mcp/src/registry-copyable-asset-lib.js tests/mcp-registry-copyable-asset-lib.test.ts
```

No visual impact (MCP tool response only); no generated artifacts touched.