### PR TITLE
fix(ci): enable ClamAV/Trivy/OSV package scanners in CI

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -943,7 +943,7 @@ jobs:
     needs: classify-pr
     if: ${{ needs.classify-pr.outputs.packages == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     concurrency:
       group: pr-validate-packages-${{ github.ref }}
       cancel-in-progress: true
@@ -972,13 +972,44 @@ jobs:
         if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         run: pnpm install --frozen-lockfile
 
+      - name: Install external package scanners
+        if: ${{ needs.classify-pr.outputs.packages == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIVY_VERSION: 0.72.0
+          OSV_SCANNER_VERSION: 2.0.2
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y clamav
+          sudo systemctl stop clamav-freshclam.service || true
+          sudo freshclam || sudo freshclam --verbose
+
+          curl -sSfL "https://raw.githubusercontent.com/aquasecurity/trivy/v${TRIVY_VERSION}/contrib/install.sh" \
+            | sudo sh -s -- -b /usr/local/bin "v${TRIVY_VERSION}"
+
+          gh release download "v${OSV_SCANNER_VERSION}" \
+            --repo google/osv-scanner \
+            --pattern 'osv-scanner_*_linux_amd64' \
+            --clobber
+          sudo mv osv-scanner_*_linux_amd64 /usr/local/bin/osv-scanner
+          sudo chmod +x /usr/local/bin/osv-scanner
+
+          command -v clamscan
+          clamscan --version
+          command -v trivy
+          trivy --version
+          command -v osv-scanner
+          osv-scanner --version
+
       - name: Validate package metadata
         if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         run: pnpm validate:packages
 
       - name: Scan package artifacts
         if: ${{ needs.classify-pr.outputs.packages == 'true' }}
-        run: pnpm scan:packages
+        run: pnpm scan:packages -- --require-scanners
 
   validate-submission-gate:
     name: validate-submission-gate

--- a/.github/workflows/package-artifact-scan.yml
+++ b/.github/workflows/package-artifact-scan.yml
@@ -2,6 +2,15 @@ name: Package Artifact Scan
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "content/skills/**/*.zip"
+      - "content/mcp/**/*.mcpb"
+      - "apps/web/public/downloads/**"
+      - "scripts/scan-download-packages.mjs"
+      - "scripts/validate-download-packages.mjs"
+      - "scripts/lib/download-package-scan.mjs"
+      - ".github/workflows/package-artifact-scan.yml"
 
 permissions:
   contents: read
@@ -9,7 +18,7 @@ permissions:
 jobs:
   scan-packages:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -26,8 +35,39 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install external package scanners
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TRIVY_VERSION: 0.72.0
+          OSV_SCANNER_VERSION: 2.0.2
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y clamav
+          # freshclam may race with the systemd timer on ubuntu runners.
+          sudo systemctl stop clamav-freshclam.service || true
+          sudo freshclam || sudo freshclam --verbose
+
+          curl -sSfL "https://raw.githubusercontent.com/aquasecurity/trivy/v${TRIVY_VERSION}/contrib/install.sh" \
+            | sudo sh -s -- -b /usr/local/bin "v${TRIVY_VERSION}"
+
+          gh release download "v${OSV_SCANNER_VERSION}" \
+            --repo google/osv-scanner \
+            --pattern 'osv-scanner_*_linux_amd64' \
+            --clobber
+          sudo mv osv-scanner_*_linux_amd64 /usr/local/bin/osv-scanner
+          sudo chmod +x /usr/local/bin/osv-scanner
+
+          command -v clamscan
+          clamscan --version
+          command -v trivy
+          trivy --version
+          command -v osv-scanner
+          osv-scanner --version
+
       - name: Validate package metadata
         run: pnpm validate:packages
 
-      - name: Scan package artifacts
-        run: pnpm scan:packages
+      - name: Scan package artifacts with external scanners
+        run: pnpm scan:packages -- --require-scanners

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -230,6 +230,7 @@ const flags = {
     /^content\/skills\/.*\.zip$/,
     /^content\/mcp\/.*\.mcpb$/,
     /^scripts\/(scan-download-packages|validate-download-packages)\.mjs$/,
+    /^\.github\/workflows\/package-artifact-scan\.yml$/,
     "package.json",
     "pnpm-lock.yaml",
   ),


### PR DESCRIPTION
## Summary
- Install ClamAV, Trivy, and OSV-Scanner on the package-scan runners and invoke `pnpm scan:packages -- --require-scanners` so the documented external scanners actually execute.
- Wire the same install + `--require-scanners` path into `content-validation.yml` `validate-packages`, and classify `package-artifact-scan.yml` changes into the packages lane so PRs that touch this workflow get scanner proof.
- Add `pull_request` path triggers to `package-artifact-scan.yml` (including the workflow file itself) and raise package-scan timeouts to 45 minutes for freshclam + archive scanning.

Closes #5228

## Quality evidence
- **No visual impact.** This is a CI/workflow-only change (no UI). Desktop/Tablet/Mobile screenshots do not apply.

## Test plan
- [x] `pnpm exec vitest run tests/download-package-scan.test.ts tests/classify-pr-changes.test.ts`
- [x] `pnpm run scan:packages -- --external-scanners` (structural scan passed locally; ClamAV/Trivy skipped on Windows without installs)
- [x] `git diff --check`
- [ ] CI Actions run on this PR shows clamscan/trivy/osv-scanner installing and executing (link below once the run starts)

## CI proof
_(Will update this section with the Actions run URL once scanners execute on this PR — edit-only, no follow-up commit.)_

Made with [Cursor](https://cursor.com)