### PR TITLE
fix(web): export the filtered compatibility-matrix rows in the CSV download

### DIFF
--- a/apps/web/src/components/compatibility-matrix.tsx
+++ b/apps/web/src/components/compatibility-matrix.tsx
@@ -93,8 +93,10 @@ export function CompatibilityMatrix({
   }, [rows, query]);
 
   const downloadCsv = () => {
-    onCsvDownloadClick?.(rows.length, clients.length);
-    const csv = buildCompatibilityCsv(clients, rows, (support) => SUPPORT_META[support].label);
+    // Export exactly the rows the filtered table is showing (filtered === rows
+    // when no search query is active), and report the same count.
+    onCsvDownloadClick?.(filtered.length, clients.length);
+    const csv = buildCompatibilityCsv(clients, filtered, (support) => SUPPORT_META[support].label);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");


### PR DESCRIPTION
Closes #5505

## Root cause

In [compatibility-matrix.tsx](apps/web/src/components/compatibility-matrix.tsx), `filtered` is the search-narrowed row set the table actually renders, but `downloadCsv` built the CSV from the full `rows` prop and reported `rows.length` to `onCsvDownloadClick` — so an export taken with an active "Filter capabilities…" query silently contained every matrix row, not the visible subset.

## Fix

`downloadCsv` now builds the CSV from `filtered` and reports `filtered.length` (still `clients.length` for clients), so the export and its recorded analytics size match what's on screen. Scope is exactly the `downloadCsv` function; `buildCompatibilityCsv` is untouched (it already accepts an arbitrary row array).

## Acceptance criteria

- ✅ With a search query narrowing the visible rows, CSV downloads only those rows.
- ✅ With no query, `filtered === rows`, so the full-matrix export is byte-identical to before.
- ✅ `Closes #5505` included.

## Quality evidence

**No visual impact** — data-export logic fix only, no UI change.

## Validation

- `pnpm type-check` → clean
- `pnpm build` → succeeds
- `git diff --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)