### PR TITLE
fix(seo): noindex thin platform hubs and drop them from the sitemap

### DIFF
--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -57,6 +57,10 @@ export const Route = createFileRoute("/for/$platform")({
       meta: [
         { title },
         { name: "description", content: description },
+        // Thin platform hubs (fewer than 2 entries) are excluded from the sitemap and
+        // noindexed, matching the policy already applied by the sibling routes
+        // for.$platform.$category.tsx and tags.$tag.tsx.
+        ...(entries.length < 2 ? [{ name: "robots", content: "noindex, follow" }] : []),
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -82,10 +82,15 @@ async function renderSitemap() {
   // One pass over ENTRIES building a `${category}/${platform}` -> count map (was platforms ×
   // categories × ENTRIES.filter ≈ 83K iterations per request).
   const intersectionCounts = new Map<string, number>();
+  // Total entries per platform, reusing the same pass — the platform hub route
+  // (for.$platform.tsx) noindexes hubs with fewer than 2 entries, so the sitemap
+  // must not advertise them, mirroring how getIndexableTagGroups() filters tags.
+  const platformCounts = new Map<string, number>();
   for (const entry of ENTRIES) {
     for (const platform of entry.platforms ?? []) {
       const key = `${entry.category}/${platform}`;
       intersectionCounts.set(key, (intersectionCounts.get(key) ?? 0) + 1);
+      platformCounts.set(platform, (platformCounts.get(platform) ?? 0) + 1);
     }
   }
   const intersectionPaths: string[] = [];
@@ -114,7 +119,10 @@ async function renderSitemap() {
       urlItem(`/${category.id}`, "0.8", "weekly", categoryLastmod.get(category.id)),
     ),
     ...getIndexableTagGroups().map((group) => urlItem(`/tags/${group.slug}`, "0.5")),
-    ...Object.keys(PLATFORM_LABEL).map((platform) => urlItem(`/for/${platform}`, "0.6")),
+    // Platform hubs with >=2 entries only — thinner ones are noindexed by the route.
+    ...Object.keys(PLATFORM_LABEL)
+      .filter((platform) => (platformCounts.get(platform) ?? 0) >= 2)
+      .map((platform) => urlItem(`/for/${platform}`, "0.6")),
     ...intersectionPaths.map((pathname) => urlItem(pathname, "0.55")),
     ...COMPARISONS.map((comparison) => urlItem(`/compare/${comparison.slug}`, "0.6")),
     ...bestPaths.map((pathname) => urlItem(pathname, "0.75")),

--- a/tests/sitemap-policy.test.ts
+++ b/tests/sitemap-policy.test.ts
@@ -88,3 +88,22 @@ describe("sitemap policy", () => {
     expect(source).toContain("entry.reviewedAt ?? entry.dateAdded");
   });
 });
+
+describe("sitemap platform hub policy", () => {
+  // Platform hubs with fewer than 2 entries are noindexed by for.$platform.tsx (#5537),
+  // so the sitemap must not advertise them — the same pairing the tag pages get via
+  // getIndexableTagGroups(). Pin the source: hubs are filtered by per-platform entry
+  // counts instead of unconditionally listing every PLATFORM_LABEL key.
+  it("only advertises platform hubs with at least 2 entries", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/routes/sitemap[.]xml.ts"),
+      "utf8",
+    );
+    expect(source).toContain(
+      ".filter((platform) => (platformCounts.get(platform) ?? 0) >= 2)",
+    );
+    expect(source).not.toContain(
+      'Object.keys(PLATFORM_LABEL).map((platform) => urlItem(`/for/${platform}`, "0.6"))',
+    );
+  });
+});

--- a/tests/web-platform-pages.test.ts
+++ b/tests/web-platform-pages.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
 
 import {
   buildPlatformPage,
   findPlatformPageDefinition,
   getPlatformPageDefinitions,
 } from "@/lib/platform-pages";
+import { repoRoot } from "./helpers/registry-fixtures";
 
 describe("platform-pages re-export surface", () => {
   it("keeps the public import path wired to the extracted lib", () => {
@@ -21,5 +24,30 @@ describe("platform-pages re-export surface", () => {
     ]);
     expect(page.count).toBe(1);
     expect(page.feedUrl).toContain("/data/feeds/platforms/");
+  });
+});
+
+describe("platform hub thin-content guard", () => {
+  // The platform hub route must apply the same "thin content -> noindex" policy as its
+  // sibling routes for.$platform.$category.tsx and tags.$tag.tsx (#5537). Routes are not
+  // importable in the node suite, so pin the guard at the source level, the same way
+  // sitemap-policy.test.ts pins the sitemap source surfaces.
+  const noindexGuard =
+    '...(entries.length < 2 ? [{ name: "robots", content: "noindex, follow" }] : []),';
+
+  it("noindexes platform hubs with fewer than 2 entries, like its sibling routes", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/routes/for.$platform.tsx"),
+      "utf8",
+    );
+    expect(source).toContain(noindexGuard);
+  });
+
+  it("keeps the guard identical to the sibling child route's pattern", () => {
+    const sibling = fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/routes/for.$platform.$category.tsx"),
+      "utf8",
+    );
+    expect(sibling).toContain(noindexGuard);
   });
 });


### PR DESCRIPTION
<!--
SUBMISSION PLAN (this comment is invisible on GitHub)
  Account:      tryeverything24 (fork: tryeverything24/awesome-claude)
  PR title:     fix(web): noindex thin platform hubs and drop them from the sitemap
  Code branch:  fix/platform-hub-thin-guard-5537     (in WSL /root/awesomeclaude, commit 5e4a2674)
  Asset branch: pr-assets-5537-platform-hub          (screenshots; push BEFORE opening the PR)
  Push:         cd /root/awesomeclaude
                git push <t24-fork> fix/platform-hub-thin-guard-5537
                git push <t24-fork> pr-assets-5537-platform-hub
  Open:         gh pr create --repo JSONbored/awesome-claude --head tryeverything24:fix/platform-hub-thin-guard-5537
  No issue needs to be filed first — #5537 is an existing OPEN maintainer-authored issue
  (filed 2026-07-24, zero cross-referenced PRs at build time). Dup-check the instant before opening.
-->
## Summary

- `for.$platform.tsx` built its `head()` meta unconditionally, so a platform hub with 0–1 entries got a fully indexed, sitemap-advertised page — even though its own child route (`for.$platform.$category.tsx`) and `tags.$tag.tsx` both noindex thin pages, and the sitemap already filters thin tag groups via `getIndexableTagGroups()`.
- Fix 1 — route: add the **identical** `...(entries.length < 2 ? [{ name: "robots", content: "noindex, follow" }] : [])` guard the sibling routes use to the platform hub's `head()` meta.
- Fix 2 — sitemap: compute per-platform totals inside the **existing** per-entry pass (the one that already builds `intersectionCounts`, so no extra iteration over `ENTRIES`) and filter the `/for/$platform` URL list to platforms with 2+ entries, mirroring the tag-group filtering.

Closes #5537

## Quality Evidence

- **No visual impact for typical platforms** — normal platform-hub rendering (title, description, JSON-LD, canonical link, cards) is completely unaffected for platforms with 2+ entries: the only change to `head()` is a conditional meta entry that contributes nothing when `entries.length >= 2`, and the sitemap keeps advertising those hubs unchanged.
- **Thin platforms in the current dataset (verified against the generated registry):** `aider` (1 entry) and `zed` (1 entry) — both now render `noindex, follow` and disappear from the sitemap. `continue` has exactly 2 entries and is unaffected (boundary verified). Every other platform has 3+ (`vscode` 3, `raycast` 6, up to `claude-code` 1179).
- **Count-source parity:** the route counts via `search({ platforms: [platform] })`, whose platform filter is `entry.platforms.some(...)` over `ENTRIES`; the sitemap counts membership of `entry.platforms` over the same `ENTRIES` array — identical populations, so the noindex guard and the sitemap filter can never disagree.
- **Acceptance criteria, verified end-to-end on a local production build (wrangler dev serving the built worker):**
  - `/for/aider` HTML contains `noindex, follow` after the fix; contained none before.
  - `/for/cursor` (182 entries) contains no robots meta — unchanged from today.
  - `sitemap.xml` after the fix contains zero `/for/aider` / `/for/zed` URLs (before: both present); `/for/cursor` still advertised.
- **Out of scope respected:** no changes to `for.$platform.$category.tsx`, `tags.$tag.tsx`, `PLATFORM_LABEL`, what counts as an entry, or generated artifacts.
- **Focused tests** (both named test files from the issue's Scope; verified they FAIL on pre-fix code):
  - `tests/web-platform-pages.test.ts` — pins the platform hub's noindex guard at source level and asserts it stays character-identical to the sibling child route's pattern.
  - `tests/sitemap-policy.test.ts` — pins that the sitemap filters platform hubs by per-platform counts and no longer lists every `PLATFORM_LABEL` key unconditionally (same source-pinning pattern that file already uses for the sitemap's other surfaces).

### Screenshot evidence

Full viewport × theme matrix for `/for/aider` (the thin hub the fix affects). This is an SEO/metadata correctness fix: the only page delta is an invisible `<meta name="robots">` tag in `<head>`, so before/after pairs are visually identical — included to show the rendered page (title/description/cards) is unaffected.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="360" alt="before desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/before-desktop-light.png"> | <img width="360" alt="after desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/after-desktop-light.png"> |
| Desktop · Dark | <img width="360" alt="before desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/before-desktop-dark.png"> | <img width="360" alt="after desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/after-desktop-dark.png"> |
| Tablet · Light | <img width="360" alt="before tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/before-tablet-light.png"> | <img width="360" alt="after tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/after-tablet-light.png"> |
| Tablet · Dark | <img width="360" alt="before tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/before-tablet-dark.png"> | <img width="360" alt="after tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/after-tablet-dark.png"> |
| Mobile · Light | <img width="360" alt="before mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/before-mobile-light.png"> | <img width="360" alt="after mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/after-mobile-light.png"> |
| Mobile · Dark | <img width="360" alt="before mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/before-mobile-dark.png"> | <img width="360" alt="after mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5537-platform-hub/shots/after-mobile-dark.png"> |

## Validation

- [x] `pnpm exec vitest run tests/web-platform-pages.test.ts tests/sitemap-policy.test.ts` — 8/8 pass (the issue's Validation commands; both new tests fail on pre-fix code)
- [x] `pnpm build` — succeeds
- [x] `pnpm type-check` — clean
- [x] End-to-end on the built worker: `/for/aider` noindexed + gone from `sitemap.xml`; `/for/zed` gone; `/for/cursor` and `/for/continue` unchanged
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check` on changed files — clean; `git diff --check` — clean
