### PR TITLE
fix(scripts): drop unsubstituted {PR_MERGE_DATE} from Raycast release checklist

### DIFF
--- a/scripts/lib/release-watch-core.mjs
+++ b/scripts/lib/release-watch-core.mjs
@@ -238,7 +238,7 @@ export function buildRaycastReleaseIssue(report, options = {}) {
     labels: ["release", "raycast"],
     checklist: [
       "Run the Raycast extension validation workflow.",
-      "Review Store metadata, screenshots, and CHANGELOG.md with {PR_MERGE_DATE}.",
+      "Review Store metadata, screenshots, and CHANGELOG.md against the latest merged release PR.",
       "Mirror integrations/raycast into raycast/extensions/extensions/heyclaude and submit the upstream PR.",
       "After the upstream PR merges, create the local raycast-v* upstream-sync marker tag.",
     ],

--- a/tests/release-watch.test.ts
+++ b/tests/release-watch.test.ts
@@ -166,6 +166,10 @@ describe("release watch", () => {
     expect(issue.labels).toEqual(["release", "raycast"]);
     expect(issue.assignees).toEqual(["release-maintainer"]);
     expect(issue.body).toContain(RAYCAST_RELEASE_DUE_MARKER);
+    // The Raycast checklist must not ship an unsubstituted templating token
+    // into the generated issue body (regression: {PR_MERGE_DATE} was literal).
+    expect(issue.body).not.toContain("{PR_MERGE_DATE}");
+    expect(issue.body).not.toMatch(/\{[A-Z_]+\}/);
   });
 
   it("filters relevant commits by exact and nested path prefixes", () => {


### PR DESCRIPTION
## Summary

- `buildRaycastReleaseIssue` in `scripts/lib/release-watch-core.mjs` shipped a literal, unsubstituted `{PR_MERGE_DATE}` token in one of its checklist lines. This text goes straight into the auto-maintained Raycast upstream-update reminder issue (currently live and showing the raw token on [issue #1003](https://github.com/JSONbored/awesome-claude/issues/1003)).
- No substitution logic for `{PR_MERGE_DATE}` exists anywhere in `release-watch-core.mjs` or its callers (confirmed by grep — the string appeared exactly once, in the template itself). This issue is a recurring reminder, not tied to a single merged PR, so no real merge date is reliably available at generation time.
- Per the issue's sanctioned alternative, the line is reworded to not reference a placeholder at all, rather than leaving a half-implemented substitution.

Closes #5469

## Quality Evidence

- **No visual impact.** This is a Node script that generates a GitHub issue body (markdown), not a website page — nothing rendered by the site changes.
- **Before:** `Review Store metadata, screenshots, and CHANGELOG.md with {PR_MERGE_DATE}.`
- **After:** `Review Store metadata, screenshots, and CHANGELOG.md against the latest merged release PR.`
- Only the one checklist line in `buildRaycastReleaseIssue` changed; every other checklist item and the broader issue-maintenance logic (marker, tags, assignees, dedupe) is untouched. `integrations/raycast/CHANGELOG.md`'s own `{PR_MERGE_DATE}` occurrences are explicitly out of scope and left alone.
- **Regression test** (`tests/release-watch.test.ts`): the existing Raycast-issue test now also asserts the generated body contains no `{PR_MERGE_DATE}` and no unsubstituted `{UPPER_SNAKE}` token. Verified this assertion **fails on the pre-fix template** and **passes after the reword**.

## Validation

- `pnpm exec vitest run tests/release-watch.test.ts tests/release-watch-args.test.ts` — 17 passed
- `pnpm type-check` — clean (exit 0)
- `node scripts/ci/classify-pr-changes.mjs` over this diff → `content=false`, `content_config=false`, `ci=true` (CI lane only)
- `git diff --check` — clean