### PR TITLE
fix(web): restore the saved-search signal (trust) filter on reopen and in its feed

### DIFF
--- a/apps/web/src/lib/feeds-lib.ts
+++ b/apps/web/src/lib/feeds-lib.ts
@@ -14,7 +14,7 @@
  * working unchanged.
  */
 import { ENTRIES } from "@/data/entries";
-import { filterSearchEntries, normalizeSearchQuery } from "@/data/search";
+import { filterSearchEntries, normalizeSearchQuery, type TrustSignalFilter } from "@/data/search";
 import { CHANGELOG, RELEASE_NOTES } from "@/data/changelog";
 import {
   CATEGORIES,
@@ -197,6 +197,7 @@ export interface SavedSearchQuery {
   category?: string;
   trust?: string;
   source?: string;
+  signal?: string;
   platform?: string;
 }
 
@@ -207,6 +208,7 @@ export function applySavedSearch(q: SavedSearchQuery): FeedItem[] {
       categories: q.category ? [q.category as Category] : undefined,
       trust: q.trust ? [q.trust as TrustLevel] : undefined,
       source: q.source ? [q.source as SourceStatus] : undefined,
+      signal: q.signal ? (q.signal as TrustSignalFilter) : undefined,
       platforms: q.platform ? [q.platform as Platform] : undefined,
     },
     ENTRIES,

--- a/apps/web/src/lib/saved-search-feed-url-lib.ts
+++ b/apps/web/src/lib/saved-search-feed-url-lib.ts
@@ -6,9 +6,9 @@ import type { SavedSearch } from "@/lib/recents";
 
 /**
  * Build the RSS feed URL for a saved search. Each of `q`, `category`, `trust`,
- * `source`, `platform`, and `label` is appended as a query param only when it
- * is a non-empty value, so empty filters are omitted. The params are
- * URL-encoded via `URLSearchParams`.
+ * `source`, `signal`, `platform`, and `label` is appended as a query param
+ * only when it is a non-empty value, so empty filters are omitted. The params
+ * are URL-encoded via `URLSearchParams`.
  */
 export function savedFeedUrl(s: SavedSearch): string {
   const p = new URLSearchParams();
@@ -16,6 +16,7 @@ export function savedFeedUrl(s: SavedSearch): string {
   if (s.category) p.set("category", s.category);
   if (s.trust) p.set("trust", s.trust);
   if (s.source) p.set("source", s.source);
+  if (s.signal) p.set("signal", s.signal);
   if (s.platform) p.set("platform", s.platform);
   if (s.label) p.set("label", s.label);
   return `/feeds/saved.xml?${p.toString()}`;

--- a/apps/web/src/lib/saved-search-nav-lib.ts
+++ b/apps/web/src/lib/saved-search-nav-lib.ts
@@ -15,6 +15,7 @@ export function applyToBrowseSearch(s: SavedSearch) {
     category: s.category ?? "",
     trust: s.trust ?? "",
     source: s.source ?? "",
+    signal: s.signal ?? "",
     platform: s.platform ?? "",
     sort: (s.sort as "popular" | "newest" | "title") ?? "popular",
     view: "row" as const,

--- a/apps/web/src/lib/saved-search-query-lib.ts
+++ b/apps/web/src/lib/saved-search-query-lib.ts
@@ -11,6 +11,7 @@ export function savedSearchQueryFromParams(params: URLSearchParams): SavedSearch
     category: params.get("category") ?? undefined,
     trust: params.get("trust") ?? undefined,
     source: params.get("source") ?? undefined,
+    signal: params.get("signal") ?? undefined,
     platform: params.get("platform") ?? undefined,
   };
 }

--- a/tests/feeds-lib.test.ts
+++ b/tests/feeds-lib.test.ts
@@ -366,6 +366,7 @@ describe("applySavedSearch", () => {
       category: "skills",
       trust: "verified",
       source: "official",
+      signal: "checksums",
       platform: "claude-code",
     });
     expect(normalizeSearchQuery).toHaveBeenCalledWith("hello");
@@ -375,6 +376,7 @@ describe("applySavedSearch", () => {
         categories: ["skills"],
         trust: ["verified"],
         source: ["official"],
+        signal: "checksums",
         platforms: ["claude-code"],
       }),
       expect.any(Array),
@@ -391,6 +393,7 @@ describe("applySavedSearch", () => {
         categories: undefined,
         trust: undefined,
         source: undefined,
+        signal: undefined,
         platforms: undefined,
       },
       expect.any(Array),

--- a/tests/saved-search-feed-url-lib.test.ts
+++ b/tests/saved-search-feed-url-lib.test.ts
@@ -18,6 +18,7 @@ describe("savedFeedUrl", () => {
         category: "mcp",
         trust: "trusted",
         source: "official",
+        signal: "checksums",
         platform: "claude-code",
         label: "my feed",
       }),
@@ -27,6 +28,7 @@ describe("savedFeedUrl", () => {
     expect(params.get("category")).toBe("mcp");
     expect(params.get("trust")).toBe("trusted");
     expect(params.get("source")).toBe("official");
+    expect(params.get("signal")).toBe("checksums");
     expect(params.get("platform")).toBe("claude-code");
     expect(params.get("label")).toBe("my feed");
   });

--- a/tests/saved-search-nav-lib.test.ts
+++ b/tests/saved-search-nav-lib.test.ts
@@ -13,6 +13,7 @@ describe("applyToBrowseSearch", () => {
       category: "",
       trust: "",
       source: "",
+      signal: "",
       platform: "",
       sort: "popular",
       view: "row",
@@ -27,6 +28,7 @@ describe("applyToBrowseSearch", () => {
         category: "mcp",
         trust: "trusted",
         source: "official",
+        signal: "checksums",
         platform: "claude-code",
       }),
     );
@@ -35,6 +37,7 @@ describe("applyToBrowseSearch", () => {
       category: "mcp",
       trust: "trusted",
       source: "official",
+      signal: "checksums",
       platform: "claude-code",
     });
   });

--- a/tests/saved-search-query-lib.test.ts
+++ b/tests/saved-search-query-lib.test.ts
@@ -10,6 +10,7 @@ describe("savedSearchQueryFromParams", () => {
         category: "mcp",
         trust: "verified",
         source: "github",
+        signal: "checksums",
         platform: "cursor",
       }),
     );
@@ -18,6 +19,7 @@ describe("savedSearchQueryFromParams", () => {
       category: "mcp",
       trust: "verified",
       source: "github",
+      signal: "checksums",
       platform: "cursor",
     });
   });
@@ -31,6 +33,7 @@ describe("savedSearchQueryFromParams", () => {
       category: undefined,
       trust: undefined,
       source: undefined,
+      signal: undefined,
       platform: undefined,
     });
   });


### PR DESCRIPTION
Closes #5506

## Root cause

`SavedSearch` already has a `signal?: string` field, so a trust-signal filter (e.g. "checksums", "source-backed") **is** captured when a search is saved — but nothing ever read it back:

- `applyToBrowseSearch` (saved-search-nav-lib.ts) restored `q`, `category`, `trust`, `source`, `platform`, `sort` — not `signal`, so reopening a saved search silently widened the result set.
- `savedFeedUrl` (saved-search-feed-url-lib.ts) and `savedSearchQueryFromParams` (saved-search-query-lib.ts) omitted `signal`, and `SavedSearchQuery` / `applySavedSearch` (feeds-lib.ts) had no `signal` field — so `/feeds/saved.xml` dropped the filter entirely (a subscriber to "MCP servers with checksums" got every MCP server).

## Fix

Wire `signal` through the same round trip `trust`/`source` already take, across exactly the four files named in the issue:

1. `applyToBrowseSearch` → `signal: s.signal ?? ""`
2. `savedFeedUrl` → appends `signal` when set (docstring field list updated)
3. `savedSearchQueryFromParams` → parses `signal`
4. `SavedSearchQuery` gains `signal?: string`; `applySavedSearch` forwards it to `filterSearchEntries` as `signal: q.signal as TrustSignalFilter`

`SearchFilters.signal` / `filterSearchEntries` in `data/search.ts` already fully support the filter — this was purely a plumbing gap in the saved-search layer, so nothing there changed.

## Acceptance criteria

- ✅ Reopening a saved search with an active `signal` restores the same filtered set — covered by extending the existing `applyToBrowseSearch` / `savedFeedUrl` / `savedSearchQueryFromParams` / `applySavedSearch` unit tests with a `signal` case.
- ✅ `/feeds/saved.xml?...&signal=...` filters to that trust signal (asserted via `applySavedSearch` forwarding `signal` to `filterSearchEntries`).
- ✅ `Closes #5506` included.

## Quality evidence

**No visual impact** — pure filter-plumbing logic in `.ts` libs, covered by unit tests; no component/route/`.tsx` changes.

## Validation

- `pnpm exec vitest run tests/saved-search-nav-lib.test.ts tests/saved-search-feed-url-lib.test.ts tests/saved-search-query-lib.test.ts tests/feeds-lib.test.ts` → 64/64 pass
- `pnpm type-check` → clean
- `pnpm build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)