### PR TITLE
fix(web): rate-limit crawlable /og routes like /api/og

### DIFF
--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -1,4 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { getApiRouteDefinition } from "@/lib/api/contracts";
+import { apiError, enforceRateLimit, getApiRequestId } from "@/lib/api/router";
 import { getEntry } from "@/data/search";
 import { categoryAccent } from "@/lib/og-image";
 import { ogEntryCardFields } from "@/lib/og-entry-card-lib";
@@ -12,7 +14,12 @@ import { renderOgPng } from "@/lib/og-render.server";
 export const Route = createFileRoute("/og/$category/$slug")({
   server: {
     handlers: {
-      GET: async ({ params }) => {
+      GET: async ({ request, params }) => {
+        // Same expensive Satori path as /api/og — enforce the same ceiling (#5452).
+        const ogRoute = getApiRouteDefinition("og.render");
+        if (await enforceRateLimit(ogRoute, request)) {
+          return apiError("rate_limited", 429, { requestId: getApiRequestId(request) });
+        }
         const entry = getEntry(params.category, params.slug);
         const { title, description, author, category } = ogEntryCardFields(
           entry,

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -1,4 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { getApiRouteDefinition } from "@/lib/api/contracts";
+import { apiError, enforceRateLimit, getApiRequestId } from "@/lib/api/router";
 import { resolveOgQueryFields } from "@/lib/og-query-fields-lib";
 import { renderOgPng } from "@/lib/og-render.server";
 import { siteConfig } from "@/lib/site";
@@ -13,6 +15,11 @@ export const Route = createFileRoute("/og/")({
   server: {
     handlers: {
       GET: async ({ request }) => {
+        // Same expensive Satori path as /api/og — enforce the same ceiling (#5452).
+        const ogRoute = getApiRouteDefinition("og.render");
+        if (await enforceRateLimit(ogRoute, request)) {
+          return apiError("rate_limited", 429, { requestId: getApiRequestId(request) });
+        }
         const url = new URL(request.url);
         // Defaults live in resolveOgQueryFields: title/eyebrow -> "HeyClaude",
         // description -> subtitle -> the site tagline, all clamped; accent is

--- a/tests/og-crawlable-rate-limit.test.ts
+++ b/tests/og-crawlable-rate-limit.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "..");
+
+function readRoute(rel: string) {
+  return readFileSync(resolve(root, rel), "utf8");
+}
+
+describe("crawlable /og routes rate-limit the Satori render (#5452)", () => {
+  it("og.index enforces the og.render ceiling before rendering", () => {
+    const src = readRoute("apps/web/src/routes/og.index.ts");
+    expect(src).toContain('getApiRouteDefinition("og.render")');
+    expect(src).toContain("enforceRateLimit(ogRoute, request)");
+    expect(src).toContain('apiError("rate_limited", 429');
+    expect(src.indexOf("enforceRateLimit")).toBeLessThan(src.indexOf("renderOgPng"));
+  });
+
+  it("og.$category.$slug enforces the og.render ceiling before rendering", () => {
+    const src = readRoute("apps/web/src/routes/og.$category.$slug.ts");
+    expect(src).toContain('getApiRouteDefinition("og.render")');
+    expect(src).toContain("enforceRateLimit(ogRoute, request)");
+    expect(src).toContain('apiError("rate_limited", 429');
+    expect(src.indexOf("enforceRateLimit")).toBeLessThan(src.indexOf("renderOgPng"));
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce the existing `og.render` rate limit (`API_STRICT_RATE_LIMIT`, 90/min) on crawlable `/og` and `/og/$category/$slug` before calling `renderOgPng`.
- Match `/api/og` protection so scrapers cannot burn unbounded Satori work on the robots-allowed surface.
- Add a source-guard vitest so both handlers keep the ceiling in front of the renderer.

Fixes #5452

## Test plan
- [x] `pnpm exec vitest run tests/og-crawlable-rate-limit.test.ts`
- [ ] Hit `/og` past the ceiling and confirm `429` + `rate_limited`
- [ ] Confirm a normal `/og?title=...` still returns PNG when under the limit


Made with [Cursor](https://cursor.com)