### PR TITLE
fix(web): scale k-shorthand compensation so Salary sort compares real dollars

### DIFF
--- a/apps/web/src/lib/jobs-utils-lib.ts
+++ b/apps/web/src/lib/jobs-utils-lib.ts
@@ -54,6 +54,27 @@ export function isFresh(iso: string, now = Date.now()): boolean {
   return daysSince(iso, now) <= 7;
 }
 
+/** Thousands multiplier for a trailing `k`/`K` compensation shorthand (e.g. `$210k`). */
+const COMPENSATION_K_MULTIPLIER = 1000;
+
+/**
+ * Real-dollar sort value for a free-text compensation string, so mixed-format
+ * listings compare on one scale: `"$210k"` and `"$210,000"` both yield `210000`.
+ *
+ * Ranges sort by their leading figure only (e.g. `"$100k-$150k"` → `100000`) —
+ * a deliberate pre-existing limitation of the salary sort, preserved here.
+ *
+ * Missing / empty compensation sorts last (`-1`); an unparseable string stays at `0`.
+ */
+export function compensationSortValue(compensation?: string | null): number {
+  if (!compensation) return -1;
+  // Capture the optional trailing k/K so `"$210k"` scales to 210000, not 210.
+  const m = compensation.match(/\$?(\d[\d,]*)(k)?/i);
+  if (!m) return 0;
+  const base = parseInt(m[1].replace(/,/g, ""), 10);
+  return m[2] ? base * COMPENSATION_K_MULTIPLIER : base;
+}
+
 export function sortJobs(jobs: JobListing[]): JobListing[] {
   const order: Record<JobListing["tier"], number> = {
     sponsored: 0,

--- a/apps/web/src/lib/jobs-utils.ts
+++ b/apps/web/src/lib/jobs-utils.ts
@@ -11,6 +11,7 @@ export {
   daysSince,
   relativePosted,
   isFresh,
+  compensationSortValue,
   sortJobs,
   pickDailySpotlight,
 } from "@/lib/jobs-utils-lib";

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -9,7 +9,13 @@ import type { JobListing, JobTier } from "@/types/registry";
 import { normalizeJobListing } from "@/lib/job-listing-lib";
 import { cn } from "@/lib/utils";
 import { JobCard } from "@/components/job-card";
-import { isFresh, pickDailySpotlight, relativePosted, sortJobs } from "@/lib/jobs-utils";
+import {
+  compensationSortValue,
+  isFresh,
+  pickDailySpotlight,
+  relativePosted,
+  sortJobs,
+} from "@/lib/jobs-utils";
 import { jobsEmptyStateSuggestions } from "@/lib/jobs-empty-state-lib";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -199,12 +205,9 @@ function JobsPage() {
       return [...filtered].sort((a, b) => b.postedAt.localeCompare(a.postedAt));
     }
     if (sortMode === "salary") {
-      const sval = (j: JobListing) => {
-        if (!j.compensation) return -1;
-        const m = j.compensation.match(/\$?(\d[\d,]*)k?/i);
-        return m ? parseInt(m[1].replace(/,/g, ""), 10) : 0;
-      };
-      return [...filtered].sort((a, b) => sval(b) - sval(a));
+      return [...filtered].sort(
+        (a, b) => compensationSortValue(b.compensation) - compensationSortValue(a.compensation),
+      );
     }
     return sortJobs(filtered);
   }, [filtered, sortMode]);

--- a/tests/jobs-utils-lib.test.ts
+++ b/tests/jobs-utils-lib.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { JobListing } from "@/types/registry";
 import {
   companyTint,
+  compensationSortValue,
   daysSince,
   isFresh,
   monogram,
@@ -181,5 +182,50 @@ describe("pickDailySpotlight", () => {
     // "current" vs "next" depends on the day-index rotation.
     const { current, next } = pickDailySpotlight([weak, strong], NOW);
     expect([current?.slug, next?.slug].sort()).toEqual(["strong", "weak"]);
+  });
+});
+
+describe("compensationSortValue", () => {
+  it('scales "k" shorthand to real dollars so mixed formats share one scale', () => {
+    // Regression for #5475: "$210k" sorted as 210 (below "$120,000" at
+    // 120000) because the trailing "k" multiplier was discarded.
+    expect(compensationSortValue("$210k")).toBe(210_000);
+    expect(compensationSortValue("$120,000")).toBe(120_000);
+    expect(compensationSortValue("$210k")).toBeGreaterThan(
+      compensationSortValue("$120,000"),
+    );
+  });
+
+  it("handles uppercase K, unprefixed amounts, and full-dollar figures", () => {
+    expect(compensationSortValue("$95K")).toBe(95_000);
+    expect(compensationSortValue("180k")).toBe(180_000);
+    expect(compensationSortValue("150000")).toBe(150_000);
+    expect(compensationSortValue("$210,000")).toBe(210_000);
+  });
+
+  it("uses the leading figure of a range (deliberate, documented limitation)", () => {
+    expect(compensationSortValue("$100k-$150k")).toBe(100_000);
+    expect(compensationSortValue("$90,000 - $120,000")).toBe(90_000);
+  });
+
+  it("keeps the fallback ordering: missing sorts below unparseable", () => {
+    expect(compensationSortValue(undefined)).toBe(-1);
+    expect(compensationSortValue(null)).toBe(-1);
+    expect(compensationSortValue("")).toBe(-1);
+    expect(compensationSortValue("Competitive")).toBe(0);
+  });
+
+  it("ranks a mixed-format list the same way the Salary sort does", () => {
+    const comps = ["$120,000", "$210k", "Competitive", undefined, "$95K"];
+    const ranked = [...comps].sort(
+      (a, b) => compensationSortValue(b) - compensationSortValue(a),
+    );
+    expect(ranked).toEqual([
+      "$210k",
+      "$120,000",
+      "$95K",
+      "Competitive",
+      undefined,
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Fix the `/jobs` **Salary** sort so mixed compensation formats compare on one real-dollar scale.
- Root cause: in `/$?(\d[\d,]*)k?/i`, the trailing `k` sat **outside** the capture group, so `"$210k"` sorted as `210` and ranked *below* `"$120,000"` (`120000`).
- Extract `compensationSortValue` into `jobs-utils-lib.ts` (testable, documented) and use it from the salary sort branch.

Closes #5475

## Why prior attempts failed (and what this PR does differently)

| Prior PR | What went wrong | This PR |
|---|---|---|
| [#5496](https://github.com/JSONbored/awesome-claude/pull/5496) | Inline-only fix; LoopOver nits asked for unit tests + lib extraction; **auto-closed** for incomplete Desktop/Tablet/Mobile × Light/Dark screenshot matrix | Extracted helper + focused unit tests + **full 6-row before/after matrix** below |
| [#5511](https://github.com/JSONbored/awesome-claude/pull/5511) | Correct lib+tests approach, but still **auto-closed** for the same screenshot-matrix gate | Same solid approach, plus named `COMPENSATION_K_MULTIPLIER`, documented range-leading-figure behavior, and the required screenshot table |

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots included (full viewport × theme matrix).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed routes/components:** `apps/web/src/routes/jobs.index.tsx` (salary sort branch only), `apps/web/src/lib/jobs-utils-lib.ts` / `jobs-utils.ts` (new `compensationSortValue`).
- **Expected behavior:** Salary sort ranks `"$210k"` above `"$120,000"`; missing compensation still sorts last (`-1`); unparseable strings stay at `0`.
- **Invariants / edge cases:** uppercase `K` works; ranges sort by their **leading** figure only (documented deliberate limitation); `"newest"` / default sorts untouched.
- **Backward compatibility:** free-text compensation storage/authoring unchanged; UI chrome unchanged — only list **order** for Salary mode.
- **Focused tests:** `tests/jobs-utils-lib.test.ts` — `compensationSortValue` suite (mixed formats, `K`, ranges, missing/unparseable, full ranking).

### Screenshot evidence

Sort-order evidence for `/jobs` with Salary selected. Layout/theme chrome is unchanged; the labeled rows show the ranking bug vs fix for mixed `"$XXXk"` / `"$XXX,XXX"` listings (the acceptance path allowed by #5475).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-light.png"><img width="360" alt="before desktop light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-light.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-light.png"><img width="360" alt="after desktop light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-light.png"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-dark.png"><img width="360" alt="before desktop dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-dark.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-dark.png"><img width="360" alt="after desktop dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-dark.png"></a> |
| Tablet · Light | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-light-tablet.png"><img width="360" alt="before tablet light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-light-tablet.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-light-tablet.png"><img width="360" alt="after tablet light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-light-tablet.png"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-dark-tablet.png"><img width="360" alt="before tablet dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-dark-tablet.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-dark-tablet.png"><img width="360" alt="after tablet dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-dark-tablet.png"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-light-mobile.png"><img width="360" alt="before mobile light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-light-mobile.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-light-mobile.png"><img width="360" alt="after mobile light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-light-mobile.png"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-dark-mobile.png"><img width="360" alt="before mobile dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/before-dark-mobile.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-dark-mobile.png"><img width="360" alt="after mobile dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5475-salary-sort/shots/after-dark-mobile.png"></a> |

## Validation

- [x] `pnpm exec vitest run tests/jobs-utils-lib.test.ts` — **21 passed**
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — succeeds
- [x] `git diff --check` — clean
- [x] No generated artifacts committed

## Notes

- Supersedes closed [#5496](https://github.com/JSONbored/awesome-claude/pull/5496) and [#5511](https://github.com/JSONbored/awesome-claude/pull/5511).
- Scope matches #5475 exactly: salary `sval` / `compensationSortValue` only.
