### PR TITLE
fix(web): add distribution to state-of-tooling/mcp-servers Dataset JSON-LD

### DIFF
--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -15,6 +15,7 @@ import { ENTRIES, QUALITY_STATS, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { installMethodDistribution, notesCoverage } from "@/lib/ecosystem-stats";
 import { pctOf } from "@/lib/pct-of-lib";
 import { absoluteUrl } from "@/lib/seo";
+import { reportExportUrl } from "@/lib/data-reports-lib";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { PageContainer } from "@/components/page-container";
@@ -187,6 +188,18 @@ export const Route = createFileRoute("/state-of-claude-tooling")({
         "Platform coverage",
         "Install-method distribution",
         "Safety and privacy notes coverage",
+      ],
+      distribution: [
+        {
+          "@type": "DataDownload",
+          encodingFormat: "application/json",
+          contentUrl: reportExportUrl("claude-tooling", "json"),
+        },
+        {
+          "@type": "DataDownload",
+          encodingFormat: "text/csv",
+          contentUrl: reportExportUrl("claude-tooling", "csv"),
+        },
       ],
     };
     const breadcrumbs = {

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -11,6 +11,7 @@ import {
   hostingOf,
 } from "@/lib/mcp-stats";
 import { absoluteUrl } from "@/lib/seo";
+import { reportExportUrl } from "@/lib/data-reports-lib";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { PageContainer } from "@/components/page-container";
@@ -199,6 +200,18 @@ export const Route = createFileRoute("/state-of-mcp-servers")({
         "Source provenance distribution",
         "Install-method distribution",
         "Most common integration tags",
+      ],
+      distribution: [
+        {
+          "@type": "DataDownload",
+          encodingFormat: "application/json",
+          contentUrl: reportExportUrl("mcp-servers", "json"),
+        },
+        {
+          "@type": "DataDownload",
+          encodingFormat: "text/csv",
+          contentUrl: reportExportUrl("mcp-servers", "csv"),
+        },
       ],
     };
     const breadcrumbs = {


### PR DESCRIPTION
## Summary

- `buildReportDataset()` (`apps/web/src/lib/data-reports-lib.ts`) is the shared helper that emits `Dataset` JSON-LD **including** a `distribution` array linking each report's JSON + CSV export URLs — the mechanism this project uses so AI/search engines can discover and fetch the underlying data. The three `state-of-claude-code-hooks` / `state-of-agent-skills` / `state-of-ai-agents` pages call it directly and get `distribution` for free.
- `state-of-claude-tooling.tsx` and `state-of-mcp-servers.tsx` both ship real, working exports (`ReportDownloads exportSlug="claude-tooling"` / `"mcp-servers"`, backed by `/api/reports/{slug}.json|.csv`) but hand-roll their own `"@type": "Dataset"` JSON-LD blocks that never got the `distribution` key — so two pages with working exports don't advertise them to structured-data consumers, while three pages with the same capability do.
- Fix: add the `distribution` array to each page's hand-rolled Dataset block via `reportExportUrl(slug, format)` — the exact `DataDownload` shape (`encodingFormat` + `contentUrl`) `buildReportDataset()` already produces, pointing at each page's existing `/api/reports/{claude-tooling|mcp-servers}.{json,csv}` URLs. I added the array rather than switching the pages wholesale to `buildReportDataset()`, because each page's hand-rolled block carries a richer, page-specific `variableMeasured` list that the shared helper derives differently — adding `distribution` is the surgical change that fixes the gap without altering any other structured-data field.

Closes #5455

## Quality Evidence

- No visual impact (JSON-LD `<script type="application/ld+json">` only; no visible page content changes).
- Diff of each rendered Dataset block adds only the `distribution` array (import + 12 lines per page, +26 total); all pre-existing fields (`name`/`description`/`keywords`/`variableMeasured`/…) are untouched.
- Resolved export URLs (via `reportExportUrl` → `absoluteUrl("/api/reports/${slug}.${format}")`, base `https://heyclau.de`):
  - claude-tooling → `https://heyclau.de/api/reports/claude-tooling.json` + `…/claude-tooling.csv`
  - mcp-servers → `https://heyclau.de/api/reports/mcp-servers.json` + `…/mcp-servers.csv`
  - Slugs verified against `REPORT_BUILDERS` (`claude-tooling-stats-lib.ts:48` / `mcp-servers-stats-lib.ts:50`) and the `<ReportDownloads exportSlug=…>` on each page.

## Validation

```
pnpm exec vitest run tests/data-reports-lib.test.ts tests/web-data-reports.test.ts   # 48 passed
pnpm type-check      # clean
pnpm build           # clean
pnpm exec prettier --check <changed files>   # clean
git diff --check     # clean
```
