### PR TITLE
fix(web): scale k-suffixed compensation in jobs Salary sort

### DIFF
--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -201,8 +201,10 @@ function JobsPage() {
     if (sortMode === "salary") {
       const sval = (j: JobListing) => {
         if (!j.compensation) return -1;
-        const m = j.compensation.match(/\$?(\d[\d,]*)k?/i);
-        return m ? parseInt(m[1].replace(/,/g, ""), 10) : 0;
+        const m = j.compensation.match(/\$?(\d[\d,]*)(k)?/i);
+        if (!m) return 0;
+        const base = parseInt(m[1].replace(/,/g, ""), 10);
+        return m[2] ? base * 1000 : base;
       };
       return [...filtered].sort((a, b) => sval(b) - sval(a));
     }


### PR DESCRIPTION
## Summary

- The `/jobs` **Salary** sort compared raw digit runs while silently discarding the `k` thousands-multiplier, so a `"$210k"` listing ($210,000) sorted as the number `210` and ranked *below* a `"$120,000"` listing — the sort was wrong for exactly the mixed `"$XXXk"` / `"$XXX,XXX"` compensation strings the site actually has.
- Root cause (`apps/web/src/routes/jobs.index.tsx:204`): in `/\$?(\d[\d,]*)k?/i`, the `k?` sits **outside** the captured group, so `"$210k"` and `"$210,000"` both yield the captured digits `"210"` despite being 1000x apart.
- Fix: capture the trailing `k`/`K` (`/\$?(\d[\d,]*)(k)?/i`) and multiply the base by 1000 when it is present, putting every listing on the same real-dollar scale.

Closes #5475

## Quality Evidence

No visual impact — this changes only the numeric key used to order the existing jobs list (no markup/style change).

`sval` mapping before → after, covering both formats plus the fallback cases the acceptance criteria require to stay unchanged:

| `compensation` | before | after |
| --- | --- | --- |
| `"$210k"` | `210` | `210000` |
| `"$120,000"` | `120000` | `120000` |
| `"$210,000"` | `210000` | `210000` |
| `"$95K"` | `95` | `95000` |
| `""` / missing | `-1` | `-1` (unchanged, sorts last) |
| `"competitive"` (unparseable) | `0` | `0` (unchanged fallback) |

After the fix `"$210k"` (→ `210000`) correctly ranks above `"$120,000"` (→ `120000`); missing compensation still returns `-1` and unparseable strings still return `0`, so both keep sorting last exactly as before.

## Validation

- `pnpm type-check` — clean
- `pnpm build` — succeeds
- `pnpm exec prettier --check apps/web/src/routes/jobs.index.tsx` — passes
- `git diff --check` — clean
- Scope: single-file, route-only change to the `sval` helper inside the `salary` sort branch (`apps/web/src/routes/jobs.index.tsx`, ~lines 202-207); no other sort mode, compensation authoring/storage, or the sort-dropdown UI is touched.
