### PR TITLE
fix(web): rate-limit crawlable /og routes like /api/og

### DIFF
--- a/apps/web/src/lib/og-rate-limit-lib.ts
+++ b/apps/web/src/lib/og-rate-limit-lib.ts
@@ -1,0 +1,19 @@
+import { getApiRouteDefinition } from "@/lib/api/contracts";
+import { apiError, enforceApiRateLimit, getApiRequestId } from "@/lib/api/router";
+
+/**
+ * Shared crawlable-/api OG rate-limit gate (#5452).
+ *
+ * Both `/og` surfaces and `/api/og` (via `createApiHandler("og.render")`) must
+ * share the `og.render` contract ceiling so scrapers cannot bypass the limit by
+ * hitting the robots-allowed routes.
+ *
+ * Returns a 429 Response when limited; otherwise null so the caller can render.
+ */
+export async function maybeOgRateLimitedResponse(request: Request): Promise<Response | null> {
+  const ogRoute = getApiRouteDefinition("og.render");
+  if (await enforceApiRateLimit(ogRoute, request)) {
+    return apiError("rate_limited", 429, { requestId: getApiRequestId(request) });
+  }
+  return null;
+}

--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { getEntry } from "@/data/search";
 import { categoryAccent } from "@/lib/og-image";
 import { ogEntryCardFields } from "@/lib/og-entry-card-lib";
+import { maybeOgRateLimitedResponse } from "@/lib/og-rate-limit-lib";
 import { renderOgPng } from "@/lib/og-render.server";
 
 /**
@@ -12,7 +13,10 @@ import { renderOgPng } from "@/lib/og-render.server";
 export const Route = createFileRoute("/og/$category/$slug")({
   server: {
     handlers: {
-      GET: async ({ params }) => {
+      GET: async ({ request, params }) => {
+        // Same expensive Satori path as /api/og — enforce the same ceiling (#5452).
+        const limited = await maybeOgRateLimitedResponse(request);
+        if (limited) return limited;
         const entry = getEntry(params.category, params.slug);
         const { title, description, author, category } = ogEntryCardFields(
           entry,

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { maybeOgRateLimitedResponse } from "@/lib/og-rate-limit-lib";
 import { resolveOgQueryFields } from "@/lib/og-query-fields-lib";
 import { renderOgPng } from "@/lib/og-render.server";
 import { siteConfig } from "@/lib/site";
@@ -13,6 +14,9 @@ export const Route = createFileRoute("/og/")({
   server: {
     handlers: {
       GET: async ({ request }) => {
+        // Same expensive Satori path as /api/og — enforce the same ceiling (#5452).
+        const limited = await maybeOgRateLimitedResponse(request);
+        if (limited) return limited;
         const url = new URL(request.url);
         // Defaults live in resolveOgQueryFields: title/eyebrow -> "HeyClaude",
         // description -> subtitle -> the site tagline, all clamped; accent is

--- a/tests/og-crawlable-rate-limit.test.ts
+++ b/tests/og-crawlable-rate-limit.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getApiRouteDefinition } from "@/lib/api/contracts";
+
+const root = resolve(import.meta.dirname, "..");
+
+function readRoute(rel: string) {
+  return readFileSync(resolve(root, rel), "utf8");
+}
+
+const enforceApiRateLimit = vi.fn();
+
+vi.mock("@/lib/api/router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api/router")>();
+  return {
+    ...actual,
+    enforceApiRateLimit: (...args: unknown[]) => enforceApiRateLimit(...args),
+  };
+});
+
+describe("crawlable /og routes share the og.render rate-limit contract (#5452)", () => {
+  beforeEach(() => {
+    enforceApiRateLimit.mockReset();
+  });
+
+  it("og.render is the same contract /api/og uses (shared ceiling)", () => {
+    const route = getApiRouteDefinition("og.render");
+    expect(route.path).toBe("/api/og");
+    expect(route.rateLimit?.scope).toBe("og-image");
+    expect(route.rateLimit?.limit).toBe(90);
+  });
+
+  it("returns a 429 rate_limited Response when the shared ceiling is hit", async () => {
+    enforceApiRateLimit.mockResolvedValue(true);
+    const { maybeOgRateLimitedResponse } =
+      await import("@/lib/og-rate-limit-lib");
+    const res = await maybeOgRateLimitedResponse(
+      new Request("https://heyclau.de/og?title=x"),
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+    const body = (await res!.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("rate_limited");
+    expect(enforceApiRateLimit).toHaveBeenCalledTimes(1);
+    const [definition] = enforceApiRateLimit.mock.calls[0]!;
+    expect(definition).toMatchObject({ id: "og.render" });
+  });
+
+  it("returns null when under the ceiling so callers can render", async () => {
+    enforceApiRateLimit.mockResolvedValue(false);
+    const { maybeOgRateLimitedResponse } =
+      await import("@/lib/og-rate-limit-lib");
+    const res = await maybeOgRateLimitedResponse(
+      new Request("https://heyclau.de/og?title=x"),
+    );
+    expect(res).toBeNull();
+  });
+
+  it("og.index and og.$category.$slug call the shared gate before rendering", () => {
+    for (const rel of [
+      "apps/web/src/routes/og.index.ts",
+      "apps/web/src/routes/og.$category.$slug.ts",
+    ]) {
+      const src = readRoute(rel);
+      expect(src).toContain("maybeOgRateLimitedResponse(request)");
+      expect(src.indexOf("maybeOgRateLimitedResponse")).toBeLessThan(
+        src.indexOf("renderOgPng"),
+      );
+    }
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Enforce the existing `og.render` rate limit on crawlable `/og` and `/og/$category/$slug` before `renderOgPng`.
- Extract shared `maybeOgRateLimitedResponse` so both crawlable routes reuse the same contract `/api/og` already uses via `createApiHandler("og.render")`.
- Add behavioral + source-guard vitests (429 when limited; shared `og.render` ceiling).

Fixes #5452

Supersedes #5533 / #5534 (closed for screenshot-gate formatting despite non-visual server-only changes; CI was green on #5534).

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots: **No visual impact** (server-only rate-limit gate on PNG route handlers; no page/component/CSS/theme changes).
- [x] This PR links the issue it resolves (#5452).

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `apps/web/src/routes/og.index.ts`
  - `apps/web/src/routes/og.$category.$slug.ts`
  - `apps/web/src/lib/og-rate-limit-lib.ts` (new shared gate)
  - `tests/og-crawlable-rate-limit.test.ts`
- Expected behavior: when the shared `og.render` ceiling is exceeded, crawlable `/og*` returns `429` + `rate_limited` before calling `renderOgPng`; under the limit, PNG rendering proceeds unchanged.
- Important edge cases or invariants: rate-limit scope/limit/binding come from `getApiRouteDefinition("og.render")` — the same contract `/api/og` uses.
- Backward compatibility notes: responses under the limit are unchanged; only adds the missing limit on crawlable surfaces.
- Screenshots for frontend/page/UI changes:
  - **No visual impact** — this PR does not change any rendered HTML page, theme, layout, or viewport. It only adds a server-side rate-limit check on existing PNG image handlers. No Desktop/Tablet/Mobile × Light/Dark screenshot table applies.
- Focused tests or reason tests are not practical:
  - `pnpm exec vitest run tests/og-crawlable-rate-limit.test.ts` (behavioral 429 mock + shared-contract assertion + source ordering)

## Validation

- [x] Platform/code PR: focused vitest passed locally (`tests/og-crawlable-rate-limit.test.ts`).
- [x] I ran the focused checks listed above.
- [x] Trunk/prettier clean on touched files.

## Notes

- Linked issue: #5452
- Prior closes (#5533/#5534) were screenshot-bot false positives on non-visual route-handler changes; this body uses the repo PR template `No visual impact` checklist explicitly.


Made with [Cursor](https://cursor.com)