### PR TITLE
fix(web): use sitemapEntryLastModified for entry lastmod in the sitemap

### DIFF
--- a/apps/web/src/lib/sitemap-policy-lib.ts
+++ b/apps/web/src/lib/sitemap-policy-lib.ts
@@ -1,5 +1,3 @@
-import type { DirectoryEntry } from "@/lib/content.server";
-
 export function safeSitemapDate(value?: string | null) {
   if (!value) return undefined;
   const date = new Date(value);
@@ -21,7 +19,18 @@ export function isSitemapIndexableEntry(entry: { category: string; robotsIndex?:
   return entry.robotsIndex !== false;
 }
 
-export function sitemapEntryLastModified(entry: DirectoryEntry) {
+/**
+ * Sitemap `lastmod` for an entry, preferring real content-update signals over a
+ * bare `dateAdded`. Accepts any entry-shaped object (with all fields optional)
+ * so both the server `DirectoryEntry` and the client registry `Entry` satisfy
+ * it — the same widening `isSitemapIndexableEntry` uses above.
+ */
+export function sitemapEntryLastModified(entry: {
+  contentUpdatedAt?: string | null;
+  repoUpdatedAt?: string | null;
+  verifiedAt?: string | null;
+  dateAdded?: string | null;
+}) {
   return safeSitemapDate(
     entry.contentUpdatedAt || entry.repoUpdatedAt || entry.verifiedAt || entry.dateAdded,
   );

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -8,7 +8,7 @@ import { siteConfig } from "@/lib/site";
 import { applySecurityHeaders } from "@/lib/security-headers";
 import { CATEGORIES, PLATFORM_LABEL } from "@/types/registry";
 import { getIndexableTagGroups } from "@/lib/tags";
-import { isSitemapIndexableEntry } from "@/lib/sitemap-policy";
+import { isSitemapIndexableEntry, sitemapEntryLastModified } from "@/lib/sitemap-policy";
 import { COMPARISONS } from "@/data/comparisons";
 import { REPORT_PATHS } from "@/lib/data-reports";
 import { sitemapUrlItem } from "@/lib/sitemap-url-item-lib";
@@ -125,7 +125,7 @@ async function renderSitemap() {
         `/entry/${entry.category}/${entry.slug}`,
         "0.8",
         "monthly",
-        entry.reviewedAt ?? entry.dateAdded,
+        sitemapEntryLastModified(entry)?.toISOString(),
       ),
     ),
     ...contributorPaths.map((pathname) => urlItem(pathname, "0.5", "monthly")),


### PR DESCRIPTION
Closes #5472

## Root cause

`apps/web/src/routes/sitemap[.]xml.ts` computed each entry's `<lastmod>` inline as `entry.reviewedAt ?? entry.dateAdded`, ignoring the content-update-aware `sitemapEntryLastModified` helper (`contentUpdatedAt || repoUpdatedAt || verifiedAt || dateAdded`) in `apps/web/src/lib/sitemap-policy-lib.ts` — which was fully unit-tested but had **zero callers**. So the sitemap advertised a review/added date instead of the real last-content-change date.

## Fix

Wire the tested helper into the route's entry `urlItem` call:

```diff
-        entry.reviewedAt ?? entry.dateAdded,
+        sitemapEntryLastModified(entry)?.toISOString(),
```

The helper returns a `Date` (as its existing tests assert via `?.toISOString()`), and `sitemapUrlItem` slices `lastmod` to `YYYY-MM-DD`, so the emitted value format is unchanged.

To let the helper accept the client registry `Entry` the route iterates (as well as the server `DirectoryEntry`), I widened its parameter to a structural all-optional shape — **the same widening the sibling `isSitemapIndexableEntry` already uses in this file** — and dropped the now-unused `DirectoryEntry` import. The date-selection logic is untouched and stays covered by `tests/sitemap-policy-lib.test.ts`.

## Which real entries change (spot-check)

Over the current 1385 entries, **8** get a different `lastmod`. Sample:

| slug | before (`reviewedAt ?? dateAdded`) | after (`contentUpdatedAt …`) |
|---|---|---|
| heyclaude-content-submission-factory | 2026-04-30 | **2026-06-02** |
| heyclaude-skill-submission-factory | 2026-04-27 | **2026-06-02** |
| loopover-mcp | 2026-06-03 | **2026-07-20** |
| contrastapi-mcp-server | 2026-04-30 | 2026-04-20 |
| memesio-mcp-server | 2026-05-10 | 2026-05-08 |

Most move to a newer date (the content genuinely changed after it was reviewed). A couple move slightly earlier because `contentUpdatedAt` (the actual last content change) predates the maintainer `reviewedAt` action — which is the more accurate "last modified" signal for a sitemap, and exactly the fallback order the maintainer built and tested into the helper.

## Acceptance criteria

- ✅ Entry `lastmod` now comes from `sitemapEntryLastModified`, not the inline `reviewedAt ?? dateAdded`.
- ✅ Existing sitemap tests still pass (805 in `sitemap-policy-lib`, plus `sitemap-policy` / `sitemap-url-item-lib`).
- ✅ `Closes #5472`.

## Quality evidence

**No visual impact** — XML feed content only. `pnpm type-check` clean; `pnpm build` succeeds; `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)