### PR TITLE
fix(scripts): bound resolve-pr-preview-url GitHub fetch with an abort timeout

### DIFF
--- a/scripts/resolve-pr-preview-url.mjs
+++ b/scripts/resolve-pr-preview-url.mjs
@@ -86,6 +86,14 @@ function sleep(ms) {
   });
 }
 
+// Per-request bound for GitHub API calls. The poll loop only checks its own
+// `deadline` *between* attempts, so an un-bounded `fetch` that hangs mid-request
+// (network stall, slow TLS, GitHub degraded) could outlast the whole wait budget.
+// 10s is comfortably shorter than the default 15s poll interval and any realistic
+// wait window, so a stalled request fails fast and the loop can retry or exit
+// cleanly instead of blocking indefinitely.
+const GITHUB_FETCH_TIMEOUT_MS = 10_000;
+
 async function githubJson(pathname, env = process.env) {
   const token = env.GITHUB_TOKEN;
   const repository = env.GITHUB_REPOSITORY;
@@ -99,6 +107,7 @@ async function githubJson(pathname, env = process.env) {
       authorization: `Bearer ${token}`,
       "x-github-api-version": "2022-11-28",
     },
+    signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS),
   });
   if (!response.ok) {
     throw new Error(`GitHub API ${pathname} returned ${response.status}`);

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -406,4 +406,23 @@ describe("resolveFromPrComments — reads the Cloudflare Workers Builds PR comme
     ).toBeNull();
     expect(await resolveFromPrComments({}, env)).toBeNull();
   });
+
+  it("bounds the GitHub API fetch with an abort-timeout signal so a hung request can't outlast the poll deadline", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await resolveFromPrComments({ pull_request: { number: 4045 } }, env);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit | undefined;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+    // A real AbortSignal.timeout(...) is live and un-aborted at call time.
+    expect(init?.signal?.aborted).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

- `resolve-pr-preview-url.mjs` polls the GitHub API in a loop with an explicit `deadline = Date.now() + waitSeconds * 1000`, checked only *between* poll attempts. But `githubJson()`'s underlying `fetch()` had no timeout/`AbortSignal`, so a single hung request (network stall, slow TLS, GitHub degraded) could block far past the script's own designed wait budget, since the deadline is never checked *during* a request.
- Fix: bound `githubJson()`'s fetch with `signal: AbortSignal.timeout(GITHUB_FETCH_TIMEOUT_MS)` so a stalled request fails fast and the poll loop can retry or exit cleanly instead of blocking indefinitely.

Closes #5470

## Quality Evidence

No visual impact — CI/build script only (resolves a PR preview URL from the GitHub API); it renders no page output.

- **Timeout value: 10s** (`GITHUB_FETCH_TIMEOUT_MS = 10_000`). Chosen shorter than the poll loop's own cadence and any realistic wait budget: the poll interval defaults to `pollSeconds = 15`s (`PR_PREVIEW_POLL_SECONDS`), and the overall `deadline` derives from `waitSeconds` (`PR_PREVIEW_WAIT_SECONDS`). 10s < 15s guarantees a hung request aborts within one poll cycle rather than outlasting the deadline, while staying generous for a healthy GitHub API response.
- Normal, fast responses are unaffected — the signal only aborts a request that exceeds 10s.
- Scope is `githubJson()`'s fetch only; the poll loop's `deadline`/`waitSeconds` logic and `deploymentQueries`/`resolveFromGithubDeployments` are untouched. Other scripts' fetch calls are intentionally left out of scope.

## Validation

- Added a regression test (`tests/deployment-preview-url.test.ts`): stubs `fetch`, drives `githubJson` via `resolveFromPrComments`, and asserts the request is issued with an un-aborted `AbortSignal` timeout. Full file: **18 tests pass**.
- `pnpm type-check` — clean
- `pnpm exec prettier --check` on both changed files — passes
- `pnpm validate:clean` — passes
- `git diff --check` — clean
- Classifier (`scripts/ci/classify-pr-changes.mjs`): `content=no`, `content_config=no` (ci lane), 2 files changed.
