### PR TITLE
fix(mcp): stop normalizePlatform mirrors leaking unrecognized input (#5538)

### DIFF
--- a/packages/mcp/src/registry-normalize-lib.js
+++ b/packages/mcp/src/registry-normalize-lib.js
@@ -51,5 +51,6 @@ export function normalizeOffset(value) {
 export function normalizePlatform(value) {
   const normalized = normalizeText(value).replace(/[^a-z0-9]+/g, "-");
   if (!normalized) return "";
-  return platformAliases.get(normalized) || String(value || "").trim();
+  // Unrecognized input -> "" (callers treat falsy as "no filter"), not raw leak.
+  return platformAliases.get(normalized) || "";
 }

--- a/packages/mcp/src/search-ranking-lib.js
+++ b/packages/mcp/src/search-ranking-lib.js
@@ -340,7 +340,8 @@ export function tokenizeRegistrySearchQuery(query) {
 export function normalizeRegistryPlatform(value) {
   const normalized = text(value).replace(/[^a-z0-9]+/g, "-");
   if (!normalized) return "";
-  return PLATFORM_ALIASES.get(normalized) || String(value || "").trim();
+  // Unrecognized input -> "" (matchesRegistryPlatform treats falsy as no filter).
+  return PLATFORM_ALIASES.get(normalized) || "";
 }
 
 export function normalizedRegistrySearchText(entry) {

--- a/tests/mcp-registry-normalize-lib.test.ts
+++ b/tests/mcp-registry-normalize-lib.test.ts
@@ -35,7 +35,8 @@ describe("registry-normalize-lib platform aliases", () => {
     expect(normalizePlatform("   ")).toBe("");
   });
 
-  it("preserves unknown platform labels without alias mapping", () => {
-    expect(normalizePlatform("Antigravity")).toBe("Antigravity");
+  it("returns empty string for unrecognized platforms instead of leaking raw input", () => {
+    expect(normalizePlatform("Antigravity")).toBe("");
+    expect(normalizePlatform("Cluade Code")).toBe("");
   });
 });

--- a/tests/mcp-search-ranking-lib.test.ts
+++ b/tests/mcp-search-ranking-lib.test.ts
@@ -61,9 +61,8 @@ describe("search-ranking-lib platform and haystack helpers", () => {
   it("normalizes platform aliases", () => {
     expect(normalizeRegistryPlatform("claude")).toBe("claude-code");
     expect(normalizeRegistryPlatform("cursor-rules")).toBe("cursor");
-    expect(normalizeRegistryPlatform("unknown-platform")).toBe(
-      "unknown-platform",
-    );
+    expect(normalizeRegistryPlatform("unknown-platform")).toBe("");
+    expect(normalizeRegistryPlatform("Cluade Code")).toBe("");
   });
 
   it("builds normalized search text from entry metadata", () => {
@@ -82,6 +81,8 @@ describe("search-ranking-lib platform and haystack helpers", () => {
     expect(matchesRegistryPlatform(entry, "claude")).toBe(true);
     expect(matchesRegistryPlatform(entry, "codex")).toBe(false);
     expect(matchesRegistryPlatform(entry, "")).toBe(true);
+    // Unrecognized / misspelled platforms are treated as "no filter".
+    expect(matchesRegistryPlatform(entry, "Cluade Code")).toBe(true);
   });
 });
 
@@ -367,7 +368,7 @@ describe("search-ranking-lib ranking and helper fallbacks", () => {
     expect(matchesRegistryPlatform({}, "")).toBe(true);
   });
 
-  it("keeps a trimmed original value for an unknown platform alias", () => {
-    expect(normalizeRegistryPlatform("MyTool")).toBe("MyTool");
+  it("returns empty string for an unknown platform alias instead of leaking raw input", () => {
+    expect(normalizeRegistryPlatform("MyTool")).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

- Align MCP's duplicated `normalizePlatform` / `normalizeRegistryPlatform` with the registry contract: unrecognized platform input returns `""` instead of leaking the raw trimmed string.
- That makes `matchesRegistryPlatform`'s `if (!target) return true` treat typos/garbage as "no filter" (match everything) instead of an unmatchable strict filter that zeroes results.

Closes #5538

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/mcp/src/registry-normalize-lib.js` — `normalizePlatform`
  - `packages/mcp/src/search-ranking-lib.js` — `normalizeRegistryPlatform`
  - `tests/mcp-registry-normalize-lib.test.ts`, `tests/mcp-search-ranking-lib.test.ts`
- **Consumers of these normalizers (via `matchesRegistryPlatform` / `entryMatchesPlatform`):** `search_registry`, `plan_workflow_toolbox`, and compare / trust-compare / safety-review handlers in `registry-tool-orchestration-lib.js` (plus `registry-compare-lib` / `registry-trust-compare-lib` / `registry-safety-review-lib`).
- **Expected behavior:**
  - `normalizePlatform("Cluade Code")` → `""` (was `"Cluade Code"`)
  - `normalizeRegistryPlatform("Cluade Code")` → `""`
  - `normalizePlatform("Claude")` / `normalizeRegistryPlatform("claude")` → `"claude-code"` (unchanged)
  - `matchesRegistryPlatform(entry, "Cluade Code")` → `true` (no filter)
  - `matchesRegistryPlatform(entry, "codex")` still false when entry has no codex platform
- **Invariant:** known-alias filtering unchanged; only the unrecognized-input path is fixed.
- **Screenshots:** **No visual impact** — MCP library correctness fix; no routes/UI.
- **Focused tests:** unrecognized-platform cases in both test files (+ existing alias/blank coverage updated).

## Validation

- [x] `pnpm exec vitest run tests/mcp-registry-normalize-lib.test.ts tests/mcp-search-ranking-lib.test.ts` — **31 passed**
- [x] `pnpm test:mcp` — **72 passed**
- [x] `pnpm validate:mcp-package` — validated packed `@heyclaude/mcp`
- [x] `pnpm exec vitest run tests/mcp-search-ranking.test.ts` — **4 passed**
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean
- [ ] `pnpm build` — not run (no generated artifacts / schema / UI touched; issue-requested MCP gates covered above)

## Notes

- No prior PR existed for #5538 (timeline empty). Sibling MCP package PRs that failed were usually open-PR-cap or screenshot-matrix issues — this change is package-only with explicit **No visual impact**.
- One-shot commit; four files only.
