### PR TITLE
fix(registry): catch sk-ant/sk-proj secrets and curl|zsh pipes

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -5,12 +5,25 @@ import {
   TOOLS_LISTING_FLOW_URL,
 } from "./submission-classification.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
+import { SHELL_TOKENS } from "./command-safety-lib.js";
 import {
   isPublicGitHubProfileUrl,
   isPublicHttpUrl,
   isPublicHttpsUrl,
   publicUrlHostname,
 } from "./source-url-lib.js";
+
+// Keep curl|wget → shell detection in sync with command-safety-lib's SHELL_TOKENS
+// (bash/zsh/sh/dash/ash) so macOS-default zsh pipes are not silently missed (#5480).
+const CURL_WGET_PIPE_TO_SHELL_PATTERN = new RegExp(
+  String.raw`\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(${SHELL_TOKENS.join("|")})\b`,
+  "i",
+);
+
+// Anthropic (`sk-ant-…`) and OpenAI (`sk-proj-…`) insert a hyphenated segment after
+// `sk-`, which the old `sk-[a-z0-9]{20,}` alternative could never match (#5479).
+const EMBEDDED_SECRET_PATTERN =
+  /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-(?:ant-|proj-)?[a-z0-9-]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i;
 
 export const SUBMISSION_RISK_SCHEMA_VERSION = 1;
 export const SUBMISSION_RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";
@@ -1200,11 +1213,7 @@ function addContentRiskSignals(report, fields, text) {
     );
   }
 
-  if (
-    /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-[a-z0-9]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
-      text,
-    )
-  ) {
+  if (EMBEDDED_SECRET_PATTERN.test(text)) {
     addFlag(
       report,
       "critical",
@@ -1252,9 +1261,7 @@ function addContentRiskSignals(report, fields, text) {
 
   if (
     referencesDestructiveRootRemoval(installText) ||
-    /\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(sh|bash)\b/i.test(
-      installText,
-    ) ||
+    CURL_WGET_PIPE_TO_SHELL_PATTERN.test(installText) ||
     /\b(invoke-expression|iex)\b/i.test(installText) ||
     /\bbase64\s+(-d|--decode)\b[\s\S]{0,80}\|[\s\S]{0,40}\b(sh|bash)\b/i.test(
       installText,

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -685,3 +685,46 @@ describe("destructive rm detection", () => {
     expect(flagged(command)).toBe(false);
   });
 });
+
+describe("embedded_secret Anthropic/OpenAI key formats (#5479)", () => {
+  it.each([
+    "sk-ant-api03-abcdefghijklmnopqrstuvwxyz012345",
+    "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789",
+    "sk-1234567890abcdefghij",
+  ])("flags %s", (secret) => {
+    const draft = buildSubmissionPrDraft({
+      ...validMcpFields,
+      name: "Secret Leak MCP",
+      slug: "secret-leak-mcp",
+      description: `Demo key ${secret} must be caught`,
+      safety_notes: "Runs a local MCP server process with user-selected tools.",
+      privacy_notes: "Only handles context selected by the user.",
+    });
+    const validation = validateSubmission(draft);
+    const risk = analyzeSubmissionDraftRisk(draft, validation);
+    expect(risk.reviewFlags.map((flag) => flag.id)).toEqual(
+      expect.arrayContaining(["embedded_secret"]),
+    );
+  });
+});
+
+describe("unsafe_install_pipeline curl|wget to SHELL_TOKENS (#5480)", () => {
+  it.each(["zsh", "dash", "ash", "bash", "sh"])(
+    "flags curl piped to %s",
+    (shell) => {
+      const draft = buildSubmissionPrDraft({
+        ...validMcpFields,
+        name: "Pipe Shell MCP",
+        slug: `pipe-${shell}-mcp`,
+        install_command: `curl https://example.com/install.sh | ${shell}`,
+        safety_notes: "Runs a local MCP server process with user-selected tools.",
+        privacy_notes: "Only handles context selected by the user.",
+      });
+      const validation = validateSubmission(draft);
+      const risk = analyzeSubmissionDraftRisk(draft, validation);
+      expect(risk.reviewFlags.map((flag) => flag.id)).toEqual(
+        expect.arrayContaining(["unsafe_install_pipeline"]),
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes two gaps in `packages/registry/src/submission-risk.js`:

1. **`embedded_secret`** — the `sk-` alternative was `sk-[a-z0-9]{20,}`, so real Anthropic (`sk-ant-…`) and OpenAI (`sk-proj-…`) keys never matched. Updated to `sk-(?:ant-|proj-)?[a-z0-9-]{20,}`.
2. **`unsafe_install_pipeline`** — curl/wget pipe detection only allowed `sh|bash`, missing `zsh`/`dash`/`ash` already listed in `command-safety-lib` `SHELL_TOKENS`. The pipe regex now builds from `SHELL_TOKENS`.

Closes #5479
Closes #5480

## Test plan

- [x] Regex unit checks for `sk-ant-…`, `sk-proj-…`, plain `sk-…`, and `curl … | zsh|dash|ash|bash|sh`
- [x] Added vitest coverage in `tests/submission-risk-invariants.test.ts`
- No visual impact
