### PR TITLE
fix(a11y): add aria-pressed to jobs/claim toggle buttons

### DIFF
--- a/apps/web/src/routes/claim.tsx
+++ b/apps/web/src/routes/claim.tsx
@@ -353,6 +353,7 @@ function ClaimPage() {
                 <button
                   type="button"
                   key={t}
+                  aria-pressed={type === t}
                   onClick={() => {
                     if (type !== t) {
                       trackEvent(

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -475,6 +475,7 @@ function JobsPage() {
           <button
             type="button"
             onClick={onFreshToggle}
+            aria-pressed={freshOnly}
             className={cn(
               "h-9 rounded-md border px-2.5 text-xs font-medium transition-colors duration-200 ease-out",
               freshOnly
@@ -487,6 +488,7 @@ function JobsPage() {
           <button
             type="button"
             onClick={onFeaturedToggle}
+            aria-pressed={featuredOnly}
             className={cn(
               "h-9 rounded-md border px-2.5 text-xs font-medium transition-colors duration-200 ease-out",
               featuredOnly

--- a/apps/web/src/routes/jobs.post.tsx
+++ b/apps/web/src/routes/jobs.post.tsx
@@ -151,6 +151,7 @@ function PostJobPage() {
           <button
             key={t.id}
             type="button"
+            aria-pressed={tier === t.id}
             onClick={() => {
               setTier(t.id);
               trackEvent(


### PR DESCRIPTION
## Summary
Toggle buttons for jobs filters (`is:fresh`, Featured only), job-post tier tiles, and claim-type selectors visually show selection but lacked `aria-pressed`, unlike advertise/browse.

Adds `aria-pressed` matching the existing pattern in `advertise.tsx` / `browse.tsx`.

Closes #5476

## Test plan
- [x] Diff only adds `aria-pressed={...}` on the three call sites named in the issue
- [ ] Spot-check Jobs / Post a job / Claim pages with a screen reader or a11y tree

Made with [Cursor](https://cursor.com)