### PR TITLE
fix(mcp): return a clean error envelope when resource artifact reads fail

### DIFF
--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -678,14 +678,27 @@ export async function listJobsActive(options = {}) {
 }
 
 export async function listRegistryResources(args = {}, options = {}) {
-  const manifest = await readJsonArtifact("registry-manifest.json", options);
-  const categories = Object.keys(manifest.categories || {}).sort();
-  return buildListRegistryResourcesResponse({
-    manifest,
-    categories,
-    discoveryResources: DISCOVERY_RESOURCES,
-    jsonMimeType: JSON_MIME_TYPE,
-  });
+  try {
+    const manifest = await readJsonArtifact("registry-manifest.json", options);
+    const categories = Object.keys(manifest.categories || {}).sort();
+    return buildListRegistryResourcesResponse({
+      manifest,
+      categories,
+      discoveryResources: DISCOVERY_RESOURCES,
+      jsonMimeType: JSON_MIME_TYPE,
+    });
+  } catch (error) {
+    // A missing/corrupt manifest (missing file, wrong --data-dir, corrupt JSON)
+    // otherwise escapes through the SDK request handler as a raw transport
+    // error. Return the same "unavailable" envelope the tools/call boundary
+    // (callRegistryTool) already uses for this exact failure mode.
+    return withPublicPolicy(
+      unavailable(
+        "HeyClaude registry data is unavailable.",
+        error instanceof Error ? error.message : String(error),
+      ),
+    );
+  }
 }
 
 export async function readRegistryResource(args = {}, options = {}) {
@@ -712,68 +725,86 @@ export async function readRegistryResource(args = {}, options = {}) {
   }
 
   const parts = parsed.pathname.split("/").filter(Boolean);
-  let payload;
-  if (parsed.hostname === "feeds" && parts[0] === "directory") {
-    payload = await readJsonArtifact("directory-index.json", options);
-  } else if (parsed.hostname === "category" && parts.length === 1) {
-    const category = normalizeText(parts[0]);
-    if (!isSafePathPart(category)) {
+  try {
+    let payload;
+    if (parsed.hostname === "feeds" && parts[0] === "directory") {
+      payload = await readJsonArtifact("directory-index.json", options);
+    } else if (parsed.hostname === "category" && parts.length === 1) {
+      const category = normalizeText(parts[0]);
+      if (!isSafePathPart(category)) {
+        return resourcePayload(
+          invalid("Category resource path is not slug-safe."),
+        );
+      }
+      const entries = unwrapEntries(
+        await readJsonArtifact("search-index.json", options),
+      );
+      // Bound the category resource like every other listing surface. Absent
+      // params fall back to DISCOVERY_RESOURCE_LIMIT (normalizeLimit needs
+      // undefined, not the null that URLSearchParams.get returns, to hit its
+      // fallback); normalizeLimit also hard-caps the page at that limit.
+      const offset = normalizeOffset(
+        parsed.searchParams.get("offset") ?? undefined,
+      );
+      const limit = normalizeLimit(
+        parsed.searchParams.get("limit") ?? undefined,
+        DISCOVERY_RESOURCE_LIMIT,
+      );
+      payload = buildCategoryResourcePayload(
+        category,
+        entries,
+        toEntrySummary,
+        {
+          offset,
+          limit,
+        },
+      );
+    } else if (parsed.hostname === "entry" && parts.length === 2) {
+      const [category, slug] = parts.map(normalizeText);
+      // Resource reads return the full document; only the tool defaults to a
+      // token-efficient excerpt.
+      const detail = await getEntryDetail(
+        { category, slug, bodyMode: "full" },
+        options,
+      );
+      payload = detail;
+    } else if (
+      parsed.hostname === "registry" &&
+      parts.length === 1 &&
+      parts[0] === "recent"
+    ) {
+      payload = await listRegistryRecent(options);
+    } else if (
+      parsed.hostname === "registry" &&
+      parts.length === 1 &&
+      parts[0] === "trending"
+    ) {
+      payload = await listRegistryTrending(options);
+    } else if (
+      parsed.hostname === "jobs" &&
+      parts.length === 1 &&
+      parts[0] === "active"
+    ) {
+      payload = await listJobsActive(options);
+    } else {
       return resourcePayload(
-        invalid("Category resource path is not slug-safe."),
+        notFound(`Unsupported HeyClaude resource URI: ${uri}`),
       );
     }
-    const entries = unwrapEntries(
-      await readJsonArtifact("search-index.json", options),
-    );
-    // Bound the category resource like every other listing surface. Absent
-    // params fall back to DISCOVERY_RESOURCE_LIMIT (normalizeLimit needs
-    // undefined, not the null that URLSearchParams.get returns, to hit its
-    // fallback); normalizeLimit also hard-caps the page at that limit.
-    const offset = normalizeOffset(
-      parsed.searchParams.get("offset") ?? undefined,
-    );
-    const limit = normalizeLimit(
-      parsed.searchParams.get("limit") ?? undefined,
-      DISCOVERY_RESOURCE_LIMIT,
-    );
-    payload = buildCategoryResourcePayload(category, entries, toEntrySummary, {
-      offset,
-      limit,
-    });
-  } else if (parsed.hostname === "entry" && parts.length === 2) {
-    const [category, slug] = parts.map(normalizeText);
-    // Resource reads return the full document; only the tool defaults to a
-    // token-efficient excerpt.
-    const detail = await getEntryDetail(
-      { category, slug, bodyMode: "full" },
-      options,
-    );
-    payload = detail;
-  } else if (
-    parsed.hostname === "registry" &&
-    parts.length === 1 &&
-    parts[0] === "recent"
-  ) {
-    payload = await listRegistryRecent(options);
-  } else if (
-    parsed.hostname === "registry" &&
-    parts.length === 1 &&
-    parts[0] === "trending"
-  ) {
-    payload = await listRegistryTrending(options);
-  } else if (
-    parsed.hostname === "jobs" &&
-    parts.length === 1 &&
-    parts[0] === "active"
-  ) {
-    payload = await listJobsActive(options);
-  } else {
+
+    return resourcePayload(payload);
+  } catch (error) {
+    // Same artifact-read failure boundary as callRegistryTool: a missing/corrupt
+    // artifact returns the "unavailable" envelope (wrapped as resource contents,
+    // consistent with this function's other error responses) instead of throwing
+    // a raw transport error.
     return resourcePayload(
-      notFound(`Unsupported HeyClaude resource URI: ${uri}`),
+      unavailable(
+        "HeyClaude registry data is unavailable.",
+        error instanceof Error ? error.message : String(error),
+      ),
     );
   }
-
-  return resourcePayload(payload);
 }
 export async function getCompatibility(args = {}, options = {}) {
   const category = normalizeText(args.category || "skills");

--- a/tests/mcp-registry-tool-orchestration-lib-f.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-f.test.ts
@@ -2,8 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   getPlatformAdapter,
+  listRegistryResources,
   readRegistryResource,
 } from "../packages/mcp/src/registry-tool-orchestration-lib.js";
+
+const failingArtifactOptions = {
+  readJsonArtifact: async () => {
+    throw new Error("ENOENT: registry artifact missing");
+  },
+  readTextArtifact: async () => "",
+};
 
 const artifactOptions = {
   readJsonArtifact: async (relativePath: string) =>
@@ -105,6 +113,26 @@ describe("registry-tool-orchestration readRegistryResource uri routing", () => {
     expect(payload.total).toBe(30);
     expect(payload.entries.length).toBeLessThanOrEqual(25);
     expect(payload.count).toBe(payload.entries.length);
+  });
+
+  it("returns an unavailable envelope when a resource artifact read fails", async () => {
+    // A missing/corrupt artifact must not escape as a raw transport error.
+    const payload = resourcePayload(
+      await readRegistryResource(
+        { uri: "heyclaude://category/mcp" },
+        failingArtifactOptions,
+      ),
+    );
+    expect(payload.ok).toBe(false);
+    expect(payload.error?.code).toBe("unavailable");
+  });
+});
+
+describe("registry-tool-orchestration listRegistryResources", () => {
+  it("returns an unavailable envelope when the manifest read fails", async () => {
+    const result = await listRegistryResources({}, failingArtifactOptions);
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("unavailable");
   });
 });
 


### PR DESCRIPTION
Closes #5460

## Problem

`callRegistryTool` (the `tools/call` path) wraps its dispatch in a try/catch with a comment explaining exactly why: artifact reads (missing file, wrong `--data-dir`, corrupt JSON) throw from deep inside the handlers, and without a boundary they escape through the SDK request handler as a raw transport error, bypassing the tool's own output schema. It converts that into a clean `unavailable` envelope.

`listRegistryResources` and `readRegistryResource` (the `resources/list` / `resources/read` handlers) call `readJsonArtifact(...)` — the exact same failing call — with no equivalent boundary. The failure mode `tools/call` was explicitly hardened against was still open on the resources path.

## Fix

Add the same boundary, in the same orchestration functions (mirroring where `callRegistryTool`'s boundary lives):

- `listRegistryResources`: wrap the manifest read + response build in try/catch; on failure return `withPublicPolicy(unavailable(...))`.
- `readRegistryResource`: wrap the URI-dispatch (all the `readJsonArtifact` branches, after URL parsing) in try/catch; on failure return `resourcePayload(unavailable(...))` — wrapped as resource `contents`, consistent with the function's existing `notFound`/`invalid` error responses.

Both reuse the existing `unavailable(...)` envelope and message that `callRegistryTool` and the HTTP-backed/remote-proxy paths already return.

## Invariants

- Success paths for both functions are unchanged (the existing resource-routing tests pass untouched).
- Domain responses inside `readRegistryResource` (`notFound` for an unknown URI, `invalid` for a non-slug-safe category) are `return`s, not throws, so they're unaffected by the boundary.
- `callRegistryTool` and `server-lib.js`'s handler registration are untouched (out of scope).

## Tests

`tests/mcp-registry-tool-orchestration-lib-f.test.ts`: with a `readJsonArtifact` that throws,
- `readRegistryResource("heyclaude://category/mcp")` returns an `unavailable` envelope (not a throw);
- `listRegistryResources()` returns an `unavailable` envelope.

## Validation

```
pnpm exec vitest run tests/mcp-registry-tool-orchestration-lib-f.test.ts   # 12 passed
pnpm exec vitest run tests/mcp-server.test.ts tests/non-ui-branch-matrix.test.ts   # consumers green (88)
pnpm exec prettier --check <changed files>
```

No visual impact (MCP server error handling only); no generated artifacts touched.