### PR TITLE
fix(registry): detect curl/wget piped to zsh/dash/ash in submission risk scan

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -11,8 +11,21 @@ import {
   isPublicHttpsUrl,
   publicUrlHostname,
 } from "./source-url-lib.js";
+import { SHELL_TOKENS } from "./command-safety-lib.js";
 
 export const SUBMISSION_RISK_SCHEMA_VERSION = 1;
+
+// A downloader piped straight into a shell. Kept in sync with
+// command-safety-lib's SHELL_TOKENS (bash/zsh/sh/dash/ash) so both detectors
+// recognize the same receiving shells — zsh in particular is macOS's default,
+// so `curl … | zsh` is a realistic install instruction. The tokens are plain
+// shell names (no regex metacharacters), so they are safe to interpolate.
+const CURL_PIPE_TO_SHELL_PATTERN = new RegExp(
+  `\\b(curl|wget)\\b[\\s\\S]{0,120}\\|[\\s\\S]{0,40}\\b(sudo\\s+)?(${SHELL_TOKENS.join(
+    "|",
+  )})\\b`,
+  "i",
+);
 export const SUBMISSION_RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";
 
 const SEVERITY_WEIGHT = {
@@ -1252,9 +1265,7 @@ function addContentRiskSignals(report, fields, text) {
 
   if (
     referencesDestructiveRootRemoval(installText) ||
-    /\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(sh|bash)\b/i.test(
-      installText,
-    ) ||
+    CURL_PIPE_TO_SHELL_PATTERN.test(installText) ||
     /\b(invoke-expression|iex)\b/i.test(installText) ||
     /\bbase64\s+(-d|--decode)\b[\s\S]{0,80}\|[\s\S]{0,40}\b(sh|bash)\b/i.test(
       installText,

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -135,6 +135,40 @@ describe("submission risk invariants", () => {
     );
   });
 
+  it.each(["zsh", "dash", "ash", "sh", "bash"])(
+    "flags a curl download piped to %s as an unsafe install pipeline",
+    (shell) => {
+      const draft = {
+        ...buildSubmissionPrDraft({
+          ...validMcpFields,
+          slug: `pipe-${shell}-mcp`,
+          install_command: `curl https://example.com/install.sh | ${shell}`,
+        }),
+        labels: [{ name: "submission" }],
+        user: { login: "author" },
+      };
+      const report = analyzeSubmissionDraftRisk(
+        draft,
+        validateSubmission(draft),
+      );
+      expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+        "unsafe_install_pipeline",
+      );
+    },
+  );
+
+  it("does not flag a benign npx install as an unsafe pipeline", () => {
+    const draft = {
+      ...buildSubmissionPrDraft({ ...validMcpFields, slug: "safe-mcp" }),
+      labels: [{ name: "submission" }],
+      user: { login: "author" },
+    };
+    const report = analyzeSubmissionDraftRisk(draft, validateSubmission(draft));
+    expect(report.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
   it("blocks unsafe executable pipelines in issue config snippets", () => {
     const draft = buildSubmissionPrDraft({
       ...validMcpFields,


### PR DESCRIPTION
Closes #5480

## Problem

`submission-risk.js` flags install instructions that pipe a downloaded script straight into a shell (`curl … | sh`) as a real security concern. But its regex only matched `(sudo\s+)?(sh|bash)`, while `command-safety-lib.js`'s `SHELL_TOKENS` — used for the identical "downloader piped into a shell" concern elsewhere — is `["bash", "zsh", "sh", "dash", "ash"]`. `zsh` has been macOS's default since 2019, so `curl https://example.com/install.sh | zsh` is a realistic install instruction this check silently missed.

## Fix

Keep the two detectors in sync by building the receiving-shell alternation from `SHELL_TOKENS` (the reference implementation) instead of a hardcoded `sh|bash`:

```js
import { SHELL_TOKENS } from "./command-safety-lib.js";

const CURL_PIPE_TO_SHELL_PATTERN = new RegExp(
  `\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(${SHELL_TOKENS.join("|")})\b`,
  "i",
);
```

The tokens are plain shell names (no regex metacharacters), and `bash` precedes `sh` in `SHELL_TOKENS` so `| bash` still matches `bash`, not `sh`. No import cycle (`command-safety-lib.js` doesn't import `submission-risk.js`). The other three alternatives in the same combined condition (`iex`, `base64 -d | sh`, `powershell -encodedcommand`) are unchanged.

## Before / after (regex against `curl https://example.com/install.sh | <shell>`)

| shell | before | after |
|---|---|---|
| `sh` | ✅ flagged | ✅ flagged |
| `bash` | ✅ flagged | ✅ flagged |
| `zsh` | ❌ missed | ✅ flagged |
| `dash` | ❌ missed | ✅ flagged |
| `ash` | ❌ missed | ✅ flagged |

## Tests

`tests/submission-risk-invariants.test.ts`: a parametrized case asserts `curl … | <shell>` raises the `unsafe_install_pipeline` flag for `zsh`/`dash`/`ash` (and still for `sh`/`bash`), plus a benign `npx -y …` install does not.

## Validation

```
pnpm exec vitest run tests/submission-risk-invariants.test.ts   # 54 passed
pnpm exec vitest run tests/command-safety-lib.test.ts tests/non-ui-branch-matrix.test.ts   # consumers green
node --check packages/registry/src/submission-risk.js
```

(Two pre-existing `submission-gate-worker` failures are unrelated CRLF-sensitive assertions that fail identically on `main`.)

No visual impact; no generated artifacts touched.