### PR TITLE
fix(mcp): align schema .d.ts declarations with schemas-lib.js runtime exports

### DIFF
--- a/packages/mcp/src/registry.d.ts
+++ b/packages/mcp/src/registry.d.ts
@@ -217,7 +217,8 @@ export function callRegistryTool(
 export {
   SearchRegistryInputSchema,
   PlanWorkflowToolboxInputSchema,
-  ServerInfoInputSchema,
+  RecommendForTaskInputSchema,
+  GetServerInfoInputSchema,
   ListCategoryEntriesInputSchema,
   RecentUpdatesInputSchema,
   RelatedEntriesInputSchema,

--- a/packages/mcp/src/schemas.d.ts
+++ b/packages/mcp/src/schemas.d.ts
@@ -2,7 +2,8 @@ import type { z } from "zod";
 
 export const SearchRegistryInputSchema: z.ZodType;
 export const PlanWorkflowToolboxInputSchema: z.ZodType;
-export const ServerInfoInputSchema: z.ZodType;
+export const RecommendForTaskInputSchema: z.ZodType;
+export const GetServerInfoInputSchema: z.ZodType;
 export const ListCategoryEntriesInputSchema: z.ZodType;
 export const RecentUpdatesInputSchema: z.ZodType;
 export const RelatedEntriesInputSchema: z.ZodType;


### PR DESCRIPTION
## Summary

- The hand-written type declarations in `packages/mcp/src` had drifted from the real runtime exports in `schemas-lib.js`. Comparing every `*InputSchema` export against every declaration turned up exactly the two discrepancies this issue describes (the other 26 already matched).
- `schemas.d.ts` / `registry.d.ts` declared `ServerInfoInputSchema`, a name that does **not** exist at runtime. The live `"registry.info"` tool's schema is exported as `GetServerInfoInputSchema` (`schemas-lib.js:222`, dispatched at `schemas-lib.js:677`). Renamed the declaration and the re-export.
- `RecommendForTaskInputSchema` (the live, dispatched `"registry.recommend"` tool schema, `schemas-lib.js:196`) had **no** type declaration at all. Added it to both files, placed in `schemas-lib.js` source order (right after `PlanWorkflowToolboxInputSchema`, before `GetServerInfoInputSchema`).

Closes #5482

## Quality Evidence

- No visual impact (type declarations only).
- `schemas.d.ts` now has 28 `InputSchema` declarations, matching the 28 `InputSchema` exports in `schemas-lib.js` (was 27 — the one missing was `RecommendForTaskInputSchema`).
- No consumer imported the wrong `ServerInfoInputSchema` name: it appeared **only** in the two `.d.ts` files. `packages/mcp/src/schemas.js`, `schemas-lib.js`, and `tests/mcp-schemas-lib.test.ts` already reference the correct `GetServerInfoInputSchema` — so the rename fixes the declaration to match code that was already using the runtime name.

## Validation

- `pnpm validate:mcp-package` — `Validated packed @heyclaude/mcp@0.12.1`
- `pnpm test:mcp` — 72 passed
- `pnpm exec vitest run tests/mcp-schemas-lib.test.ts` — 586 passed
- `pnpm --filter web exec tsc --noEmit` — exit 0 (declarations type-check cleanly)
- `pnpm exec prettier --check packages/mcp/src/schemas.d.ts packages/mcp/src/registry.d.ts` — clean
- `git diff --check` — clean