### PR TITLE
fix(scripts): detect missing source without always-set githubUrl

### DIFF
--- a/scripts/lib/growth-dashboard.mjs
+++ b/scripts/lib/growth-dashboard.mjs
@@ -48,7 +48,10 @@ export function trustGaps(entry) {
       detail: "no documented privacy behavior",
     });
   }
-  if (!entry.documentationUrl && !entry.repoUrl && !entry.githubUrl) {
+  // `githubUrl` is always set to this repo's own .mdx path by content-builder
+  // (`buildGitHubUrl`), so it is never a signal of real external source backing.
+  // Match quality-lib's external-source posture: only documentationUrl/repoUrl count.
+  if (!entry.documentationUrl && !entry.repoUrl) {
     gaps.push({
       field: "source",
       code: "missing",

--- a/tests/growth-dashboard.test.ts
+++ b/tests/growth-dashboard.test.ts
@@ -22,12 +22,43 @@ describe("trustGaps", () => {
     expect(gaps).toEqual(["safetyNotes", "privacyNotes", "source"]);
   });
 
+  it("still flags source when only the self-referential directory githubUrl is set", () => {
+    const gaps = trustGaps(
+      entry({
+        safetyNotes: ["runs shell"],
+        privacyNotes: ["telemetry"],
+        githubUrl:
+          "https://github.com/JSONbored/awesome-claude/blob/main/content/mcp/x.mdx",
+      }),
+    );
+    expect(gaps).toEqual([
+      {
+        field: "source",
+        code: "missing",
+        detail: "no documentation or repository URL",
+      },
+    ]);
+  });
+
   it("clears once the signals are present", () => {
     const gaps = trustGaps(
       entry({
         safetyNotes: ["runs shell"],
         privacyNotes: ["telemetry"],
         repoUrl: "https://github.com/x/y",
+      }),
+    );
+    expect(gaps).toEqual([]);
+  });
+
+  it("clears the source gap when documentationUrl is present", () => {
+    const gaps = trustGaps(
+      entry({
+        safetyNotes: ["runs shell"],
+        privacyNotes: ["telemetry"],
+        documentationUrl: "https://example.com/docs",
+        githubUrl:
+          "https://github.com/JSONbored/awesome-claude/blob/main/content/mcp/x.mdx",
       }),
     );
     expect(gaps).toEqual([]);


### PR DESCRIPTION
## Summary
- Fix `trustGaps()` in `scripts/lib/growth-dashboard.mjs` so the `source` gap no longer requires `githubUrl` to be falsy.
- `githubUrl` is always set by `buildGitHubUrl` to this repo's own `.mdx` path, so including it made the missing-source check dead code.
- Entries with a real `documentationUrl` or `repoUrl` are unchanged; entries with only the self-referential directory `githubUrl` are now flagged.

Closes #5468

## Submission Source
- [x] This is not a direct content submission.
- [x] Changed tools: `scripts/lib/growth-dashboard.mjs` (`trustGaps`).
- [x] Screenshots: **No visual impact** (CLI maintainer worklist only; no routes/components/UI).
- [x] Links #5468.

## Quality Evidence
- Changed routes/components/endpoints/tools: `pnpm growth:dashboard` / `trustGaps` only.
- Expected behavior: missing `documentationUrl` + `repoUrl` → `source` gap, even when self-referential `githubUrl` is present.
- Screenshots for frontend/page/UI changes: **No visual impact** — this PR does not change any rendered page, theme, or viewport. It only updates a Node CLI gap detector. No Desktop/Tablet/Mobile screenshot table applies.
- Focused tests: `tests/growth-dashboard.test.ts` (added coverage for self-referential `githubUrl` and `documentationUrl`).

## Before / after (registry spot-check)
Against the current atlas registry (1385 entries):

| Check | Source gaps |
|---|---|
| Before (`!documentationUrl && !repoUrl && !githubUrl`) | **0** (never fires) |
| After (`!documentationUrl && !repoUrl`) | **37** newly flagged |

Examples newly flagged (directory `githubUrl` only): `collections/agent-operator-growth-master-pack`, `agents/ai-code-review-security-agent`, `guides/mcp-server-auth-least-privilege`, `hooks/documentation-auto-generator-on-stop`.

## Test plan
- [x] `pnpm exec vitest run tests/growth-dashboard.test.ts`
- [x] `pnpm build`
- [x] `git diff --check`

