### PR TITLE
fix(web): give adminJobs list/upsert/update independent rate-limit scopes

### DIFF
--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -1337,7 +1337,7 @@ export const apiRouteDefinitions = {
     querySchema: adminJobsQuerySchema,
     auth: "admin-token",
     rateLimit: {
-      scope: "admin-jobs",
+      scope: "admin-jobs-list",
       limit: 60,
       windowMs: 60_000,
       binding: "API_STRICT_RATE_LIMIT",
@@ -1356,7 +1356,7 @@ export const apiRouteDefinitions = {
     bodyLimitBytes: 32 * 1024,
     auth: "admin-token",
     rateLimit: {
-      scope: "admin-jobs",
+      scope: "admin-jobs-upsert",
       limit: 45,
       windowMs: 60_000,
       binding: "API_STRICT_RATE_LIMIT",
@@ -1375,7 +1375,7 @@ export const apiRouteDefinitions = {
     bodyLimitBytes: 4 * 1024,
     auth: "admin-token",
     rateLimit: {
-      scope: "admin-jobs",
+      scope: "admin-jobs-update",
       limit: 45,
       windowMs: 60_000,
       binding: "API_STRICT_RATE_LIMIT",

--- a/tests/api-security-lib.test.ts
+++ b/tests/api-security-lib.test.ts
@@ -9,6 +9,7 @@ import {
   isRateLimited,
   readRequestTextWithinLimit,
 } from "../apps/web/src/lib/api-security-lib";
+import { getApiRouteDefinition } from "../apps/web/src/lib/api/contracts-lib";
 
 const request = (
   init: RequestInit & { headers?: Record<string, string> } = {},
@@ -394,6 +395,65 @@ describe("isRateLimited fallback limiter", () => {
         ...params,
         scope: "other",
         request: fallbackRequest("10.0.0.1"),
+      }),
+    ).toBe(false);
+  });
+
+  it("gives adminJobs list/upsert/update independent rate-limit buckets", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    const rateLimitFor = (id: "adminJobs.list" | "adminJobs.upsert") => {
+      const def = getApiRouteDefinition(id).rateLimit;
+      if (!def) throw new Error(`${id} is expected to declare a rateLimit`);
+      return def;
+    };
+    const list = rateLimitFor("adminJobs.list");
+    const upsert = rateLimitFor("adminJobs.upsert");
+    const update = getApiRouteDefinition("adminJobs.update").rateLimit;
+    if (!update) throw new Error("adminJobs.update should declare a rateLimit");
+
+    // Regression guard: the three operations must NOT share one scope string,
+    // or they share a single counter bucket despite three declared limits.
+    expect(new Set([list.scope, upsert.scope, update.scope]).size).toBe(3);
+
+    const ip = "203.0.113.77";
+    // Exhaust adminJobs.list's own budget for this client.
+    for (let i = 0; i < list.limit; i += 1) {
+      expect(
+        isRateLimited({
+          request: fallbackRequest(ip),
+          scope: list.scope,
+          limit: list.limit,
+          windowMs: list.windowMs,
+        }),
+      ).toBe(false);
+    }
+    expect(
+      isRateLimited({
+        request: fallbackRequest(ip),
+        scope: list.scope,
+        limit: list.limit,
+        windowMs: list.windowMs,
+      }),
+    ).toBe(true);
+
+    // A subsequent upsert/update from the same client is unaffected — the
+    // counters are now independent rather than sharing one "admin-jobs" bucket.
+    expect(
+      isRateLimited({
+        request: fallbackRequest(ip),
+        scope: upsert.scope,
+        limit: upsert.limit,
+        windowMs: upsert.windowMs,
+      }),
+    ).toBe(false);
+    expect(
+      isRateLimited({
+        request: fallbackRequest(ip),
+        scope: update.scope,
+        limit: update.limit,
+        windowMs: update.windowMs,
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary

- `api-security-lib.ts`'s in-memory rate limiter (`isRateLimited`, the fallback used when the Cloudflare binding is unavailable) keys its counter as `` `${scope}:${clientIp}` `` — its own doc comment describes `scope` as "Logical bucket namespace (for example a route name)."
- But `adminJobs.list` (limit 60/min), `adminJobs.upsert` (limit 45/min), and `adminJobs.update` (limit 45/min) — three different operations with three different declared limits — all shared `scope: "admin-jobs"`. Sharing one counter, calls to any of the three increment the same bucket, but whichever endpoint is invoked applies *its own* declared limit against that shared count. In practice an admin browsing the jobs list heavily (under its own 60/min budget) can push the shared counter past 45 and block the next legitimate `adminJobs.upsert`/`adminJobs.update` call even though upsert/update haven't been called at all — and vice versa. The quotas weren't actually independent despite being declared as if they were.
- Fix: give each route its own distinct scope — `"admin-jobs-list"`, `"admin-jobs-upsert"`, `"admin-jobs-update"` — matching the doc comment's "a route name" convention and the already-distinct `adminJobs.health` (`"admin-jobs-health"`). Now each declared limit maps to its own counter bucket, as the contract already implied.

Closes #5473

## Quality Evidence

- No visual impact (server-side rate limiting only).
- The Cloudflare-binding path passes `key = scope:ip` to `binding.limit(...)` with no `limit`/`windowMs`, so its threshold is whatever's configured on the `API_STRICT_RATE_LIMIT` binding — this fix is scoped to making the **in-memory fallback** path's per-route limits real, as the issue specifies. If per-route granularity is also wanted at the Cloudflare binding level, that's a separate infra-level change (flagged, not attempted here).
- Added a regression test to `tests/api-security-lib.test.ts` (`isRateLimited fallback limiter` suite) that reads the three routes' real `rateLimit` from the contract via `getApiRouteDefinition`, asserts their scopes are pairwise distinct (`new Set([...]).size === 3` — fails if anyone reverts them to a shared string), then exhausts `adminJobs.list`'s limit for a client and confirms a subsequent `adminJobs.upsert`/`adminJobs.update` call from the same client is **not** blocked.

## Validation

```
pnpm exec vitest run tests/api-security-lib.test.ts tests/api-contracts-lib.test.ts   # 444 passed
pnpm exec vitest run tests/api-contracts.test.ts tests/job-admin-lib.test.ts tests/web-job-admin.test.ts   # 274 passed
pnpm type-check      # clean
pnpm exec prettier --check <changed files>   # clean
git diff --check     # clean
```
