### PR TITLE
feat(mcp): let registry.updates filter by platform like search/list

### DIFF
--- a/packages/mcp/src/registry-handlers-lib.js
+++ b/packages/mcp/src/registry-handlers-lib.js
@@ -131,10 +131,16 @@ export function sortEntriesByUpdatedAt(entries, entryUpdatedAt) {
   });
 }
 
-export function buildRecentUpdatesResponse({ category, since, entries }) {
+export function buildRecentUpdatesResponse({
+  category,
+  platform,
+  since,
+  entries,
+}) {
   return {
     ok: true,
     category: category || "",
+    platform: platform || "",
     since,
     count: entries.length,
     entries,

--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -374,12 +374,14 @@ export async function getRecentUpdates(args = {}, options = {}) {
     return invalid("since must be a parseable date such as 2026-05-01.");
   }
   const limit = normalizeLimit(args.limit, 10);
+  const platform = normalizePlatform(args.platform);
   const searchIndex = unwrapEntries(
     await readJsonArtifact("search-index.json", options),
   );
   const sorted = sortEntriesByUpdatedAt(
     searchIndex
       .filter((entry) => !category || entry.category === category)
+      .filter((entry) => entryMatchesPlatform(entry, platform))
       .filter((entry) => !since || entryUpdatedAt(entry) >= since),
     entryUpdatedAt,
   );
@@ -389,7 +391,7 @@ export async function getRecentUpdates(args = {}, options = {}) {
     entryUpdatedAt,
   );
 
-  return buildRecentUpdatesResponse({ category, since, entries });
+  return buildRecentUpdatesResponse({ category, platform, since, entries });
 }
 
 export async function getRelatedEntries(args = {}, options = {}) {

--- a/packages/mcp/src/schemas-lib.js
+++ b/packages/mcp/src/schemas-lib.js
@@ -291,6 +291,9 @@ export const RecentUpdatesInputSchema = z
     category: pathPart
       .optional()
       .describe("Restrict to a single category (e.g. 'mcp', 'hooks')."),
+    platform: platform
+      .optional()
+      .describe("Filter to entries compatible with this platform."),
     since: z
       .string()
       .trim()

--- a/tests/mcp-registry-tool-orchestration-lib-g.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-g.test.ts
@@ -97,6 +97,48 @@ describe("registry-tool-orchestration getRecentUpdates", () => {
       (await getRecentUpdates({ since: "2026-01-01" }, artifactOptions)).ok,
     ).toBe(true);
   });
+
+  const mixedPlatformOptions = {
+    readJsonArtifact: async () => ({
+      entries: [
+        {
+          category: "mcp",
+          slug: "cc-server",
+          title: "CC Server",
+          description: "d",
+          tags: [],
+          platforms: ["claude-code"],
+          dateAdded: "2026-05-02",
+        },
+        {
+          category: "mcp",
+          slug: "cursor-server",
+          title: "Cursor Server",
+          description: "d",
+          tags: [],
+          platforms: ["cursor"],
+          dateAdded: "2026-05-01",
+        },
+      ],
+    }),
+    readTextArtifact: async () => "",
+  };
+
+  it("filters recent updates by platform, like registry.search/list", async () => {
+    const result = await getRecentUpdates(
+      { platform: "claude-code" },
+      mixedPlatformOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.platform).toBe("claude-code");
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["cc-server"]);
+  });
+
+  it("returns every platform's updates when no platform is given", async () => {
+    const result = await getRecentUpdates({}, mixedPlatformOptions);
+    expect(result.count).toBe(2);
+    expect(result.platform).toBe("");
+  });
 });
 
 describe("registry-tool-orchestration getRelatedEntries", () => {


### PR DESCRIPTION
Closes #5483

## Problem

`registry.search` and `registry.list` both accept a `platform` parameter to restrict results to entries compatible with a client (e.g. `claude-code`, `cursor`). `registry.updates` — the "what's recently changed" tool — only took `category`/`since`/`limit`, so an agent that only cares about, say, Cursor-compatible updates had no way to ask for that from this tool.

## Fix

Pure parity, reusing the exact helpers the other two tools use (no new logic):

- `schemas-lib.js`: `RecentUpdatesInputSchema` gains an optional `platform` field (same `platform` Zod primitive + description as `SearchRegistryInputSchema`/`ListCategoryEntriesInputSchema`).
- `registry-tool-orchestration-lib.js` (`getRecentUpdates`): computes `normalizePlatform(args.platform)` and applies `entryMatchesPlatform(...)` in the filter chain **before** the `limit` slice — identical to `registry.search`/`registry.list`.
- `registry-handlers-lib.js` (`buildRecentUpdatesResponse`): echoes the applied `platform` alongside the existing `category`/`since`, matching how the sibling tools report their active filters.

## Invariant / backward compatibility

- Platform compatibility is determined by the shared `entryMatchesPlatform` → `matchesRegistryPlatform` (exact normalized membership in `entry.platforms`), the same path `registry.search`/`registry.list` use — not a new one.
- `platform` is optional; omitting it normalizes to `""`, which `matchesRegistryPlatform` treats as "match all" — so existing callers get byte-identical behavior. No `.d.ts` change needed (`getRecentUpdates`/`RecentUpdatesInputSchema` are typed generically).

## Tests

`tests/mcp-registry-tool-orchestration-lib-g.test.ts`:
- `registry.updates` with `platform: "claude-code"` over a claude-code + cursor set returns only the claude-code entry and echoes `platform`;
- with no platform, both entries are returned and `platform` is `""`.

## Validation

```
pnpm exec vitest run tests/mcp-registry-tool-orchestration-lib-g.test.ts tests/mcp-schemas-lib.test.ts   # 601 passed
pnpm exec vitest run tests/non-ui-branch-matrix.test.ts tests/mcp-server.test.ts tests/mcp-http-route.test.ts   # consumers green (99)
pnpm exec prettier --check <changed files>
```

No visual impact (MCP tool schema/response only); no generated artifacts touched.