### PR TITLE
fix(registry): detect sk-ant-/sk-proj- API key formats in embedded secret scan

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1201,7 +1201,7 @@ function addContentRiskSignals(report, fields, text) {
   }
 
   if (
-    /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-[a-z0-9]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
+    /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-(?:(?:ant-|proj-)[a-z0-9-]{20,}|[a-z0-9]{20,})|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
       text,
     )
   ) {

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -135,6 +135,46 @@ describe("submission risk invariants", () => {
     );
   });
 
+  it.each([
+    ["Anthropic sk-ant", "sk-ant-", `api03-${"a".repeat(30)}`],
+    ["OpenAI sk-proj", "sk-proj-", "b".repeat(30)],
+    ["plain sk-", "sk-", "c".repeat(24)],
+  ])("flags an embedded %s API key as a secret", (_label, prefix, rest) => {
+    // Assembled at runtime so no key-shaped literal sits in source; low-entropy
+    // filler keeps it obviously non-real while still matching the detector.
+    const key = prefix + rest;
+    const draft = {
+      ...buildSubmissionPrDraft({
+        ...validMcpFields,
+        slug: "secret-mcp",
+        usage_snippet: `Set the api key to ${key} before running.`,
+      }),
+      labels: [{ name: "submission" }],
+      user: { login: "author" },
+    };
+    const report = analyzeSubmissionDraftRisk(draft, validateSubmission(draft));
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "embedded_secret",
+    );
+  });
+
+  it("does not flag benign hyphenated text containing 'sk-' as a secret", () => {
+    const draft = {
+      ...buildSubmissionPrDraft({
+        ...validMcpFields,
+        slug: "benign-mcp",
+        usage_snippet:
+          "A task-management sk- reference for long-hyphenated workflows here.",
+      }),
+      labels: [{ name: "submission" }],
+      user: { login: "author" },
+    };
+    const report = analyzeSubmissionDraftRisk(draft, validateSubmission(draft));
+    expect(report.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "embedded_secret",
+    );
+  });
+
   it("blocks unsafe executable pipelines in issue config snippets", () => {
     const draft = buildSubmissionPrDraft({
       ...validMcpFields,


### PR DESCRIPTION
Closes #5479

## Problem

`submission-risk.js`'s `embedded_secret` detector flags submissions that appear to contain a real API token. Its `sk-` alternative was `sk-[a-z0-9]{20,}` — it requires 20+ alphanumerics *immediately* after `sk-`, with no hyphens. Real Anthropic (`sk-ant-api03-…`) and OpenAI (`sk-proj-…`) keys insert a hyphenated segment right after `sk-`, breaking the match before it reaches 20 chars. So the one check meant to catch accidental credential leaks missed Anthropic's own key format — on a directory site specifically about Claude/Anthropic tooling.

## Fix

Extend only the `sk-` alternative (the other alternatives are unchanged):

```
sk-[a-z0-9]{20,}
->
sk-(?:(?:ant-|proj-)[a-z0-9-]{20,}|[a-z0-9]{20,})
```

This is deliberately tighter than the issue's `sk-(?:ant-|proj-)?[a-z0-9-]{20,}` suggestion: hyphens are allowed only *after* an `ant-`/`proj-` prefix, so the plain `sk-<20+ alnum>` case stays hyphen-free and doesn't newly false-positive on ordinary hyphenated prose like `sk-this-is-a-long-hyphenated-phrase`.

## Before / after (regex `.test(...)`)

| input | before | after |
|---|---|---|
| `sk-ant-api03-…` (30+ chars) | ❌ | ✅ |
| `sk-proj-…` (30+ chars) | ❌ | ✅ |
| `sk-<24 alnum>` (plain) | ✅ | ✅ |
| `sk-this-is-a-long-hyphenated-benign-phrase` | ❌ | ❌ (no new false positive) |
| `masks-and-tasks-overview-guide` | ❌ | ❌ |
| `ghp_…`, `akia…` (other alternatives) | ✅ | ✅ (unchanged) |

## Tests

`tests/submission-risk-invariants.test.ts`: a submission whose `usage_snippet` embeds an `sk-ant-`/`sk-proj-`/plain-`sk-` key now raises the `embedded_secret` flag, and benign hyphenated text containing `sk-` does not. The key strings are assembled at runtime from low-entropy fragments (obviously non-real, and no key-shaped literal in the diff).

## Validation

```
pnpm exec vitest run tests/submission-risk-invariants.test.ts   # 52 passed
pnpm exec vitest run tests/non-ui-branch-matrix.test.ts   # consumer green
node --check packages/registry/src/submission-risk.js
```

No visual impact; no generated artifacts touched.