### PR TITLE
fix(mcp): reject reserved GitHub owners in isPublicGitHubProfileUrl

### DIFF
--- a/packages/mcp/src/public-url-lib.js
+++ b/packages/mcp/src/public-url-lib.js
@@ -5,6 +5,52 @@
  * @heyclaude/registry, so packed tarballs stay self-contained.
  */
 
+/**
+ * Single-segment github.com paths that are product/marketing surfaces, not
+ * user accounts. Kept in sync with `RESERVED_OWNERS` in
+ * `packages/registry/src/source-repo-lib.js` — inlined here so the MCP tarball
+ * stays free of a registry dependency.
+ */
+export const RESERVED_OWNERS = new Set([
+  "about",
+  "account",
+  "apps",
+  "business",
+  "codespaces",
+  "collections",
+  "contact",
+  "customer-stories",
+  "dashboard",
+  "education",
+  "enterprise",
+  "explore",
+  "features",
+  "issues",
+  "join",
+  "login",
+  "logout",
+  "marketplace",
+  "new",
+  "nonprofits",
+  "notifications",
+  "organizations",
+  "orgs",
+  "pricing",
+  "pulls",
+  "readme",
+  "search",
+  "security",
+  "sessions",
+  "settings",
+  "signup",
+  "sponsors",
+  "stars",
+  "team",
+  "topics",
+  "trending",
+  "watching",
+]);
+
 function parseUrl(value) {
   const text = String(value ?? "").trim();
   if (!text) return null;
@@ -31,16 +77,28 @@ export function isPublicHttpsUrl(value) {
   );
 }
 
+/**
+ * Return true for a single-segment GitHub profile URL without embedded userinfo.
+ *
+ * The single path segment must be a real account name, not a GitHub product
+ * surface (`github.com/features`, `/sponsors`, `/about`, …). Mirrors the
+ * registry `isPublicGitHubProfileUrl` classifier.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
 export function isPublicGitHubProfileUrl(value) {
   const url = parseUrl(value);
   if (!url) return false;
+  const segments = url.pathname.split("/").filter(Boolean);
   const hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
   return (
     url.protocol === "https:" &&
     url.username === "" &&
     url.password === "" &&
     hostname === "github.com" &&
-    url.pathname.split("/").filter(Boolean).length === 1
+    segments.length === 1 &&
+    !RESERVED_OWNERS.has(segments[0].toLowerCase())
   );
 }
 

--- a/tests/mcp-public-url-lib.test.ts
+++ b/tests/mcp-public-url-lib.test.ts
@@ -289,12 +289,23 @@ describe("public URL helper integration", () => {
 });
 
 describe("isPublicGitHubProfileUrl reserved paths", () => {
+  // Regression for #5507: reserved product/marketing pages must not pass as
+  // profiles (parity with packages/registry/src/source-url-lib.js).
   it.each([
-    ["https://github.com/login", true],
-    ["https://github.com/explore", true],
-    ["https://github.com/marketplace", true],
-  ])("treats single-segment reserved path %s as profile-shaped URL", (url) => {
-    expect(isPublicGitHubProfileUrl(url)).toBe(true);
+    ["https://github.com/features", false],
+    ["https://github.com/sponsors", false],
+    ["https://github.com/about", false],
+    ["https://github.com/login", false],
+    ["https://github.com/explore", false],
+    ["https://github.com/marketplace", false],
+    ["https://github.com/apps", false],
+    ["https://www.github.com/Features", false],
+  ])("rejects reserved single-segment path %s", (url, expected) => {
+    expect(isPublicGitHubProfileUrl(url)).toBe(expected);
+  });
+
+  it("still accepts a real profile URL", () => {
+    expect(isPublicGitHubProfileUrl("https://github.com/torvalds")).toBe(true);
   });
 });
 
@@ -392,7 +403,8 @@ describe("isPublicGitHubProfileUrl path segmentation", () => {
     ["https://github.com/orgs/acme/people", false],
     ["https://github.com/sponsors/octocat", false],
     ["https://github.com/features/copilot", false],
-    ["https://github.com/enterprise", true],
+    // single-segment reserved owner (enterprise), not a profile
+    ["https://github.com/enterprise", false],
   ])("profile check for %s => %s", (url, expected) => {
     expect(isPublicGitHubProfileUrl(url)).toBe(expected);
   });


### PR DESCRIPTION
## Summary

- Bring the MCP package's `isPublicGitHubProfileUrl` in sync with the registry classifier: reject single-segment reserved GitHub product/marketing paths (`/features`, `/sponsors`, `/about`, …).
- Inline a local `RESERVED_OWNERS` set in `packages/mcp/src/public-url-lib.js` (same members as `packages/registry/src/source-repo-lib.js`) — no cross-package import, so packed tarballs stay self-contained.
- Update unit tests that previously treated reserved paths as valid profiles.

Closes #5507

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots: **No visual impact** (MCP package validation only; no routes/UI).
- [x] Links the issue it resolves.

## Quality Evidence

- **Changed surface:** `packages/mcp/src/public-url-lib.js` (`RESERVED_OWNERS` + `isPublicGitHubProfileUrl`); `tests/mcp-public-url-lib.test.ts`.
- **Expected behavior:**
  - `isPublicGitHubProfileUrl("https://github.com/features")` → `false`
  - `…/sponsors`, `…/about` → `false`
  - `isPublicGitHubProfileUrl("https://github.com/torvalds")` → `true`
- **Invariant:** MCP contact validation via `isPublicContact` now rejects the same reserved owners the registry-side submission pipeline already rejects.
- **Out of scope:** no cross-package import; other helpers in this file untouched.
- **Screenshots:** No visual impact — package-internal validation fix; unit tests are the proof.

## Validation

- [x] `pnpm exec vitest run tests/mcp-public-url-lib.test.ts` — **170 passed**
- [x] `pnpm test:mcp` — **72 passed**
- [x] `pnpm validate:mcp-package` — validated packed `@heyclaude/mcp@0.13.0`
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean

## Notes

- No prior open/closed PRs against #5507 at start of work.
- One-shot commit; two files only.
