### PR TITLE
fix(web): order the weak trust-coverage range low-to-high in the browse hint

### DIFF
--- a/apps/web/src/lib/browse-results-trust-decision-lib.ts
+++ b/apps/web/src/lib/browse-results-trust-decision-lib.ts
@@ -127,7 +127,13 @@ export function browseTrustPanelDecisionHint(
   const coverage = browseTrustCoverageChips(entries);
   const weakCoverage = coverage.filter((chip) => chip.emphasis === "low");
   if (weakCoverage.length >= 2 && compareCount < 2) {
-    return `Only ${weakCoverage[0]?.percent ?? 0}%–${weakCoverage[weakCoverage.length - 1]?.percent ?? 0}% of results have key trust signals — compare before you commit.`;
+    // Chips arrive in fixed signal order (safety, privacy, ...), not by value,
+    // so take min/max — indexing first/last could render a backwards range
+    // like "Only 20%–0%".
+    const weakPercents = weakCoverage.map((chip) => chip.percent);
+    const lowest = Math.min(...weakPercents);
+    const highest = Math.max(...weakPercents);
+    return `Only ${lowest}%–${highest}% of results have key trust signals — compare before you commit.`;
   }
 
   return null;

--- a/tests/browse-results-trust-decision-lib.test.ts
+++ b/tests/browse-results-trust-decision-lib.test.ts
@@ -158,6 +158,21 @@ describe("browse results trust decision lib", () => {
     );
   });
 
+  it("renders the weak-coverage range low-to-high regardless of chip order", () => {
+    // Safety lands at 20% (1 of 5) while every later chip is 0%. Chips are in
+    // fixed signal order, so first/last indexing rendered "Only 20%–0%".
+    const sparse = [
+      entry({ safetyNotes: "Careful" }),
+      entry({ slug: "two" }),
+      entry({ slug: "three" }),
+      entry({ slug: "four" }),
+      entry({ slug: "five" }),
+    ];
+    expect(browseTrustPanelDecisionHint(sparse, 0, [])).toContain(
+      "Only 0%–20%",
+    );
+  });
+
   it("prefers side-by-side compare copy when diverging labels exist and compare is ready", () => {
     expect(
       browseTrustPanelDecisionHint([entry(), entry({ slug: "two" })], 2, [


### PR DESCRIPTION
## Problem

`browseTrustPanelDecisionHint` in `apps/web/src/lib/browse-results-trust-decision-lib.ts` renders the weak trust-coverage range by indexing the **first and last** low-emphasis chips:

```ts
return `Only ${weakCoverage[0]?.percent ?? 0}%–${weakCoverage[weakCoverage.length - 1]?.percent ?? 0}% of results have key trust signals — compare before you commit.`;
```

But `browseTrustCoverageChips` returns chips in **fixed signal order** (safety, privacy, reviewed, source-backed, claimed) — not by value. Filtering for `emphasis === "low"` preserves that order, so the rendered range can read backwards.

### Concrete failing case

5 browse results where exactly 1 has safety notes and nothing else is covered:
- safety chip → 20% (low), every later chip → 0% (low)
- **Rendered (buggy):** `"Only 20%–0% of results have key trust signals — compare before you commit."` — a backwards range shown to users on the browse page
- **Correct:** `"Only 0%–20% of results have key trust signals — …"`

## Fix

Take `Math.min` / `Math.max` over the weak chips' percents so the range always reads low-to-high:

```ts
const weakPercents = weakCoverage.map((chip) => chip.percent);
const lowest = Math.min(...weakPercents);
const highest = Math.max(...weakPercents);
return `Only ${lowest}%–${highest}% of results have key trust signals — compare before you commit.`;
```

## Risk / tradeoffs

- Pure function, no signature/API change; only the ordering of the two numbers in the hint string changes (and only when it was previously backwards).
- The guarded branch (`weakCoverage.length >= 2 && compareCount < 2`) is unchanged.

## Tests

- Adds a regression case where the first weak chip carries the higher percent — asserts `"Only 0%–20%"`. The existing weak-coverage test only asserted the suffix text, which is why the reversed range shipped unnoticed.
- `pnpm exec vitest run tests/browse-results-trust-decision-lib.test.ts` → 11/11 pass.
- `pnpm type-check` clean; `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)