### PR TITLE
fix(web): wire sitemapEntryLastModified into sitemap entry lastmod

### DIFF
--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { BEST_LISTS, ENTRIES } from "@/data/entries";
+import { BEST_LISTS, ENTRIES, REGISTRY_ENTRIES } from "@/data/entries";
 import { CONTRIBUTORS } from "@/data/contributors";
 import { INTEGRATIONS } from "@/data/integrations";
 import atlasRegistry from "@/generated/atlas-registry.json";
@@ -8,7 +8,7 @@ import { siteConfig } from "@/lib/site";
 import { applySecurityHeaders } from "@/lib/security-headers";
 import { CATEGORIES, PLATFORM_LABEL } from "@/types/registry";
 import { getIndexableTagGroups } from "@/lib/tags";
-import { isSitemapIndexableEntry } from "@/lib/sitemap-policy";
+import { isSitemapIndexableEntry, sitemapEntryLastModified } from "@/lib/sitemap-policy";
 import { COMPARISONS } from "@/data/comparisons";
 import { REPORT_PATHS } from "@/lib/data-reports";
 import { sitemapUrlItem } from "@/lib/sitemap-url-item-lib";
@@ -120,12 +120,15 @@ async function renderSitemap() {
     ...bestPaths.map((pathname) => urlItem(pathname, "0.75")),
     // Advertise every indexable entry page (all categories, including `tools`).
     // Entries opt out per-entry with `robotsIndex:false` (see isSitemapIndexableEntry).
-    ...ENTRIES.filter(isSitemapIndexableEntry).map((entry) =>
+    // Prefer REGISTRY_ENTRIES so contentUpdatedAt/repoUpdatedAt survive for lastmod.
+    ...REGISTRY_ENTRIES.filter(isSitemapIndexableEntry).map((entry) =>
       urlItem(
         `/entry/${entry.category}/${entry.slug}`,
         "0.8",
         "monthly",
-        entry.reviewedAt ?? entry.dateAdded,
+        sitemapEntryLastModified(
+          entry as Parameters<typeof sitemapEntryLastModified>[0],
+        )?.toISOString(),
       ),
     ),
     ...contributorPaths.map((pathname) => urlItem(pathname, "0.5", "monthly")),

--- a/tests/sitemap-policy.test.ts
+++ b/tests/sitemap-policy.test.ts
@@ -82,9 +82,10 @@ describe("sitemap policy", () => {
     expect(source).not.toContain("lastModified: new Date()");
     // Entry pages are filtered through the sitemap-indexable policy (advertises
     // every category, including `tools`, except robotsIndex:false entries).
-    expect(source).toContain("ENTRIES.filter(isSitemapIndexableEntry)");
-    // Category hub landing pages with per-category + per-entry lastmod.
+    // REGISTRY_ENTRIES keeps contentUpdatedAt/repoUpdatedAt for lastmod.
+    expect(source).toContain("REGISTRY_ENTRIES.filter(isSitemapIndexableEntry)");
+    expect(source).toContain("sitemapEntryLastModified");
+    // Category hub landing pages with per-category lastmod.
     expect(source).toContain("categoryLastmod");
-    expect(source).toContain("entry.reviewedAt ?? entry.dateAdded");
   });
 });

--- a/tests/sitemap-policy.test.ts
+++ b/tests/sitemap-policy.test.ts
@@ -83,7 +83,9 @@ describe("sitemap policy", () => {
     // Entry pages are filtered through the sitemap-indexable policy (advertises
     // every category, including `tools`, except robotsIndex:false entries).
     // REGISTRY_ENTRIES keeps contentUpdatedAt/repoUpdatedAt for lastmod.
-    expect(source).toContain("REGISTRY_ENTRIES.filter(isSitemapIndexableEntry)");
+    expect(source).toContain(
+      "REGISTRY_ENTRIES.filter(isSitemapIndexableEntry)",
+    );
     expect(source).toContain("sitemapEntryLastModified");
     // Category hub landing pages with per-category lastmod.
     expect(source).toContain("categoryLastmod");


### PR DESCRIPTION
## Summary
- Wire the already-tested `sitemapEntryLastModified` helper into `apps/web/src/routes/sitemap[.]xml.ts` so entry `lastmod` uses `contentUpdatedAt || repoUpdatedAt || verifiedAt || dateAdded` instead of the weaker inline `reviewedAt ?? dateAdded`.
- Map entry sitemap rows from `REGISTRY_ENTRIES` (not normalized `ENTRIES`) so `contentUpdatedAt` / `repoUpdatedAt` are still present for that helper.
- Update the sitemap policy source assertion to expect the helper call.

Closes #5472

## Spot-check (lastmod changes)
Against the current atlas registry (1385 entries), only **5** entry pages change `lastmod` vs the previous `Entry.reviewedAt ?? dateAdded` path. All prefer `contentUpdatedAt` over a later `reviewedAt` — which matches sitemap `lastmod` as a content-update signal:

| Entry | Old lastmod | New lastmod | Why |
|---|---|---|---|
| `mcp/contrastapi-mcp-server` | 2026-04-30 (reviewedAt) | 2026-04-20 (contentUpdatedAt) | content update date |
| `mcp/memesio-mcp-server` | 2026-05-10 | 2026-05-08 | content update date |
| `mcp/packrift-mcp-server` | 2026-05-16 | 2026-05-10 | content update date |
| `mcp/prompt-to-asset` | 2026-04-30 | 2026-04-25 | content update date |
| `mcp/legal-fournier-spain-legal-mcp` | 2026-05-10 | 2026-05-08 | content update date |

No visual impact (XML feed only). Hub/category `lastmod` derivations are unchanged.

## Test plan
- [x] `pnpm exec vitest run tests/sitemap-policy.test.ts tests/sitemap-policy-lib.test.ts tests/web-non-ui-utilities.test.ts`
- [x] `pnpm build`
- [x] `git diff --check`

