### PR TITLE
fix(web): stop nesting GitHub anchor inside contributors card Link

### DIFF
--- a/apps/web/src/routes/contributors.index.tsx
+++ b/apps/web/src/routes/contributors.index.tsx
@@ -178,40 +178,45 @@ function ContributorsPage() {
         {rest.map((c, rowIndex) => {
           const destination = contributorsIndexProfileDestination(c.slug);
           if (!destination) return null;
+          // Match the featured "Top contributor" card: outer non-link shell with
+          // profile <Link> and GitHub <a> as siblings (no nested anchors).
           return (
-            <Link
+            <div
               key={c.slug}
-              to={destination.to}
-              params={destination.params}
-              onClick={() =>
-                trackEvent(
-                  contributorsIndexProfileAnalyticsEvent(),
-                  contributorsIndexProfileAnalyticsData(
-                    c.slug,
-                    c.acceptedCount,
-                    rowIndex,
-                    sorted.length,
-                  ),
-                )
-              }
               className="group hover-lift flex items-center gap-3 rounded-xl border border-border bg-surface p-4 transition-[border-color,background-color] duration-200 ease-out hover:border-ink/20 hover:bg-surface-2"
             >
-              <Monogram name={c.name || c.handle} size={40} className="rounded-full" />
-              <div className="min-w-0 flex-1">
-                <div className="truncate font-display text-sm font-semibold text-ink transition-colors duration-200 ease-out group-hover:text-ink-hover">
-                  {c.name}
+              <Link
+                to={destination.to}
+                params={destination.params}
+                onClick={() =>
+                  trackEvent(
+                    contributorsIndexProfileAnalyticsEvent(),
+                    contributorsIndexProfileAnalyticsData(
+                      c.slug,
+                      c.acceptedCount,
+                      rowIndex,
+                      sorted.length,
+                    ),
+                  )
+                }
+                className="flex min-w-0 flex-1 items-center gap-3 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+              >
+                <Monogram name={c.name || c.handle} size={40} className="rounded-full" />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-display text-sm font-semibold text-ink transition-colors duration-200 ease-out group-hover:text-ink-hover">
+                    {c.name}
+                  </div>
+                  <div className="truncate text-xs text-ink-muted">
+                    @{c.handle} · {contributorCardSummary(c)}
+                  </div>
                 </div>
-                <div className="truncate text-xs text-ink-muted">
-                  @{c.handle} · {contributorCardSummary(c)}
-                </div>
-              </div>
+              </Link>
               {c.github && (
                 <a
                   href={c.github}
                   target="_blank"
                   rel="noreferrer"
-                  onClick={(e) => {
-                    e.stopPropagation();
+                  onClick={() =>
                     trackEvent(
                       contributorsIndexGithubAnalyticsEvent(),
                       contributorsIndexGithubAnalyticsData(
@@ -221,15 +226,15 @@ function ContributorsPage() {
                         rowIndex,
                         sorted.length,
                       ),
-                    );
-                  }}
-                  className="text-ink-subtle hover:text-ink"
+                    )
+                  }
+                  className="shrink-0 text-ink-subtle hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
                   aria-label={`${c.handle} on GitHub`}
                 >
                   <Github className="h-3.5 w-3.5" />
                 </a>
               )}
-            </Link>
+            </div>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary

- Fix invalid nested anchors on `/contributors` grid cards: the card was a `<Link>` wrapping a GitHub `<a>`.
- Restructure to match the already-correct **Top contributor** featured card: outer non-link shell with profile `<Link>` and GitHub `<a>` as **siblings**.
- Same anti-pattern class as the `integration-card.tsx` nested-link fix (`bb54fd79`); keeps both click targets working without `stopPropagation` papering over invalid HTML.

Closes #5474

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots included (Desktop/Tablet/Mobile × Light/Dark).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed routes:** `apps/web/src/routes/contributors.index.tsx` (contributor grid card block only, ~lines 180–250).
- **Expected behavior:** No `<a>` nested inside another `<a>`/`<Link>` on the grid cards. Card body still navigates to the profile; GitHub icon still opens `c.github` in a new tab and fires the existing analytics event.
- **Reference pattern:** Identical sibling layout already used by the featured Top contributor block in this same file; `integration-card.tsx` removed its nested link entirely — here we keep the GitHub egress as a sibling `<a>` so behavior is preserved.
- **Out of scope (untouched):** featured card, stats links, submit CTA, `integration-card.tsx`.
- **Accessibility:** profile `Link` and GitHub `<a>` each have their own focus ring; GitHub `aria-label` retained.
- **DOM check (Elements):** after the change, structure is `div.card > Link + a` (siblings), not `Link > a`.

### Screenshot evidence

Card chrome is intentionally unchanged visually; annotations call out the DOM structure before vs after (acceptance: desktop + mobile screenshots of unchanged cards).

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-light.png"><img width="360" alt="before desktop light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-light.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-light.png"><img width="360" alt="after desktop light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-light.png"></a> |
| Desktop · Dark | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-dark.png"><img width="360" alt="before desktop dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-dark.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-dark.png"><img width="360" alt="after desktop dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-dark.png"></a> |
| Tablet · Light | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-light-tablet.png"><img width="360" alt="before tablet light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-light-tablet.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-light-tablet.png"><img width="360" alt="after tablet light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-light-tablet.png"></a> |
| Tablet · Dark | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-dark-tablet.png"><img width="360" alt="before tablet dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-dark-tablet.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-dark-tablet.png"><img width="360" alt="after tablet dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-dark-tablet.png"></a> |
| Mobile · Light | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-light-mobile.png"><img width="360" alt="before mobile light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-light-mobile.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-light-mobile.png"><img width="360" alt="after mobile light" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-light-mobile.png"></a> |
| Mobile · Dark | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-dark-mobile.png"><img width="360" alt="before mobile dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/before-dark-mobile.png"></a> | <a href="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-dark-mobile.png"><img width="360" alt="after mobile dark" src="https://raw.githubusercontent.com/wondercreatemaster/awesome-claude/pr-assets-5474-nested-anchor/shots/after-dark-mobile.png"></a> |

## Validation

- [x] `pnpm exec prettier --check apps/web/src/routes/contributors.index.tsx` — clean
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — succeeds
- [x] `git diff --check` — clean
- [x] No generated artifacts committed

## Notes

- No prior open/closed PRs against #5474 at start of work.
- One-file, one-commit PR.

Made with [Cursor](https://cursor.com)