### PR TITLE
fix(web): guard admin jobs with legal state transitions

### DIFF
--- a/apps/web/src/lib/job-admin-lib.ts
+++ b/apps/web/src/lib/job-admin-lib.ts
@@ -170,6 +170,84 @@ export class JobNotFoundError extends Error {
   }
 }
 
+export class JobInvalidTransitionError extends Error {
+  currentStatus: JobStatus;
+  action: JobAdminAction;
+
+  constructor(currentStatus: JobStatus, action: JobAdminAction) {
+    super(`Invalid job admin transition: ${action} from ${currentStatus}`);
+    this.name = "JobInvalidTransitionError";
+    this.currentStatus = currentStatus;
+    this.action = action;
+  }
+}
+
+const JOB_STATUSES: readonly JobStatus[] = [
+  "draft",
+  "pending_review",
+  "active",
+  "stale_pending_review",
+  "closed",
+  "archived",
+];
+
+function normalizeJobStatus(status: string | null | undefined): JobStatus {
+  const normalized = String(status || "")
+    .trim()
+    .toLowerCase();
+  return (JOB_STATUSES as readonly string[]).includes(normalized)
+    ? (normalized as JobStatus)
+    : "draft";
+}
+
+/**
+ * Legal next status for a jobs admin action, or `null` when the action is
+ * illegal from the current status. `revalidate` never changes status and is
+ * allowed from any known status (returns the current status).
+ *
+ * Mirror of `nextLeadStatus` for listing-leads — activate first-publishes from
+ * draft/pending_review; reactivate reopens stale/closed; stale only from active.
+ */
+export function nextJobStatus(
+  currentStatus: string | null | undefined,
+  action: JobAdminAction,
+): JobStatus | null {
+  const current = normalizeJobStatus(currentStatus);
+  if (action === "revalidate") return current;
+
+  const transitions: Record<JobStatus, Partial<Record<JobAdminAction, JobStatus>>> = {
+    draft: {
+      review: "pending_review",
+      activate: "active",
+      archive: "archived",
+    },
+    pending_review: {
+      activate: "active",
+      close: "closed",
+      archive: "archived",
+    },
+    active: {
+      stale: "stale_pending_review",
+      close: "closed",
+      expire: "closed",
+      archive: "archived",
+    },
+    stale_pending_review: {
+      reactivate: "active",
+      close: "closed",
+      expire: "closed",
+      archive: "archived",
+    },
+    closed: {
+      reactivate: "active",
+      archive: "archived",
+    },
+    archived: {},
+  };
+
+  return transitions[current]?.[action] ?? null;
+}
+
 function assertJobPublicationQuality(job: Record<string, unknown>) {
   const report = validateJobPublicExposure(job);
   if (!report.ok) {
@@ -436,9 +514,16 @@ export async function updateAdminJobState(
   const hasExpiresAt = Object.prototype.hasOwnProperty.call(input, "expiresAt");
   const expiresAt = input.expiresAt === null ? null : optionalText(input.expiresAt);
 
+  const existing = await queryAdminJobBySlug(db, input.slug);
+  if (!existing) throw new JobNotFoundError(input.slug);
+
+  const currentStatus = normalizeJobStatus(existing.status);
+  const nextStatus = nextJobStatus(currentStatus, input.action);
+  if (nextStatus === null) {
+    throw new JobInvalidTransitionError(currentStatus, input.action);
+  }
+
   if (input.action === "activate" || input.action === "reactivate") {
-    const existing = await queryAdminJobBySlug(db, input.slug);
-    if (!existing) throw new JobNotFoundError(input.slug);
     assertJobPublicationQuality({
       ...existing,
       status: "active",
@@ -484,16 +569,6 @@ export async function updateAdminJobState(
     }
     return;
   }
-
-  const nextStatusByAction: Record<Exclude<JobAdminAction, "revalidate" | "stale">, JobStatus> = {
-    review: "pending_review",
-    activate: "active",
-    close: "closed",
-    archive: "archived",
-    reactivate: "active",
-    expire: "closed",
-  };
-  const nextStatus = nextStatusByAction[input.action];
 
   const result = await db
     .prepare(

--- a/apps/web/src/lib/job-admin.ts
+++ b/apps/web/src/lib/job-admin.ts
@@ -5,12 +5,14 @@
  * surface so existing `@/lib/job-admin` imports stay unchanged.
  */
 export {
+  JobInvalidTransitionError,
   JobNotFoundError,
   JobPublicationQualityError,
   REQUIRED_JOB_COLUMNS,
   REQUIRED_JOBS_MIGRATION,
   checkJobsSchema,
   getJobsHealth,
+  nextJobStatus,
   queryAdminJobBySlug,
   queryAdminJobs,
   updateAdminJobState,

--- a/apps/web/src/routes/api/admin/jobs.ts
+++ b/apps/web/src/routes/api/admin/jobs.ts
@@ -17,6 +17,7 @@ import { logApiError, logApiInfo, logApiWarn } from "@/lib/api-logs";
 import { getSiteDb } from "@/lib/db";
 import {
   checkJobsSchema,
+  JobInvalidTransitionError,
   JobNotFoundError,
   JobPublicationQualityError,
   queryAdminJobs,
@@ -138,6 +139,20 @@ export const PATCH = createApiHandler("adminJobs.update", async ({ request, body
       return apiError("job_quality_gate_failed", 400, {
         requestId,
         details: caught.errors,
+      });
+    }
+    if (caught instanceof JobInvalidTransitionError) {
+      logApiWarn(request, "admin.jobs.invalid_transition", {
+        slug: payload.slug,
+        action: payload.action,
+        currentStatus: caught.currentStatus,
+      });
+      return apiError("invalid_transition", 400, {
+        requestId,
+        details: {
+          action: caught.action,
+          currentStatus: caught.currentStatus,
+        },
       });
     }
     if (caught instanceof JobNotFoundError) {

--- a/tests/d1-dynamic-state.test.ts
+++ b/tests/d1-dynamic-state.test.ts
@@ -942,6 +942,18 @@ describe("D1 dynamic state helpers", () => {
     ).resolves.toMatchObject({ slug: "reviewed-ai-engineer" });
     await expect(queryAdminJobBySlug(db, "missing-role")).resolves.toBeNull();
 
+    // Source-check automation only runs against active (and stale) rows; promote
+    // here so revalidate/stale stay on the legal lifecycle path without re-testing
+    // the activate quality gate (covered elsewhere).
+    db.jobRows[0] = {
+      ...db.jobRows[0],
+      status: "active",
+      description_md:
+        "Own Claude workflow systems with source verification, external apply links, and private D1-backed publication state for production teams.",
+      source_checked_at: "2026-04-28T00:00:00.000Z",
+      last_checked_at: "2026-04-28T00:00:00.000Z",
+    };
+
     await updateAdminJobState(db, {
       slug: "reviewed-ai-engineer",
       action: "revalidate",

--- a/tests/job-admin-lib.test.ts
+++ b/tests/job-admin-lib.test.ts
@@ -4,10 +4,12 @@ import type { D1DatabaseLike, D1RunResult } from "../apps/web/src/lib/db";
 import {
   REQUIRED_JOB_COLUMNS,
   REQUIRED_JOBS_MIGRATION,
+  JobInvalidTransitionError,
   JobNotFoundError,
   JobPublicationQualityError,
   checkJobsSchema,
   getJobsHealth,
+  nextJobStatus,
   queryAdminJobBySlug,
   queryAdminJobs,
   updateAdminJobState,
@@ -821,47 +823,85 @@ describe("upsertAdminJob", () => {
   });
 });
 
-describe("updateAdminJobState", () => {
-  it.each([
-    ["review", "pending_review"],
-    ["activate", "active"],
-    ["close", "closed"],
-    ["archive", "archived"],
-    ["reactivate", "active"],
-    ["expire", "closed"],
-  ] as const)("maps action %s to status %s", async (action, expectedStatus) => {
-    const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: `${action}-role` })];
-    await updateAdminJobState(db, { slug: `${action}-role`, action });
-    expect(db.runCalls.at(-1)?.query).toContain("status = ?");
-    expect(db.runCalls.at(-1)?.values).toContain(expectedStatus);
+describe("nextJobStatus", () => {
+  it("allows legal lifecycle transitions", () => {
+    expect(nextJobStatus("draft", "review")).toBe("pending_review");
+    expect(nextJobStatus("draft", "activate")).toBe("active");
+    expect(nextJobStatus("pending_review", "activate")).toBe("active");
+    expect(nextJobStatus("active", "stale")).toBe("stale_pending_review");
+    expect(nextJobStatus("active", "close")).toBe("closed");
+    expect(nextJobStatus("active", "expire")).toBe("closed");
+    expect(nextJobStatus("stale_pending_review", "reactivate")).toBe("active");
+    expect(nextJobStatus("closed", "reactivate")).toBe("active");
+    expect(nextJobStatus("active", "revalidate")).toBe("active");
   });
 
-  it.each(["close", "archive", "expire", "review"] as const)(
-    "persists checkedAt for action %s",
-    async (action) => {
-      // scripts/check-d1-job-sources.mjs sends checkedAt when it closes a job
-      // for a dead source; that timestamp justifies the closure and was
-      // previously dropped for these four actions.
+  it("blocks illegal action/status pairs that were previously unconstrained", () => {
+    expect(nextJobStatus("archived", "activate")).toBeNull();
+    expect(nextJobStatus("closed", "activate")).toBeNull();
+    expect(nextJobStatus("draft", "stale")).toBeNull();
+    expect(nextJobStatus("pending_review", "stale")).toBeNull();
+    expect(nextJobStatus("active", "reactivate")).toBeNull();
+    expect(nextJobStatus("draft", "reactivate")).toBeNull();
+    expect(nextJobStatus("archived", "stale")).toBeNull();
+    expect(nextJobStatus("archived", "reactivate")).toBeNull();
+    expect(nextJobStatus("pending_review", "expire")).toBeNull();
+    expect(nextJobStatus("pending_review", "review")).toBeNull();
+  });
+});
+
+describe("updateAdminJobState", () => {
+  it.each([
+    ["draft", "review", "pending_review"],
+    ["pending_review", "activate", "active"],
+    ["active", "close", "closed"],
+    ["active", "archive", "archived"],
+    ["stale_pending_review", "reactivate", "active"],
+    ["active", "expire", "closed"],
+  ] as const)(
+    "maps %s + %s to %s",
+    async (fromStatus, action, expectedStatus) => {
       const db = new FakeD1();
-      db.jobRows = [validActiveJobRow({ slug: `${action}-checked` })];
-      await updateAdminJobState(db, {
-        slug: `${action}-checked`,
-        action,
-        checkedAt: VALID_CHECKED_AT,
-      });
-      const call = db.runCalls.at(-1);
-      expect(call?.query).toContain("source_checked_at = ?");
-      expect(call?.query).toContain("last_checked_at = ?");
-      expect(call?.values).toContain(VALID_CHECKED_AT);
+      db.jobRows = [
+        validActiveJobRow({ slug: `${action}-role`, status: fromStatus }),
+      ];
+      await updateAdminJobState(db, { slug: `${action}-role`, action });
+      expect(db.runCalls.at(-1)?.query).toContain("status = ?");
+      expect(db.runCalls.at(-1)?.values).toContain(expectedStatus);
     },
   );
+
+  it.each([
+    ["active", "close"],
+    ["active", "archive"],
+    ["active", "expire"],
+    ["draft", "review"],
+  ] as const)("persists checkedAt for %s + %s", async (fromStatus, action) => {
+    // scripts/check-d1-job-sources.mjs sends checkedAt when it closes a job
+    // for a dead source; that timestamp justifies the closure and was
+    // previously dropped for these four actions.
+    const db = new FakeD1();
+    db.jobRows = [
+      validActiveJobRow({ slug: `${action}-checked`, status: fromStatus }),
+    ];
+    await updateAdminJobState(db, {
+      slug: `${action}-checked`,
+      action,
+      checkedAt: VALID_CHECKED_AT,
+    });
+    const call = db.runCalls.at(-1);
+    expect(call?.query).toContain("source_checked_at = ?");
+    expect(call?.query).toContain("last_checked_at = ?");
+    expect(call?.values).toContain(VALID_CHECKED_AT);
+  });
 
   it("keeps the stale_check_count reset scoped to activate/reactivate", async () => {
     // Only activate/reactivate mean the source is healthy again, so closing or
     // archiving must not wipe the accumulated stale history.
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "close-history" })];
+    db.jobRows = [
+      validActiveJobRow({ slug: "close-history", status: "active" }),
+    ];
     await updateAdminJobState(db, {
       slug: "close-history",
       action: "close",
@@ -875,7 +915,11 @@ describe("updateAdminJobState", () => {
   it("marks a job stale and increments stale_check_count", async () => {
     const db = new FakeD1();
     db.jobRows = [
-      validActiveJobRow({ slug: "stale-role", stale_check_count: 2 }),
+      validActiveJobRow({
+        slug: "stale-role",
+        status: "active",
+        stale_check_count: 2,
+      }),
     ];
     await updateAdminJobState(db, {
       slug: "stale-role",
@@ -890,7 +934,11 @@ describe("updateAdminJobState", () => {
   it("revalidates source timestamps and clears stale_check_count", async () => {
     const db = new FakeD1();
     db.jobRows = [
-      validActiveJobRow({ slug: "revalidate-role", stale_check_count: 4 }),
+      validActiveJobRow({
+        slug: "revalidate-role",
+        status: "active",
+        stale_check_count: 4,
+      }),
     ];
     await updateAdminJobState(db, {
       slug: "revalidate-role",
@@ -906,7 +954,9 @@ describe("updateAdminJobState", () => {
 
   it("revalidate can explicitly clear expires_at with null", async () => {
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "clear-expiry-role" })];
+    db.jobRows = [
+      validActiveJobRow({ slug: "clear-expiry-role", status: "active" }),
+    ];
     await updateAdminJobState(db, {
       slug: "clear-expiry-role",
       action: "revalidate",
@@ -917,7 +967,7 @@ describe("updateAdminJobState", () => {
 
   it("uses the current timestamp when checkedAt is omitted", async () => {
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "now-role" })];
+    db.jobRows = [validActiveJobRow({ slug: "now-role", status: "active" })];
     await updateAdminJobState(db, { slug: "now-role", action: "stale" });
     const checkedAt = String(db.runCalls.at(-1)?.values[0] ?? "");
     expect(checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
@@ -968,6 +1018,24 @@ describe("updateAdminJobState", () => {
   });
 
   it.each([
+    ["archived", "activate"],
+    ["closed", "activate"],
+    ["draft", "stale"],
+    ["active", "reactivate"],
+  ] as const)(
+    "rejects illegal transition %s + %s",
+    async (fromStatus, action) => {
+      const db = new FakeD1();
+      db.jobRows = [
+        validActiveJobRow({ slug: "illegal-role", status: fromStatus }),
+      ];
+      await expect(
+        updateAdminJobState(db, { slug: "illegal-role", action }),
+      ).rejects.toBeInstanceOf(JobInvalidTransitionError);
+    },
+  );
+
+  it.each([
     ["revalidate"],
     ["stale"],
     ["close"],
@@ -993,7 +1061,9 @@ describe("updateAdminJobState", () => {
 
   it("passes expiresAt through status updates when provided", async () => {
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "expire-at-role" })];
+    db.jobRows = [
+      validActiveJobRow({ slug: "expire-at-role", status: "active" }),
+    ];
     await updateAdminJobState(db, {
       slug: "expire-at-role",
       action: "close",
@@ -1004,20 +1074,25 @@ describe("updateAdminJobState", () => {
   });
 
   it.each([
-    ["review"],
-    ["activate"],
-    ["close"],
-    ["archive"],
-    ["reactivate"],
-    ["expire"],
-  ])(
-    "includes reactivation reset fields for %s when applicable",
-    async (action) => {
+    ["draft", "review"],
+    ["pending_review", "activate"],
+    ["active", "close"],
+    ["active", "archive"],
+    ["closed", "reactivate"],
+    ["active", "expire"],
+  ] as const)(
+    "includes reactivation reset fields for %s + %s when applicable",
+    async (fromStatus, action) => {
       const db = new FakeD1();
-      db.jobRows = [validActiveJobRow({ slug: `${action}-reset-role` })];
+      db.jobRows = [
+        validActiveJobRow({
+          slug: `${action}-reset-role`,
+          status: fromStatus,
+        }),
+      ];
       await updateAdminJobState(db, {
         slug: `${action}-reset-role`,
-        action: action as "review",
+        action,
         checkedAt: VALID_CHECKED_AT,
       });
       const query = db.runCalls.at(-1)?.query ?? "";
@@ -1038,22 +1113,24 @@ describe("updateAdminJobState", () => {
   });
 
   it.each([
-    ["review", "pending_review"],
-    ["activate", "active"],
-    ["close", "closed"],
-    ["archive", "archived"],
-    ["reactivate", "active"],
-    ["expire", "closed"],
-    ["stale", "stale_pending_review"],
-    ["revalidate", "pending_review"],
+    ["draft", "review"],
+    ["pending_review", "activate"],
+    ["active", "close"],
+    ["active", "archive"],
+    ["stale_pending_review", "reactivate"],
+    ["active", "expire"],
+    ["active", "stale"],
+    ["active", "revalidate"],
   ] as const)(
-    "runs %s without expiresAt override",
-    async (action, _expectedStatus) => {
+    "runs %s + %s without expiresAt override",
+    async (fromStatus, action) => {
       const db = new FakeD1();
-      db.jobRows = [validActiveJobRow({ slug: `${action}-no-expiry` })];
+      db.jobRows = [
+        validActiveJobRow({ slug: `${action}-no-expiry`, status: fromStatus }),
+      ];
       await updateAdminJobState(db, {
         slug: `${action}-no-expiry`,
-        action: action === "stale" || action === "revalidate" ? action : action,
+        action,
         checkedAt: VALID_CHECKED_AT,
       });
       expect(db.runCalls.at(-1)?.values.at(-1)).toBe(`${action}-no-expiry`);


### PR DESCRIPTION
## Summary
- Decision **(a)** for #5270: add an explicit jobs admin transition table (`nextJobStatus`) matching listing-leads.
- Illegal action/status pairs now throw `JobInvalidTransitionError`; the admin jobs PATCH route returns `400 invalid_transition`.
- Content-quality gate on activate/reactivate is unchanged.

Closes #5270

## Quality evidence
- **No visual impact.** Admin API / lib-only behavior change.

### Newly blocked (was previously allowed)
| Current status | Action | Notes |
| --- | --- | --- |
| `archived` | `activate`, `reactivate`, `stale`, `close`, `expire`, `review`, `archive` | archived is terminal |
| `closed` | `activate`, `stale`, `review`, `expire`, `close` | use `reactivate` / `archive` |
| `draft` | `stale`, `reactivate`, `close`, `expire` | use `review` / `activate` / `archive` |
| `pending_review` | `stale`, `reactivate`, `expire`, `review` | use `activate` / `close` / `archive` |
| `active` | `activate`, `reactivate`, `review` | use `stale` / `close` / `expire` / `archive` / `revalidate` |
| `stale_pending_review` | `activate`, `stale`, `review` | use `reactivate` / `close` / `expire` / `archive` |

### Still allowed (unchanged intent)
- `draft` → `review` / `activate` / `archive`
- `pending_review` → `activate` / `close` / `archive`
- `active` → `stale` / `close` / `expire` / `archive` / `revalidate`
- `stale_pending_review` → `reactivate` / `close` / `expire` / `archive`
- `closed` → `reactivate` / `archive`
- `revalidate` from any known status (no status change)

## Test plan
- [x] `pnpm exec vitest run tests/job-admin-lib.test.ts tests/d1-dynamic-state.test.ts`
- [x] `git diff --check`

