### PR TITLE
fix(mcp): distinguish graph 'zero relations' from missing graph data in getRelatedEntries

### DIFF
--- a/packages/mcp/src/registry-handlers-lib.js
+++ b/packages/mcp/src/registry-handlers-lib.js
@@ -211,7 +211,17 @@ export function resolveGraphRelatedEntries({
   toEntrySummary,
   limit,
 }) {
-  if (!graphRow?.related?.length) return null;
+  // No graph row at all (missing/corrupt graph data) — signal the caller to
+  // fall back to the ad-hoc scorer by returning `null`.
+  if (!graphRow) return null;
+  // A graph row exists but deliberately relates to nothing. That empty
+  // `related` array is the relation graph's considered "zero relations"
+  // verdict (its builder requires a candidate score >= 18, which excludes bare
+  // same-category matches), not missing data. Return an empty array — NOT
+  // `null` — so the caller reports a genuine "no related entries" result
+  // instead of falling through to the weaker ad-hoc same-category scorer and
+  // silently overriding the graph's verdict.
+  if (!graphRow.related?.length) return [];
   const searchByKey = new Map(
     searchIndex.map((entry) => [`${entry.category}:${entry.slug}`, entry]),
   );

--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -418,7 +418,13 @@ export async function getRelatedEntries(args = {}, options = {}) {
     toEntrySummary,
     limit,
   });
-  if (graphEntries) {
+  // `resolveGraphRelatedEntries` returns `null` only when there is no graph row
+  // for this entry (missing/corrupt graph data); an existing graph row yields an
+  // array — including an empty one when the graph legitimately found zero
+  // relations. Honour that empty-array verdict as a genuine "no related entries"
+  // result instead of falling through to the ad-hoc scorer, which would return
+  // bare same-category matches the graph deliberately excluded.
+  if (graphEntries !== null) {
     return buildRelatedEntriesGraphResponse({
       target,
       entries: graphEntries,

--- a/tests/mcp-registry-handlers-lib.test.ts
+++ b/tests/mcp-registry-handlers-lib.test.ts
@@ -9427,7 +9427,7 @@ describe("registry-handlers-lib related, adapter, and compatibility responses", 
     });
   });
 
-  it("resolveGraphRelatedEntries returns null when the graph row has no relations", () => {
+  it("resolveGraphRelatedEntries returns null only when there is no graph row", () => {
     expect(
       resolveGraphRelatedEntries({
         graphRow: null,
@@ -9438,12 +9438,35 @@ describe("registry-handlers-lib related, adapter, and compatibility responses", 
     ).toBeNull();
     expect(
       resolveGraphRelatedEntries({
-        graphRow: { related: [] },
+        graphRow: undefined,
         searchIndex: [],
         toEntrySummary,
         limit: 5,
       }),
     ).toBeNull();
+  });
+
+  it("resolveGraphRelatedEntries returns an empty array for a graph row with zero relations", () => {
+    // A graph row that exists but has an empty (or absent) `related` list is the
+    // graph's considered "zero relations" verdict, not missing data. It must be
+    // distinguishable from the no-graph-row case (`null`) so the caller does not
+    // fall back to the weaker ad-hoc scorer.
+    expect(
+      resolveGraphRelatedEntries({
+        graphRow: { related: [] },
+        searchIndex: [],
+        toEntrySummary,
+        limit: 5,
+      }),
+    ).toEqual([]);
+    expect(
+      resolveGraphRelatedEntries({
+        graphRow: { key: "mcp:x" },
+        searchIndex: [],
+        toEntrySummary,
+        limit: 5,
+      }),
+    ).toEqual([]);
   });
 
   it("resolveGraphRelatedEntries resolves related keys and drops unknown ones", () => {

--- a/tests/mcp-registry-tool-orchestration-lib-g.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-g.test.ts
@@ -110,6 +110,118 @@ describe("registry-tool-orchestration getRelatedEntries", () => {
       ).error.code,
     ).toBe("not_found");
   });
+
+  // Three-scenario matrix for the graph vs ad-hoc-scorer fallback decision.
+  // Search index shared by all three: a target plus a same-category peer that
+  // the ad-hoc scorer WOULD relate (same category alone scores > 0). The peer
+  // is what makes the "zero relations" scenario meaningful — it proves the
+  // graph's empty verdict is honoured rather than silently overridden.
+  const relatedSearchIndex = {
+    entries: [
+      {
+        category: "skills",
+        slug: "target-skill",
+        title: "Target Skill",
+        description: "Shared lint automation.",
+        tags: ["lint"],
+        keywords: [],
+        platforms: ["Claude"],
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        category: "skills",
+        slug: "same-category-peer",
+        title: "Same Category Peer",
+        description: "Shared lint automation.",
+        tags: ["lint"],
+        keywords: [],
+        platforms: ["Claude"],
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    ],
+  };
+
+  it("returns real graph relations when the graph row has relations", async () => {
+    const readJsonArtifact = async (relativePath: string) => {
+      if (relativePath === "relation-graph.json") {
+        return {
+          entries: [
+            {
+              key: "skills:target-skill",
+              related: [
+                {
+                  key: "skills:same-category-peer",
+                  relation: "similar",
+                  score: 42,
+                  reasons: ["tag:lint"],
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (relativePath !== "search-index.json") return null;
+      return relatedSearchIndex;
+    };
+
+    const result = await getRelatedEntries(
+      { category: "skills", slug: "target-skill", limit: 8 },
+      { readJsonArtifact },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.relationGraph).toBe(true);
+    expect(result.count).toBe(1);
+    expect(result.entries[0].slug).toBe("same-category-peer");
+    expect(result.entries[0].relatedScore).toBe(42);
+  });
+
+  it("returns a genuine no-related result (no ad-hoc fallback) when the graph row has zero relations", async () => {
+    const readJsonArtifact = async (relativePath: string) => {
+      if (relativePath === "relation-graph.json") {
+        return {
+          entries: [{ key: "skills:target-skill", related: [] }],
+        };
+      }
+      if (relativePath !== "search-index.json") return null;
+      return relatedSearchIndex;
+    };
+
+    const result = await getRelatedEntries(
+      { category: "skills", slug: "target-skill", limit: 8 },
+      { readJsonArtifact },
+    );
+
+    expect(result.ok).toBe(true);
+    // relationGraph:true + count:0 proves it honoured the graph's "zero
+    // relations" verdict rather than falling through to the ad-hoc scorer,
+    // which would have surfaced the same-category peer.
+    expect(result.relationGraph).toBe(true);
+    expect(result.count).toBe(0);
+    expect(result.entries).toEqual([]);
+  });
+
+  it("falls back to the ad-hoc scorer when there is no graph row at all", async () => {
+    const readJsonArtifact = async (relativePath: string) => {
+      // Graph data exists but has no row for this target (missing/corrupt data).
+      if (relativePath === "relation-graph.json") {
+        return { entries: [{ key: "skills:someone-else", related: [] }] };
+      }
+      if (relativePath !== "search-index.json") return null;
+      return relatedSearchIndex;
+    };
+
+    const result = await getRelatedEntries(
+      { category: "skills", slug: "target-skill", limit: 8 },
+      { readJsonArtifact },
+    );
+
+    expect(result.ok).toBe(true);
+    // No graph row → ad-hoc scorer runs, surfacing the same-category peer.
+    expect(result.relationGraph).toBe(false);
+    expect(result.count).toBe(1);
+    expect(result.entries[0].slug).toBe("same-category-peer");
+  });
 });
 
 describe("registry-tool-orchestration compareEntries", () => {


### PR DESCRIPTION
## Summary

- `resolveGraphRelatedEntries` (`packages/mcp/src/registry-handlers-lib.js`) returned `null` for **two different** cases: "no graph row exists for this entry" (missing/corrupt graph data) **and** "a graph row exists but its `related` list is deliberately empty."
- `getRelatedEntries` (`packages/mcp/src/registry-tool-orchestration-lib.js`) treated any `null` the same way — it fell through to the weaker ad-hoc `scoreRelatedEntry` scorer, whose floor is `score > 0`. A bare same-category match alone scores `4`, so entries the relation graph had **deliberately** decided have no good relations (its builder requires a candidate score `>= 18`) got a batch of unrelated same-category entries returned as "related", silently overriding the graph's own verdict.
- Fix: `resolveGraphRelatedEntries` now returns an **empty array** (not `null`) when a graph row exists with zero relations, and `null` **only** when there is no graph row at all. `getRelatedEntries` branches on `!== null`, so the "legitimately zero relations" verdict is reported as a genuine "no related entries" result instead of falling through to the ad-hoc scorer.

Closes #5461

## Quality Evidence

- No visual impact (MCP tool response only).
- **Response-shape difference for the "legitimately zero relations" case** — before: `{ relationGraph: false, count: N>0, entries: [<ad-hoc same-category matches>] }`; after: `{ relationGraph: true, count: 0, entries: [] }`. This is the same shape the tool already returns for the real-relations case (just with an empty `entries` array), so it does not break consumers expecting either the graph shape or the ad-hoc shape.
- Three-scenario test matrix added (in `tests/mcp-registry-tool-orchestration-lib-g.test.ts`), plus a unit test for `resolveGraphRelatedEntries`'s empty-vs-null distinction (`tests/mcp-registry-handlers-lib.test.ts`):
  1. graph row with **real** relations → returns those relations (`relationGraph: true`, unaffected).
  2. graph row with `related: []` → genuine no-related result (`relationGraph: true`, `count: 0`), ad-hoc scorer **not** reached even though a same-category peer exists in the search index.
  3. **no** graph row at all → falls back to the ad-hoc scorer (`relationGraph: false`), unchanged from today.

## Validation

```
pnpm exec vitest run tests/mcp-registry-handlers-lib.test.ts tests/mcp-registry-tool-orchestration-lib-g.test.ts   # 1056 passed
pnpm test:mcp        # 72 passed
pnpm type-check      # clean
pnpm exec prettier --check <changed files>   # clean
git diff --check     # clean
```
