### PR TITLE
fix(web): export filtered compatibility-matrix rows as CSV

### DIFF
--- a/apps/web/src/components/compatibility-matrix.tsx
+++ b/apps/web/src/components/compatibility-matrix.tsx
@@ -93,8 +93,9 @@ export function CompatibilityMatrix({
   }, [rows, query]);
 
   const downloadCsv = () => {
-    onCsvDownloadClick?.(rows.length, clients.length);
-    const csv = buildCompatibilityCsv(clients, rows, (support) => SUPPORT_META[support].label);
+    // Export the filtered table the user sees, not the full unfiltered matrix (#5505).
+    onCsvDownloadClick?.(filtered.length, clients.length);
+    const csv = buildCompatibilityCsv(clients, filtered, (support) => SUPPORT_META[support].label);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");


### PR DESCRIPTION
## Summary

`/ecosystem` compatibility-matrix CSV export used the full unfiltered `rows` prop while the table renders the search-narrowed `filtered` set. Export now uses `filtered` (and reports `filtered.length` to analytics).

Closes #5505

## Test plan

- [ ] Filter capabilities, download CSV — only visible rows appear
- [ ] Clear filter, download CSV — full matrix
- No visual impact (export behavior only)
