### PR TITLE
fix(registry): detect Anthropic sk-ant- and OpenAI sk-proj- key formats

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1201,7 +1201,7 @@ function addContentRiskSignals(report, fields, text) {
   }
 
   if (
-    /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-[a-z0-9]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
+    /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-(?:ant-|proj-)?[a-z0-9-]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
       text,
     )
   ) {


### PR DESCRIPTION
# Pull Request

## Summary

- `submission-risk.js`'s `embedded_secret` detector missed real **Anthropic** (`sk-ant-api03-…`) and **OpenAI** (`sk-proj-…`) key formats. Its `sk-` alternative was `sk-[a-z0-9]{20,}` — 20+ alphanumerics *immediately* after `sk-`, no hyphens — but both real formats insert a hyphenated segment right after `sk-`, breaking the match.
- Widened to `sk-(?:ant-|proj-)?[a-z0-9-]{20,}`.

Closes #5479

## Submission Source

For platform/code PRs:

- [x] Not a direct content submission.
- [x] Changed file listed below.
- [x] `No visual impact` (a risk-detection regex; no UI).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed:** `packages/registry/src/submission-risk.js` — only the `sk-` alternative of the `embedded_secret` regex (the `ghp_`/`github_pat_`/`akia`/`xq_` alternatives are untouched).
- **No visual impact.**

## Before / after (exact regex results)

```
// BEFORE: sk-[a-z0-9]{20,}
sk-ant-api03-AbC123dEf456GhI789jKl012MnO   → false   (missed)
sk-proj-AbC123dEf456GhI789xyz              → false   (missed)
sk-abcdefghij0123456789xyz                 → true

// AFTER: sk-(?:ant-|proj-)?[a-z0-9-]{20,}
sk-ant-api03-AbC123dEf456GhI789jKl012MnO   → true    ✅
sk-proj-AbC123dEf456GhI789xyz              → true    ✅
sk-abcdefghij0123456789xyz                 → true    (still matches)
ghp_abcdefghij0123456789klmno              → true    (other alts unaffected)
akia0123456789abcdef                       → true    (other alts unaffected)

// False-positive spot-checks (still correctly do NOT match)
"just some sk- prose here nothing"                  → false
"ask-someone-about-this-later-please"               → false
"talk to the task-force about disk-usage now"       → false
```

## Validation

- `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — **48 passed**.
- `pnpm exec prettier --check packages/registry/src/submission-risk.js` — clean; `git diff --check` — clean.

## Notes

- Linked issue: Closes #5479.
