### PR TITLE
fix(registry): don't treat the self-referential directory githubUrl as a real source

### DIFF
--- a/apps/web/src/lib/entry-normalize-lib.ts
+++ b/apps/web/src/lib/entry-normalize-lib.ts
@@ -275,7 +275,13 @@ export function inferSource(entry: RegistryEntry): SourceStatus {
   if (entry.downloadTrust === "first-party" || entry.trustSignals?.firstPartyEditorial) {
     return "first-party";
   }
-  if (entry.repoUrl || entry.githubUrl || entry.trustSignals?.sourceStatus === "available") {
+  // `githubUrl` is the always-present self-referential directory link, not a
+  // real external repo, so it must not by itself qualify an entry as
+  // source-backed (matching quality-lib's buildSourceProvenance exclusion).
+  const hasRealGithubUrl =
+    Boolean(entry.githubUrl) &&
+    !String(entry.githubUrl).includes("github.com/JSONbored/awesome-claude");
+  if (entry.repoUrl || hasRealGithubUrl || entry.trustSignals?.sourceStatus === "available") {
     return "source-backed";
   }
   if (entry.documentationUrl || entry.websiteUrl) return "external";

--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -178,6 +178,17 @@ function compactDefinedObject(value) {
   );
 }
 
+// `entry.githubUrl` is set unconditionally to a self-referential link to the
+// entry's own .mdx inside this directory's repo, so it is not a real external
+// source. Return it only when it points somewhere other than this repo,
+// matching quality-lib's buildSourceProvenance exclusion.
+function externalGithubUrl(entry) {
+  return entry.githubUrl &&
+    !String(entry.githubUrl).includes("github.com/JSONbored/awesome-claude")
+    ? entry.githubUrl
+    : "";
+}
+
 function raycastOneClickStdioCommandName(value) {
   const command = String(value || "").trim();
   if (!command || command.includes("/") || command.includes("\\")) return "";
@@ -1141,7 +1152,11 @@ export function buildPluginExportFeed(entries) {
     category: entry.category,
     ...buildEntryProvenanceFields(entry),
     ...buildEntryBrandFields(entry),
-    sourceUrl: entry.repoUrl || entry.githubUrl || entry.documentationUrl,
+    // `githubUrl` is the always-present self-referential directory link, not a
+    // real external repo, so it must not shadow documentationUrl as a plugin's
+    // "source" — only surface it when it points somewhere other than this repo.
+    sourceUrl:
+      entry.repoUrl || externalGithubUrl(entry) || entry.documentationUrl,
     installCommand: entry.installCommand || entry.commandSyntax || "",
     platformCompatibility:
       entry.category === "skills" ? buildSkillPlatformCompatibility(entry) : [],

--- a/packages/registry/src/presentation-lib.js
+++ b/packages/registry/src/presentation-lib.js
@@ -17,6 +17,19 @@ export function compactCount(value) {
   return String(value);
 }
 
+// `entry.githubUrl` is set unconditionally on every entry to a self-referential
+// link to the entry's own .mdx inside this directory's repo (content-builder's
+// buildGitHubUrl), so it never signals a real external source. Match
+// quality-lib's buildSourceProvenance exclusion so a real repo counts but the
+// always-present directory link does not.
+function hasRealSourceUrl(entry) {
+  return Boolean(
+    entry.repoUrl ||
+    (entry.githubUrl &&
+      !String(entry.githubUrl).includes("github.com/JSONbored/awesome-claude")),
+  );
+}
+
 export function parseAbbreviatedCount(value) {
   const text = String(value ?? "")
     .trim()
@@ -285,7 +298,7 @@ export function getDistributionBadges(entry) {
     });
   }
 
-  if (entry.repoUrl || entry.githubUrl) {
+  if (hasRealSourceUrl(entry)) {
     badges.push({
       label: "source",
       title: "Source or repository link available",
@@ -346,7 +359,7 @@ export function getEntryAccessSummary(entry) {
   const hasConfig = Boolean(source.configSnippet);
   const hasDownload = Boolean(source.downloadUrl);
   const hasDocs = Boolean(source.documentationUrl);
-  const hasSource = Boolean(source.repoUrl || source.githubUrl);
+  const hasSource = hasRealSourceUrl(source);
   const hasSafetyNotes =
     Array.isArray(source.safetyNotes) && source.safetyNotes.length > 0;
   const hasPrivacyNotes =

--- a/tests/entry-normalize-lib.test.ts
+++ b/tests/entry-normalize-lib.test.ts
@@ -182,6 +182,19 @@ describe("entry normalize lib helpers", () => {
       expect(inferSource(baseEntry())).toBe("unverified");
     });
 
+    it("does not treat the self-referential directory githubUrl as source-backed", () => {
+      // Every entry always carries this directory link; it must not by itself
+      // qualify an entry as source-backed.
+      expect(
+        inferSource(
+          baseEntry({
+            githubUrl:
+              "https://github.com/JSONbored/awesome-claude/blob/main/content/hooks/x.mdx",
+          }),
+        ),
+      ).toBe("unverified");
+    });
+
     it("derives trust posture from verification and notes", () => {
       const trusted = baseEntry({
         packageVerified: true,

--- a/tests/presentation-lib.test.ts
+++ b/tests/presentation-lib.test.ts
@@ -597,6 +597,17 @@ describe("getDistributionBadges", () => {
     expect(labels).toContain("source");
     expect(labels).not.toContain("copy-only");
   });
+
+  it("omits the source badge for a self-referential directory githubUrl", () => {
+    const labels = getDistributionBadges(
+      entry({
+        category: "tools",
+        githubUrl:
+          "https://github.com/JSONbored/awesome-claude/blob/main/content/tools/x.mdx",
+      }),
+    ).map((badge) => badge.label);
+    expect(labels).not.toContain("source");
+  });
 });
 
 describe("getEntryAccessSummary", () => {

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -11,7 +11,10 @@ describe("registry provenance", () => {
     const entry = buildContentEntryFromMdx({
       category: "hooks",
       fileName: "documentation-only-hook.mdx",
-      filePath: path.join(repoRoot, "content/hooks/documentation-only-hook.mdx"),
+      filePath: path.join(
+        repoRoot,
+        "content/hooks/documentation-only-hook.mdx",
+      ),
       repoRoot,
       contentRoot: path.join(repoRoot, "content"),
       source: `---
@@ -32,6 +35,12 @@ Use this hook after reviewing the documentation.`,
     );
 
     const [plugin] = buildPluginExportFeed([entry]).plugins;
-    expect(plugin.sourceUrl).toBe(entry.githubUrl);
+    // The plugin source must not surface the always-present self-referential
+    // directory link; with no real repoUrl it falls back to the real external
+    // documentationUrl instead.
+    expect(plugin.sourceUrl).not.toBe(entry.githubUrl);
+    expect(plugin.sourceUrl).toBe(
+      "https://github.com/example/documentation-project",
+    );
   });
 });


### PR DESCRIPTION
Closes #5466

## Problem

`entry.githubUrl` is **not** the tool's repo — `content-builder-lib.js` sets it unconditionally on every entry to `buildGitHubUrl(...)`, a link to that entry's own `.mdx` inside `github.com/JSONbored/awesome-claude`. `quality-lib.js`'s `buildSourceProvenance` already excludes that self-referential URL before counting a real external source, but several other sites naively check `entry.repoUrl || entry.githubUrl` — and since `githubUrl` is always truthy, those checks can never distinguish "has a real external source" from "has none."

## Fix

Apply the same `!url.includes("github.com/JSONbored/awesome-claude")` exclusion at the four naive sites:

- `presentation-lib.js`: new `hasRealSourceUrl(entry)` helper backs both the `"source"` badge and `getEntryAccessSummary`'s `hasSource`.
- `artifacts-lib.js`: plugin manifest `sourceUrl` uses a new `externalGithubUrl(entry)` so the self-referential link no longer shadows `documentationUrl`.
- `entry-normalize-lib.ts` (`inferSource`): a `githubUrl`-only entry no longer classifies as `"source-backed"`; it falls through to `"external"`/`"unverified"`.

A **real** external repo (`repoUrl`) or a genuine non-directory `githubUrl` still counts — only the always-present directory link is excluded.

## Out of scope (per the issue, left unchanged)

`buildGitHubUrl`/`entry.githubUrl` itself, `llms-lib.js`'s correctly-labeled `"Directory source"`, `quality-lib.js`'s reference implementation, and the intentional "show the directory link as one of several source URLs" sites (`presentation-lib.js:155`, `sourceUrlsForEntry`).

## Tests

- `entry-normalize-lib.test.ts`: a self-referential-`githubUrl`-only entry infers `"unverified"` (external github URLs still infer `"source-backed"`).
- `presentation-lib.test.ts`: no `"source"` badge for a self-referential-`githubUrl`-only entry (external github URLs still get it).
- `provenance.test.ts`: updated the plugin-`sourceUrl` assertion to the fixed behavior — a docs-only entry's plugin source is now its real `documentationUrl`, not the self-referential directory link (this test pinned exactly the `artifacts-lib.js:1144` behavior the issue targets).

## Validation

```
pnpm exec vitest run tests/presentation-lib.test.ts tests/entry-normalize-lib.test.ts tests/provenance.test.ts   # green
pnpm exec vitest run tests/artifacts-lib.test.ts tests/registry-export-feeds.test.ts tests/presentation-access-summary.test.ts tests/registry-presentation-builder.test.ts tests/non-ui-branch-matrix.test.ts   # consumers green (328)
pnpm --filter web exec tsc --noEmit   # no new type errors
pnpm exec prettier --check <changed files>
```

No visual impact beyond an entry with no real source correctly losing the `"source"` badge; no route/UI file touched; no generated artifacts committed.