### PR TITLE
fix(web): honor robotsIndex:false on entry pages and llms feeds

### DIFF
--- a/apps/web/src/lib/llms-surface-lib.ts
+++ b/apps/web/src/lib/llms-surface-lib.ts
@@ -27,6 +27,8 @@ export interface LlmsEntry {
   installCommand?: string;
   configSnippet?: string;
   fullCopy?: string;
+  /** When false, omit from llms surfaces (matches sitemap robotsIndex opt-out). */
+  robotsIndex?: boolean;
 }
 
 export interface LlmsTxtContext {
@@ -39,6 +41,11 @@ export interface LlmsFullTxtContext extends LlmsTxtContext {
   buildCitationFacts?: (entry: Record<string, unknown>, options: { siteUrl: string }) => string;
 }
 
+/** Entries that opted out of indexing must not appear in llms feeds. */
+function indexableLlmsEntries(entries: LlmsEntry[]): LlmsEntry[] {
+  return entries.filter((entry) => entry.robotsIndex !== false);
+}
+
 export function buildLlmsTxt(origin: string, context: LlmsTxtContext): string {
   const lines: string[] = [];
   lines.push("# HeyClaude registry");
@@ -49,12 +56,13 @@ export function buildLlmsTxt(origin: string, context: LlmsTxtContext): string {
   lines.push(`Feeds: ${origin}/feeds`);
   lines.push("");
 
+  const entries = indexableLlmsEntries(context.entries);
   for (const c of context.categories) {
-    const entries = context.entries.filter((e) => e.category === c.id);
-    if (entries.length === 0) continue;
+    const categoryEntries = entries.filter((e) => e.category === c.id);
+    if (categoryEntries.length === 0) continue;
     lines.push(`## ${c.label}`);
     lines.push("");
-    for (const e of entries) {
+    for (const e of categoryEntries) {
       lines.push(
         `- [${e.title}](${origin}/entry/${e.category}/${e.slug}): ${e.cardDescription ?? e.description}`,
       );
@@ -96,12 +104,13 @@ export function buildLlmsFullTxt(origin: string, context: LlmsFullTxtContext): s
   out.push(`Generated for context windows. Source: ${origin}`);
   out.push("");
 
+  const entries = indexableLlmsEntries(context.entries);
   for (const c of context.categories) {
-    const entries = context.entries.filter((e) => e.category === c.id);
-    if (entries.length === 0) continue;
+    const categoryEntries = entries.filter((e) => e.category === c.id);
+    if (categoryEntries.length === 0) continue;
     out.push(`# ${c.label}`);
     out.push("");
-    for (const e of entries) {
+    for (const e of categoryEntries) {
       out.push(`## ${e.title}`);
       out.push("");
       out.push(`- URL: ${origin}/entry/${e.category}/${e.slug}`);

--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -21,17 +21,30 @@ import {
 
 export { originOf };
 
+function llmsEntriesWithRobotsIndex() {
+  const robotsByRef = new Map(
+    REGISTRY_ENTRIES.map((entry) => [
+      `${entry.category}/${entry.slug}`,
+      entry.robotsIndex as boolean | undefined,
+    ]),
+  );
+  return ENTRIES.map((entry) => ({
+    ...entry,
+    robotsIndex: robotsByRef.get(`${entry.category}/${entry.slug}`),
+  }));
+}
+
 export function buildLlmsTxt(origin: string): string {
   return buildLlmsTxtFromContext(origin, {
     categories: CATEGORIES,
-    entries: ENTRIES,
+    entries: llmsEntriesWithRobotsIndex(),
   });
 }
 
 export function buildLlmsFullTxt(origin: string): string {
   return buildLlmsFullTxtFromContext(origin, {
     categories: CATEGORIES,
-    entries: ENTRIES,
+    entries: llmsEntriesWithRobotsIndex(),
     registryEntries: REGISTRY_ENTRIES,
     buildCitationFacts: buildEntryCitationFacts,
   });

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { getEntry, related, relatedGroups, relatedGuides } from "@/data/search";
 import { getEntryRedirectTarget } from "@/lib/entry-redirects";
-import { BEST_LISTS, ENTRIES } from "@/data/entries";
+import { BEST_LISTS, ENTRIES, REGISTRY_ENTRIES } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
 import { EntryAuthorAttribution } from "@/components/contributor-attribution";
 import { findContributorForIdentity } from "@/data/contributors";
@@ -239,10 +239,17 @@ export const Route = createFileRoute("/entry/$category/$slug")({
     const ogUrl = absoluteUrl(`/og/${params.category}/${params.slug}`);
     const ogTitle = `${e.title} — HeyClaude`;
     const metaDescription = clampDescription(e.seoDescription ?? e.description);
+    // Normalized Entry drops robotsIndex; read it from the registry snapshot.
+    const registryEntry = REGISTRY_ENTRIES.find(
+      (item) => item.category === params.category && item.slug === params.slug,
+    );
+    const noindex = registryEntry?.robotsIndex === false;
     return {
       meta: [
         { title: e.seoTitle ? `${e.seoTitle} — HeyClaude` : ogTitle },
         { name: "description", content: metaDescription },
+        // Match thin-hub noindex posture so sitemap opt-out is enforceable.
+        ...(noindex ? [{ name: "robots", content: "noindex, follow" }] : []),
         { property: "og:title", content: ogTitle },
         { property: "og:description", content: metaDescription },
         { property: "og:url", content: url },

--- a/tests/llms-surface-lib.test.ts
+++ b/tests/llms-surface-lib.test.ts
@@ -49,6 +49,39 @@ describe("llms-surface-lib buildLlmsTxt", () => {
     );
   });
 
+  it("omits entries with robotsIndex:false from llms.txt", () => {
+    const output = buildLlmsTxt("https://heyclau.de", {
+      categories: FIXTURE_CATEGORIES,
+      entries: [
+        fixtureEntry("mcp", "visible"),
+        fixtureEntry("mcp", "hidden", { robotsIndex: false }),
+      ],
+    });
+    expect(output).toContain("/entry/mcp/visible");
+    expect(output).not.toContain("/entry/mcp/hidden");
+  });
+
+  it("omits entries with robotsIndex:false from llms-full.txt", () => {
+    const output = buildLlmsFullTxt("https://heyclau.de", {
+      categories: FIXTURE_CATEGORIES,
+      entries: [
+        fixtureEntry("mcp", "visible"),
+        fixtureEntry("mcp", "hidden", { robotsIndex: false }),
+      ],
+      registryEntries: [
+        { category: "mcp", slug: "visible", title: "visible" },
+        {
+          category: "mcp",
+          slug: "hidden",
+          title: "hidden",
+          robotsIndex: false,
+        },
+      ],
+    });
+    expect(output).toContain("/entry/mcp/visible");
+    expect(output).not.toContain("/entry/mcp/hidden");
+  });
+
   it("buildLlmsTxt lists agents/agents-llms-0", () => {
     const entries = [fixtureEntry("agents", "agents-llms-0")];
     const output = buildLlmsTxt("https://heyclau.de", {

--- a/tests/sitemap-policy.test.ts
+++ b/tests/sitemap-policy.test.ts
@@ -87,4 +87,13 @@ describe("sitemap policy", () => {
     expect(source).toContain("categoryLastmod");
     expect(source).toContain("entry.reviewedAt ?? entry.dateAdded");
   });
+
+  it("emits noindex on the entry detail route when robotsIndex is false", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/routes/entry.$category.$slug.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("robotsIndex === false");
+    expect(source).toContain('content: "noindex, follow"');
+  });
 });


### PR DESCRIPTION
## Summary
- Entry detail `head()` emits `robots: noindex, follow` when the registry snapshot has `robotsIndex: false`.
- `buildLlmsTxt` / `buildLlmsFullTxt` omit opted-out entries; `llms.ts` passes `robotsIndex` from `REGISTRY_ENTRIES`.
- Default/indexable entries are unchanged on page meta, sitemap, and llms surfaces.

Closes #5471

## Submission Source
- [x] This is not a direct content submission.
- [x] Changed routes/tools: `entry.\.\.tsx`, `llms-surface-lib.ts`, `llms.ts`.
- [x] Screenshots: **No visual impact** — meta tag + text-feed filtering only; no rendered UI change.
- [x] Links #5471.

## Quality Evidence
- Opted-out entries: `noindex, follow` on detail page (source assertion in `tests/sitemap-policy.test.ts`).
- Opted-out entries absent from llms.txt / llms-full.txt (`tests/llms-surface-lib.test.ts`).
- Default entries (no `robotsIndex`) still listed and not noindexed.

## Validation (completed before opening — one-shot)
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/sitemap-policy.test.ts tests/sitemap-policy-lib.test.ts tests/web-non-ui-utilities.test.ts tests/llms-surface-lib.test.ts`
- [x] `pnpm build`
- [x] `git diff --check`
