### PR TITLE
fix(registry): detect Anthropic sk-ant- and OpenAI sk-proj- keys in embedded_secret scan

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1201,7 +1201,7 @@ function addContentRiskSignals(report, fields, text) {
   }
 
   if (
-    /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-[a-z0-9]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
+    /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-(?:ant-|proj-)?[a-z0-9-]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
       text,
     )
   ) {

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -345,6 +345,58 @@ describe("submission risk invariants", () => {
     );
   });
 
+  it("flags Anthropic sk-ant- and OpenAI sk-proj- key formats as embedded secrets", () => {
+    const withKey = (secret: string) =>
+      analyzeDirectContentRisk({
+        pullRequest: {
+          number: 501,
+          title: "content(mcp): add leaky config mcp",
+          user: { login: "contributor" },
+          head: { repo: { full_name: "contributor/awesome-claude" } },
+          base: { repo: { full_name: "JSONbored/awesome-claude" } },
+        },
+        files: [
+          sourceFile(
+            `${validMcpMdx({ slug: "leaky-config-mcp" })}\n\nExample env: API_KEY=${secret}\n`,
+            "content/mcp/leaky-config-mcp.mdx",
+          ),
+        ],
+      });
+
+    // Both real provider formats use hyphenated prefixes/segments the old
+    // `sk-[a-z0-9]{20,}` alternative could not match.
+    expect(
+      withKey("sk-ant-api03-xY7k9mN2pQr4sT6uV8wX0zA1bC3dE5fG").reviewFlags.map(
+        (flag) => flag.id,
+      ),
+    ).toContain("embedded_secret");
+    expect(
+      withKey("sk-proj-aB3dEfGh1jKlMnOpQrStUvWxYz012345").reviewFlags.map(
+        (flag) => flag.id,
+      ),
+    ).toContain("embedded_secret");
+
+    // Benign content that merely mentions "sk-" in prose stays unflagged.
+    const benign = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 502,
+        title: "content(mcp): add benign mcp",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          `${validMcpMdx({ slug: "benign-mcp" })}\n\nUse the sk-learning workflow to onboard.\n`,
+          "content/mcp/benign-mcp.mdx",
+        ),
+      ],
+    });
+    expect(benign.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "embedded_secret",
+    );
+  });
+
   it("uses same-repo frontmatter contributors when maintainer content carries submitter metadata", () => {
     const report = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
Closes #5479

## Root cause

`packages/registry/src/submission-risk.js` — the `embedded_secret` regex's `sk-` alternative was `sk-[a-z0-9]{20,}`. That character class stops at the first hyphen, so it never matched Anthropic's own `sk-ant-api03-…` or OpenAI's `sk-proj-…` key shapes (both use a hyphenated prefix and hyphens within the body). The submission-risk scanner silently let those provider keys through.

## Fix

Widen the alternative to `sk-(?:ant-|proj-)?[a-z0-9-]{20,}` — it matches both real formats and still catches the plain `sk-<20+ alnum>` case, while the 20-char minimum keeps benign prose (e.g. `sk-learning`) from matching.

## Before/after regex results

Run against the exact alternatives (only the `sk-` branch changed):

| Input | before | after |
|---|---|---|
| `sk-ant-api03-xY7k9mN2pQr4sT6uV8wX0zA1bC3dE5fG` | ❌ false | ✅ true |
| `sk-proj-aB3dEfGh1jKlMnOpQrStUvWxYz012345` | ❌ false | ✅ true |
| `sk-abcdefghij0123456789abcd` (plain) | ✅ true | ✅ true |
| `the sk-learning framework note` (benign) | false | false |
| `ghp_abcdefghij0123456789abcd` (control) | true | true |

## Acceptance criteria

- ✅ Matches realistic `sk-ant-api03-…` and `sk-proj-…` strings.
- ✅ Still matches the plain `sk-<20+ alnum>` case; no new false positive on ordinary `sk-` prose.
- ✅ `Closes #5479` included.

## Quality evidence

**No visual impact** — a single detection regex in a `.js` lib. Regression tests added in `tests/submission-risk-invariants.test.ts` assert both provider formats flag `embedded_secret` and that benign `sk-` prose does not.

## Validation

- `pnpm exec vitest run tests/submission-risk-invariants.test.ts` → 49/49 pass
- `pnpm build` → succeeds
- `git diff --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)