### PR TITLE
fix(registry): recognize zsh/dash/ash in the curl-piped-to-shell detector

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -5,6 +5,7 @@ import {
   TOOLS_LISTING_FLOW_URL,
 } from "./submission-classification.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
+import { SHELL_TOKENS } from "./command-safety-lib.js";
 import {
   isPublicGitHubProfileUrl,
   isPublicHttpUrl,
@@ -14,6 +15,15 @@ import {
 
 export const SUBMISSION_RISK_SCHEMA_VERSION = 1;
 export const SUBMISSION_RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";
+
+// Downloader piped straight into a shell (e.g. `curl … | zsh`). The receiving
+// shell names are sourced from command-safety-lib.js's SHELL_TOKENS so this
+// detector and that sibling check can't drift out of sync (zsh has been macOS's
+// default since 2019, so `| zsh` is a realistic real-world installer).
+const CURL_PIPE_TO_SHELL_RE = new RegExp(
+  `\\b(curl|wget)\\b[\\s\\S]{0,120}\\|[\\s\\S]{0,40}\\b(sudo\\s+)?(${SHELL_TOKENS.join("|")})\\b`,
+  "i",
+);
 
 const SEVERITY_WEIGHT = {
   info: 0,
@@ -1252,9 +1262,7 @@ function addContentRiskSignals(report, fields, text) {
 
   if (
     referencesDestructiveRootRemoval(installText) ||
-    /\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(sh|bash)\b/i.test(
-      installText,
-    ) ||
+    CURL_PIPE_TO_SHELL_RE.test(installText) ||
     /\b(invoke-expression|iex)\b/i.test(installText) ||
     /\bbase64\s+(-d|--decode)\b[\s\S]{0,80}\|[\s\S]{0,40}\b(sh|bash)\b/i.test(
       installText,


### PR DESCRIPTION
# Pull Request

## Summary

- `submission-risk.js`'s curl/wget-piped-to-shell detector only matched `(sudo\s+)?(sh|bash)`, so `curl … | zsh` (and `| dash`, `| ash`) slipped through — even though `command-safety-lib.js`'s `SHELL_TOKENS` already lists all five shells for the identical concern.
- Build the detector's shell alternation from `SHELL_TOKENS` so the two checks stay in sync.

Closes #5480

## Submission Source

For platform/code PRs:

- [x] Not a direct content submission.
- [x] Changed file listed below.
- [x] `No visual impact` (a risk-detection regex; no UI).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed:** `packages/registry/src/submission-risk.js` — imports `SHELL_TOKENS` from `command-safety-lib.js` and builds `CURL_PIPE_TO_SHELL_RE` from it (`['bash','zsh','sh','dash','ash']`), replacing the inline `(sh|bash)`. Referencing `SHELL_TOKENS` (rather than re-inlining names) keeps this detector and the sibling check from drifting again. The other three alternatives in the combined condition (`iex`, `base64 -d | sh`, `powershell -encodedcommand`) are untouched.
- **No visual impact.**

## Before / after (exact regex results)

```
// BEFORE: (sudo\s+)?(sh|bash)
curl https://x.com/i.sh | zsh    → false   (missed)
curl https://x.com/i.sh | dash   → false   (missed)
curl https://x.com/i.sh | ash    → false   (missed)
curl https://x.com/i.sh | sh     → true
curl https://x.com/i.sh | bash   → true

// AFTER: (sudo\s+)?(bash|zsh|sh|dash|ash)  [from SHELL_TOKENS]
curl https://x.com/i.sh | zsh         → true   ✅
curl https://x.com/i.sh | dash        → true   ✅
curl https://x.com/i.sh | ash         → true   ✅
wget -qO- https://x.com/i.sh | sudo zsh → true ✅
curl https://x.com/i.sh | sh          → true   (unchanged)
curl https://x.com/i.sh | bash        → true   (unchanged)

// Benign (still correctly do NOT match — no curl/wget pipe into a shell)
"cat notes.md and push to the stash"          → false
"curl https://x.com/data.json > out.json"     → false
```

## Validation

- `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — **48 passed** (module loads fine with the new import + `SHELL_TOKENS`-built regex).
- `pnpm exec prettier --check packages/registry/src/submission-risk.js` — clean; `git diff --check` — clean.

## Notes

- Linked issue: Closes #5480.
