### PR TITLE
fix(ci): drop deleted script names from PR classifier regexes

### DIFF
--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -162,7 +162,7 @@ const directSubmission =
 const contentValidationInfra = touches(
   /^examples\/content\//,
   /^\.github\/ISSUE_TEMPLATE\//,
-  /^scripts\/(audit-content|generate-issue-templates|validate-category-spec|validate-content)\.mjs$/,
+  /^scripts\/(audit-content|validate-category-spec|validate-content)\.mjs$/,
   /^packages\/registry\/src\/(category-spec|content-builder|submission|index\.d\.ts)/,
 );
 const generatedArtifactInfra = touches(
@@ -174,7 +174,7 @@ const generatedArtifactInfra = touches(
   "README.md",
 );
 const submissionAutomationInfra = touches(
-  /^scripts\/(analyze-submission-risk|import-submission-issue|validate-submission-issue)\.mjs$/,
+  /^scripts\/analyze-submission-risk\.mjs$/,
 );
 const scriptOrTestInfra = touches(/^scripts\//, /^tests\/.*\.test\.ts$/);
 const submissionGateInfra = touches(

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -321,4 +321,27 @@ describe("PR change classifier", () => {
       web: "false",
     });
   });
+
+  it("no longer classifies deleted submission-automation and issue-template script names as content or registry infra", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+    const scriptDir = path.join(cwd, "scripts");
+    fs.mkdirSync(scriptDir, { recursive: true });
+    for (const name of [
+      "generate-issue-templates.mjs",
+      "import-submission-issue.mjs",
+      "validate-submission-issue.mjs",
+    ]) {
+      fs.writeFileSync(path.join(scriptDir, name), "console.log('changed');\n");
+      git(cwd, ["add", `scripts/${name}`]);
+    }
+    git(cwd, ["commit", "-m", "touch deleted script names"]);
+
+    const outputs = runClassifier(cwd, baseSha);
+    expect(outputs).toMatchObject({
+      ci: "true",
+      content: "false",
+      content_config: "false",
+      registry: "false",
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `scripts/ci/classify-pr-changes.mjs`'s `contentValidationInfra` and `submissionAutomationInfra` `touches(...)` groups still matched three scripts that were deleted in `6a1ac061` ("harden direct content gate"): `generate-issue-templates.mjs`, `import-submission-issue.mjs`, and `validate-submission-issue.mjs`.
- `submissionAutomationInfra` had already been narrowed to just `analyze-submission-risk.mjs` in `6a1ac061`, but a later unrelated commit (`f29b08ea`, "fail closed for script validation lanes") silently re-added the 3-name group, regressing the fix.
- This restores `submissionAutomationInfra` to `/^scripts\/analyze-submission-risk\.mjs$/` and drops `generate-issue-templates` from `contentValidationInfra`, so both regexes only reference scripts that still exist in `scripts/`.

Closes #5467

## Quality Evidence

- **No visual impact.** This is a CI classification script (`scripts/ci/`) plus its test; it produces zero rendered output.
- **History confirms this restores a prior fix, not new behavior** (`git log -p -- scripts/ci/classify-pr-changes.mjs`): `0ee4b032` added the 3-name `submissionAutomationInfra` group → `6a1ac061` narrowed it to `analyze-submission-risk` only (deleting the other two scripts) → `f29b08ea` re-added the 3-name group. The `generate-issue-templates` reference in `contentValidationInfra` likewise points at a script deleted in `6a1ac061`.
- **Behavior for currently-real files is unchanged**: `analyze-submission-risk.mjs`, `audit-content.mjs`, `validate-category-spec.mjs`, and `validate-content.mjs` all still classify exactly as before (the existing "routes direct PR submission automation changes…" test for `analyze-submission-risk.mjs` still passes).
- **Regression test added** (`tests/classify-pr-changes.test.ts`): a PR touching the three now-deleted script names no longer trips the content/registry lanes and instead fails closed to `ci`. Verified this test **fails on the pre-fix classifier** and **passes after the fix**.

## Validation

- `pnpm exec vitest run tests/classify-pr-changes.test.ts` — 11 passed
- `pnpm type-check` — clean (exit 0)
- `node scripts/ci/classify-pr-changes.mjs` over this diff → `content=false`, `content_config=false`, `registry=false`, `ci=true` (CI lane only)
- `git diff --check` — clean