### PR TITLE
fix(registry): recognize all SHELL_TOKENS shells in curl-pipe-to-shell detector

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -4,6 +4,7 @@ import {
   TOOLS_CATEGORY,
   TOOLS_LISTING_FLOW_URL,
 } from "./submission-classification.js";
+import { SHELL_TOKENS } from "./command-safety-lib.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
 import {
   isPublicGitHubProfileUrl,
@@ -14,6 +15,20 @@ import {
 
 export const SUBMISSION_RISK_SCHEMA_VERSION = 1;
 export const SUBMISSION_RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";
+
+// Shell-name alternation for the curl/wget-piped-to-shell detector, derived
+// from command-safety-lib's SHELL_TOKENS so the two "downloader piped into a
+// shell" checks recognize the same shells (bash, zsh, sh, dash, ash) and stay
+// in sync. Longer names first so a longer shell name wins over a shorter one
+// that shares a prefix. Both ends are still \b-anchored at the use site.
+const CURL_PIPE_SHELL_ALTERNATION = [...SHELL_TOKENS]
+  .sort((a, b) => b.length - a.length)
+  .map((token) => token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  .join("|");
+const CURL_PIPE_TO_SHELL_PATTERN = new RegExp(
+  `\\b(curl|wget)\\b[\\s\\S]{0,120}\\|[\\s\\S]{0,40}\\b(sudo\\s+)?(${CURL_PIPE_SHELL_ALTERNATION})\\b`,
+  "i",
+);
 
 const SEVERITY_WEIGHT = {
   info: 0,
@@ -1252,9 +1267,7 @@ function addContentRiskSignals(report, fields, text) {
 
   if (
     referencesDestructiveRootRemoval(installText) ||
-    /\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(sh|bash)\b/i.test(
-      installText,
-    ) ||
+    CURL_PIPE_TO_SHELL_PATTERN.test(installText) ||
     /\b(invoke-expression|iex)\b/i.test(installText) ||
     /\bbase64\s+(-d|--decode)\b[\s\S]{0,80}\|[\s\S]{0,40}\b(sh|bash)\b/i.test(
       installText,

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -135,6 +135,42 @@ describe("submission risk invariants", () => {
     );
   });
 
+  it("flags curl-piped-to-shell installs for every shell in SHELL_TOKENS, not just sh/bash", () => {
+    // zsh has been macOS's default shell since Catalina (2019), so
+    // `curl … | zsh` is a realistic real-world install instruction. The
+    // detector must recognize the same shells command-safety-lib's SHELL_TOKENS
+    // already does for the identical "downloader piped into a shell" concern
+    // (bash, zsh, sh, dash, ash), not only sh/bash.
+    for (const shell of ["zsh", "dash", "ash", "sh", "bash"]) {
+      const draft = buildSubmissionPrDraft({
+        ...validMcpFields,
+        name: "Pipe Shell MCP",
+        slug: "pipe-shell-mcp",
+        install_command: `curl https://example.com/install.sh | ${shell}`,
+      });
+      const risk = analyzeSubmissionDraftRisk(draft, validateSubmission(draft));
+      expect(risk.reviewFlags.map((flag) => flag.id)).toContain(
+        "unsafe_install_pipeline",
+      );
+    }
+  });
+
+  it("does not flag a curl piped into a non-shell command as an unsafe install pipeline", () => {
+    // The shell-name alternation is \b-anchored, so a non-shell receiver (and
+    // benign words that merely contain a shell name as a substring) must not
+    // trip the flag.
+    const draft = buildSubmissionPrDraft({
+      ...validMcpFields,
+      name: "Pipe Pager MCP",
+      slug: "pipe-pager-mcp",
+      install_command: "curl https://example.com/notes.txt | less",
+    });
+    const risk = analyzeSubmissionDraftRisk(draft, validateSubmission(draft));
+    expect(risk.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
   it("blocks unsafe executable pipelines in issue config snippets", () => {
     const draft = buildSubmissionPrDraft({
       ...validMcpFields,


### PR DESCRIPTION
## Summary

- `submission-risk.js`'s curl/wget-piped-to-shell detector only matched `(sh|bash)` as the receiving shell (`/\b(curl|wget)\b…\|…\b(sudo\s+)?(sh|bash)\b/i`), while `command-safety-lib.js`'s `SHELL_TOKENS` — used for the **identical** "downloader piped into a shell" concern elsewhere in this codebase — recognizes `["bash", "zsh", "sh", "dash", "ash"]`.
- `zsh` has been macOS's default shell since Catalina (2019), so `curl https://example.com/install.sh | zsh` is a completely realistic real-world install instruction that this specific check silently missed, while the sibling detector already flags it.
- Fix: derive the shell-name alternation from `SHELL_TOKENS` (imported from `./command-safety-lib.js`) so the two checks stay in sync going forward, rather than re-hardcoding names that can drift again. The alternation is sorted longest-first and stays `\b`-anchored on both ends at the use site, so a shell name appearing as a substring or as a command argument is not flagged. `sh`/`bash` detection is unchanged.

Closes #5480

## Quality Evidence

- No visual impact.
- Before/after regex results (the old literal vs. the new `SHELL_TOKENS`-derived pattern):

| install text | before | after |
|---|---|---|
| `curl … \| zsh` | ❌ not flagged | ✅ flagged |
| `curl … \| dash` | ❌ not flagged | ✅ flagged |
| `curl … \| ash` | ❌ not flagged | ✅ flagged |
| `curl … \| bash` | ✅ flagged | ✅ flagged (unchanged) |
| `curl … \| sudo sh` | ✅ flagged | ✅ flagged (unchanged) |
| `curl … notes.txt \| less` | ❌ not flagged | ❌ not flagged (no false positive) |

- Added two tests to `tests/submission-risk-invariants.test.ts`: one asserting `curl … | <shell>` trips `unsafe_install_pipeline` for every shell in `SHELL_TOKENS` (`zsh`/`dash`/`ash`/`sh`/`bash`), and a `\b`-anchoring guard asserting a piped non-shell command (`| less`) is **not** flagged.

## Validation

```
pnpm exec vitest run tests/submission-risk-invariants.test.ts   # 50 passed
pnpm exec prettier --check <changed files>                      # clean
git diff --check                                                # clean
```
