### PR TITLE
fix(registry): rescue clean/entryUrl/sourceUrls/listValue from barrel export collisions

### DIFF
--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -3,6 +3,18 @@ export {
   categorySpec as registryCategorySpec,
 } from "./category-spec.js";
 export { generatedAtForEntries } from "./artifacts.js";
+// Explicit re-exports rescue names that collide across two or more of the
+// `export *` modules below — ECMAScript silently drops such names from the
+// aggregate namespace (the same reason generatedAtForEntries needs its own line
+// above). Each points at the general-purpose canonical implementation:
+//   clean       — identical in brand-assets/quality/llms
+//   entryUrl    — relationships' relative /entry/<cat>/<slug> (vs weekly-brief's
+//                 newsletter-specific absolute form)
+//   sourceUrls  — relationships' full source-link gatherer (vs weekly-brief's)
+//   listValue   — commercial's general list parser (vs llms' citation-fact join)
+export { clean } from "./quality.js";
+export { entryUrl, sourceUrls } from "./relationships.js";
+export { listValue } from "./commercial.js";
 export * from "./artifacts.js";
 export * from "./brand-assets.js";
 export * from "./commercial.js";

--- a/tests/registry-barrel-exports.test.ts
+++ b/tests/registry-barrel-exports.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import * as registry from "@heyclaude/registry";
+
+const surface = registry as Record<string, unknown>;
+
+describe("@heyclaude/registry barrel exports", () => {
+  // Each of these names is defined in two or more of index.js's `export *`
+  // modules, so ECMAScript silently drops it from the aggregate namespace
+  // unless an explicit re-export rescues it (like generatedAtForEntries).
+  it.each([
+    "clean",
+    "entryUrl",
+    "sourceUrls",
+    "listValue",
+    "generatedAtForEntries",
+  ])("exposes %s as a function, not undefined", (name) => {
+    expect(typeof surface[name]).toBe("function");
+  });
+
+  it("resolves the intended canonical implementation for each rescued name", () => {
+    // clean: identical trim helper across brand-assets/quality/llms.
+    expect(registry.clean("  x  ")).toBe("x");
+    // entryUrl: relationships' relative form (not weekly-brief's absolute one).
+    expect(registry.entryUrl({ category: "mcp", slug: "s" })).toBe(
+      "/entry/mcp/s",
+    );
+    // sourceUrls: relationships' array gatherer.
+    expect(
+      Array.isArray(registry.sourceUrls({ repoUrl: "https://github.com/a/b" })),
+    ).toBe(true);
+    // listValue: commercial's general list parser returns an array (llms' join
+    // helper would return a string), confirming the canonical pick.
+    expect(Array.isArray(registry.listValue(["a", "", "b"]))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #5478

## Problem

`index.js` uses `export *` for 16 modules. When two or more of them define the same binding, ECMAScript **silently excludes** that name from the aggregate namespace — no build error, the name is just missing. This already bit `generatedAtForEntries` (rescued by an explicit `export { generatedAtForEntries } from "./artifacts.js"` on line 5), but four more names were still being dropped:

| name | colliding `export *` modules |
|---|---|
| `clean` | brand-assets.js, quality.js, llms.js |
| `entryUrl` | relationships.js, weekly-brief.js |
| `sourceUrls` | relationships.js, weekly-brief.js |
| `listValue` | commercial.js, llms.js |

Verified: `import("@heyclaude/registry")` resolves all four as `undefined`, while `generatedAtForEntries` resolves to a function.

## Fix

Add explicit hoisted re-exports (same pattern as `generatedAtForEntries`), each pointing at the general-purpose canonical implementation:

```js
export { clean } from "./quality.js";              // identical trim in all three
export { entryUrl, sourceUrls } from "./relationships.js";
export { listValue } from "./commercial.js";
```

- `entryUrl`/`sourceUrls`: relationships' general helpers (relative `/entry/<cat>/<slug>`, full source-link gatherer) rather than weekly-brief's newsletter-specific variants.
- `listValue`: commercial's general list parser (returns an array) rather than llms' citation-fact join (returns a string).
- `clean` is byte-identical across all three modules, so the choice is behavior-neutral.

Purely additive — these names were `undefined` before, so no existing importer changes behavior.

## Tests

New `tests/registry-barrel-exports.test.ts`: asserts `clean`/`entryUrl`/`sourceUrls`/`listValue` (and `generatedAtForEntries` as a control) each resolve to a function via `@heyclaude/registry`, and that each resolves to the intended canonical implementation (e.g. `entryUrl(...)` → `/entry/mcp/s`, `listValue([...])` → an array) so a future ambiguous collision can't silently reintroduce the bug.

## Verification output

```
clean function        entryUrl function      sourceUrls function
listValue function    generatedAtForEntries function
clean("  x  ") -> "x"     entryUrl({category:"mcp",slug:"s"}) -> "/entry/mcp/s"
```

## Validation

```
pnpm exec vitest run tests/registry-barrel-exports.test.ts   # 6 passed
pnpm exec vitest run tests/quality-lib.test.ts tests/relationships-lib.test.ts tests/commercial-lib.test.ts   # consumers green (148)
node --check packages/registry/src/index.js
```

No visual impact (Node package export surface only); no generated artifacts touched.