### PR TITLE
fix(web): rate-limit crawlable /og routes like /api/og

### DIFF
--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -1,4 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { getApiRouteDefinition } from "@/lib/api/contracts";
+import { apiError, enforceApiRateLimit, getApiRequestId } from "@/lib/api/router";
 import { getEntry } from "@/data/search";
 import { categoryAccent } from "@/lib/og-image";
 import { ogEntryCardFields } from "@/lib/og-entry-card-lib";
@@ -12,7 +14,12 @@ import { renderOgPng } from "@/lib/og-render.server";
 export const Route = createFileRoute("/og/$category/$slug")({
   server: {
     handlers: {
-      GET: async ({ params }) => {
+      GET: async ({ request, params }) => {
+        // Same expensive Satori path as /api/og — enforce the same ceiling (#5452).
+        const ogRoute = getApiRouteDefinition("og.render");
+        if (await enforceApiRateLimit(ogRoute, request)) {
+          return apiError("rate_limited", 429, { requestId: getApiRequestId(request) });
+        }
         const entry = getEntry(params.category, params.slug);
         const { title, description, author, category } = ogEntryCardFields(
           entry,

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -1,4 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { getApiRouteDefinition } from "@/lib/api/contracts";
+import { apiError, enforceApiRateLimit, getApiRequestId } from "@/lib/api/router";
 import { resolveOgQueryFields } from "@/lib/og-query-fields-lib";
 import { renderOgPng } from "@/lib/og-render.server";
 import { siteConfig } from "@/lib/site";
@@ -13,6 +15,11 @@ export const Route = createFileRoute("/og/")({
   server: {
     handlers: {
       GET: async ({ request }) => {
+        // Same expensive Satori path as /api/og — enforce the same ceiling (#5452).
+        const ogRoute = getApiRouteDefinition("og.render");
+        if (await enforceApiRateLimit(ogRoute, request)) {
+          return apiError("rate_limited", 429, { requestId: getApiRequestId(request) });
+        }
         const url = new URL(request.url);
         // Defaults live in resolveOgQueryFields: title/eyebrow -> "HeyClaude",
         // description -> subtitle -> the site tagline, all clamped; accent is

--- a/tests/og-crawlable-rate-limit.test.ts
+++ b/tests/og-crawlable-rate-limit.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = resolve(import.meta.dirname, "..");
+
+function readRoute(rel: string) {
+  return readFileSync(resolve(root, rel), "utf8");
+}
+
+describe("crawlable /og routes rate-limit the Satori render (#5452)", () => {
+  it("og.index enforces the og.render ceiling before rendering", () => {
+    const src = readRoute("apps/web/src/routes/og.index.ts");
+    expect(src).toContain('getApiRouteDefinition("og.render")');
+    expect(src).toContain("enforceApiRateLimit(ogRoute, request)");
+    expect(src).toContain('apiError("rate_limited", 429');
+    expect(src.indexOf("enforceApiRateLimit")).toBeLessThan(
+      src.indexOf("renderOgPng"),
+    );
+  });
+
+  it("og.$category.$slug enforces the og.render ceiling before rendering", () => {
+    const src = readRoute("apps/web/src/routes/og.$category.$slug.ts");
+    expect(src).toContain('getApiRouteDefinition("og.render")');
+    expect(src).toContain("enforceApiRateLimit(ogRoute, request)");
+    expect(src).toContain('apiError("rate_limited", 429');
+    expect(src.indexOf("enforceApiRateLimit")).toBeLessThan(
+      src.indexOf("renderOgPng"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce the existing `og.render` rate limit on crawlable `/og` and `/og/$category/$slug` before `renderOgPng`, using the public `enforceApiRateLimit` export (same path as `/api/mcp` / newsletter).
- Add a source-guard vitest so both handlers keep the ceiling ahead of the renderer.

Fixes #5452

Supersedes #5533 (closed for CI + missing visual note).

## Visual
**No visual impact** — server-only rate-limit wiring on PNG route handlers; no page/component/CSS changes.

## Test plan
- [x] `pnpm exec vitest run tests/og-crawlable-rate-limit.test.ts`
- [x] Imports use `enforceApiRateLimit` (fixes prior `tsc` failure on non-exported `enforceRateLimit`)
- [ ] CI `validate-web` / `validate-ci` green


Made with [Cursor](https://cursor.com)