### PR TITLE
fix(web): scale k-shorthand compensation so Salary sort compares real dollars

### DIFF
--- a/apps/web/src/lib/jobs-utils-lib.ts
+++ b/apps/web/src/lib/jobs-utils-lib.ts
@@ -54,6 +54,19 @@ export function isFresh(iso: string, now = Date.now()): boolean {
   return daysSince(iso, now) <= 7;
 }
 
+/**
+ * Real-dollar sort value for a free-text compensation string, so mixed-format
+ * listings compare on one scale: "$210k" and "$210,000" both yield 210000.
+ * Missing compensation sorts last (-1); an unparseable string stays at 0.
+ */
+export function compensationSortValue(compensation?: string | null): number {
+  if (!compensation) return -1;
+  const m = compensation.match(/\$?(\d[\d,]*)(k)?/i);
+  if (!m) return 0;
+  const base = parseInt(m[1].replace(/,/g, ""), 10);
+  return m[2] ? base * 1000 : base;
+}
+
 export function sortJobs(jobs: JobListing[]): JobListing[] {
   const order: Record<JobListing["tier"], number> = {
     sponsored: 0,

--- a/apps/web/src/lib/jobs-utils.ts
+++ b/apps/web/src/lib/jobs-utils.ts
@@ -11,6 +11,7 @@ export {
   daysSince,
   relativePosted,
   isFresh,
+  compensationSortValue,
   sortJobs,
   pickDailySpotlight,
 } from "@/lib/jobs-utils-lib";

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -9,7 +9,13 @@ import type { JobListing, JobTier } from "@/types/registry";
 import { normalizeJobListing } from "@/lib/job-listing-lib";
 import { cn } from "@/lib/utils";
 import { JobCard } from "@/components/job-card";
-import { isFresh, pickDailySpotlight, relativePosted, sortJobs } from "@/lib/jobs-utils";
+import {
+  compensationSortValue,
+  isFresh,
+  pickDailySpotlight,
+  relativePosted,
+  sortJobs,
+} from "@/lib/jobs-utils";
 import { jobsEmptyStateSuggestions } from "@/lib/jobs-empty-state-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -199,11 +205,7 @@ function JobsPage() {
       return [...filtered].sort((a, b) => b.postedAt.localeCompare(a.postedAt));
     }
     if (sortMode === "salary") {
-      const sval = (j: JobListing) => {
-        if (!j.compensation) return -1;
-        const m = j.compensation.match(/\$?(\d[\d,]*)k?/i);
-        return m ? parseInt(m[1].replace(/,/g, ""), 10) : 0;
-      };
+      const sval = (j: JobListing) => compensationSortValue(j.compensation);
       return [...filtered].sort((a, b) => sval(b) - sval(a));
     }
     return sortJobs(filtered);

--- a/tests/jobs-utils-lib.test.ts
+++ b/tests/jobs-utils-lib.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { JobListing } from "@/types/registry";
 import {
   companyTint,
+  compensationSortValue,
   daysSince,
   isFresh,
   monogram,
@@ -181,5 +182,35 @@ describe("pickDailySpotlight", () => {
     // "current" vs "next" depends on the day-index rotation.
     const { current, next } = pickDailySpotlight([weak, strong], NOW);
     expect([current?.slug, next?.slug].sort()).toEqual(["strong", "weak"]);
+  });
+});
+
+describe("compensationSortValue", () => {
+  it('scales "k" shorthand to real dollars so mixed formats share one scale', () => {
+    // Regression for #5475: "$210k" sorted as 210 (below "$120,000" at
+    // 120000) because the trailing "k" multiplier was discarded.
+    expect(compensationSortValue("$210k")).toBe(210_000);
+    expect(compensationSortValue("$120,000")).toBe(120_000);
+    expect(compensationSortValue("$210k")).toBeGreaterThan(
+      compensationSortValue("$120,000"),
+    );
+  });
+
+  it("handles uppercase K and unprefixed amounts", () => {
+    expect(compensationSortValue("$95K")).toBe(95_000);
+    expect(compensationSortValue("180k")).toBe(180_000);
+    expect(compensationSortValue("150000")).toBe(150_000);
+  });
+
+  it("uses the leading figure of a range", () => {
+    expect(compensationSortValue("$100k-$150k")).toBe(100_000);
+    expect(compensationSortValue("$90,000 - $120,000")).toBe(90_000);
+  });
+
+  it("keeps the fallback ordering: missing sorts below unparseable", () => {
+    expect(compensationSortValue(undefined)).toBe(-1);
+    expect(compensationSortValue(null)).toBe(-1);
+    expect(compensationSortValue("")).toBe(-1);
+    expect(compensationSortValue("Competitive")).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #5475

## Root cause

The Salary sort's value extractor in `apps/web/src/routes/jobs.index.tsx` matched a trailing `k` **outside** the captured group, so the multiplier was discarded:

```ts
const m = j.compensation.match(/\$?(\d[\d,]*)k?/i);
return m ? parseInt(m[1].replace(/,/g, ""), 10) : 0;
```

`"$210k"` → `210` while `"$120,000"` → `120000`, so a $210,000/yr listing ranked *below* a $120,000/yr one whenever the higher figure used shorthand — exactly the mixed-format data the site has.

## Fix

Extracted the parsing into `compensationSortValue` in `jobs-utils-lib.ts` (the jobs board's existing pure-helper surface, re-exported through `@/lib/jobs-utils`) and captured the `k`/`K` suffix, multiplying by 1000:

```ts
export function compensationSortValue(compensation?: string | null): number {
  if (!compensation) return -1;
  const m = compensation.match(/\$?(\d[\d,]*)(k)?/i);
  if (!m) return 0;
  const base = parseInt(m[1].replace(/,/g, ""), 10);
  return m[2] ? base * 1000 : base;
}
```

The route's `salary` branch now delegates to it. Both formats compare on the same real-dollar scale: `"$210k"` → `210000`, `"$120,000"` → `120000`.

## Acceptance criteria

- ✅ Sorting by Salary ranks `"$210k"` above `"$120,000"` (asserted directly in the new unit tests).
- ✅ Jobs with missing compensation still sort last (`-1`) and unparseable strings stay at `0` — fallback behavior unchanged.
- ✅ `Closes #5475` included.

## Quality evidence

**No visual impact** — sort-order logic only. Unit tests in `tests/jobs-utils-lib.test.ts` cover both formats (`$210k` vs `$120,000`), uppercase `K`, unprefixed amounts, ranges (leading figure), and the missing/unparseable fallback ordering. `pnpm exec vitest run tests/jobs-utils-lib.test.ts` → 20/20 pass.

## Validation

- `pnpm build` → succeeds
- `git diff --check` → clean
- `pnpm type-check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)