### PR TITLE
fix(web): enforce the robotsIndex:false opt-out on the entry page and llms surfaces

### DIFF
--- a/apps/web/src/lib/llms-surface-lib.ts
+++ b/apps/web/src/lib/llms-surface-lib.ts
@@ -27,6 +27,11 @@ export interface LlmsEntry {
   installCommand?: string;
   configSnippet?: string;
   fullCopy?: string;
+  /**
+   * Per-entry indexing opt-out. `false` keeps the entry out of both llms
+   * surfaces, mirroring `isSitemapIndexableEntry` (sitemap-policy-lib).
+   */
+  robotsIndex?: boolean;
 }
 
 export interface LlmsTxtContext {
@@ -49,8 +54,12 @@ export function buildLlmsTxt(origin: string, context: LlmsTxtContext): string {
   lines.push(`Feeds: ${origin}/feeds`);
   lines.push("");
 
+  // Honor the per-entry `robotsIndex:false` opt-out, mirroring the sitemap's
+  // isSitemapIndexableEntry filter: an entry hidden from the sitemap must not
+  // be published to the llms surfaces either.
+  const listableEntries = context.entries.filter((e) => e.robotsIndex !== false);
   for (const c of context.categories) {
-    const entries = context.entries.filter((e) => e.category === c.id);
+    const entries = listableEntries.filter((e) => e.category === c.id);
     if (entries.length === 0) continue;
     lines.push(`## ${c.label}`);
     lines.push("");
@@ -96,8 +105,10 @@ export function buildLlmsFullTxt(origin: string, context: LlmsFullTxtContext): s
   out.push(`Generated for context windows. Source: ${origin}`);
   out.push("");
 
+  // Same `robotsIndex:false` opt-out as buildLlmsTxt / the sitemap policy.
+  const listableEntries = context.entries.filter((e) => e.robotsIndex !== false);
   for (const c of context.categories) {
-    const entries = context.entries.filter((e) => e.category === c.id);
+    const entries = listableEntries.filter((e) => e.category === c.id);
     if (entries.length === 0) continue;
     out.push(`# ${c.label}`);
     out.push("");

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -243,6 +243,12 @@ export const Route = createFileRoute("/entry/$category/$slug")({
       meta: [
         { title: e.seoTitle ? `${e.seoTitle} — HeyClaude` : ogTitle },
         { name: "description", content: metaDescription },
+        // robotsIndex:false entries are already dropped from the sitemap
+        // (isSitemapIndexableEntry); emit the matching noindex on the detail
+        // page itself so the opt-out also holds for crawlers arriving via
+        // internal links or backlinks — same pattern as the thin-content
+        // guards in tags.$tag.tsx and for.$platform.$category.tsx.
+        ...(e.robotsIndex === false ? [{ name: "robots", content: "noindex, follow" }] : []),
         { property: "og:title", content: ogTitle },
         { property: "og:description", content: metaDescription },
         { property: "og:url", content: url },

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -225,6 +225,13 @@ export interface Entry extends Provenance, BrandInfo, SkillFields {
   hasPrerequisites?: boolean;
   hasTroubleshooting?: boolean;
   hasBreakingChanges?: boolean;
+  /**
+   * Per-entry search-indexing opt-out (mirrors the registry ContentEntry
+   * field). `false` keeps the entry out of the sitemap
+   * (isSitemapIndexableEntry), noindexes its detail page, and hides it from
+   * the llms.txt surfaces; unset/true means indexable.
+   */
+  robotsIndex?: boolean;
   websiteUrl?: string;
   pricingModel?: string;
   disclosure?: string;

--- a/tests/entry-noindex-policy.test.ts
+++ b/tests/entry-noindex-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+describe("entry detail robotsIndex noindex enforcement (#5471)", () => {
+  // `robotsIndex:false` is documented as the per-entry quality-gate opt-out
+  // (sitemap-policy-lib), but the sitemap was the only surface honoring it —
+  // the entry's own detail page never emitted a robots meta, so crawlers could
+  // still index it via internal links or backlinks. Routes are not importable
+  // in the node suite, so pin the guard at the source level, the same way
+  // web-platform-pages.test.ts pins the thin-content noindex guard (#5537).
+  const noindexGuard =
+    '...(e.robotsIndex === false ? [{ name: "robots", content: "noindex, follow" }] : []),';
+
+  it("emits a robots noindex meta for robotsIndex:false entries", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/routes/entry.$category.$slug.tsx"),
+      "utf8",
+    );
+    expect(source).toContain(noindexGuard);
+  });
+
+  it("uses the same noindex meta shape as the sibling thin-content guards", () => {
+    const sibling = fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/routes/tags.$tag.tsx"),
+      "utf8",
+    );
+    expect(sibling).toContain('{ name: "robots", content: "noindex, follow" }');
+  });
+});

--- a/tests/llms-surface-lib.test.ts
+++ b/tests/llms-surface-lib.test.ts
@@ -6502,3 +6502,44 @@ describe("llms-surface-lib originOf", () => {
     expect(originOf(new Request(url))).toBe("https://host-49.example.com");
   });
 });
+
+describe("llms-surface-lib robotsIndex opt-out (#5471)", () => {
+  // An entry that opts out of indexing with `robotsIndex:false` is dropped from
+  // the sitemap by isSitemapIndexableEntry — the llms surfaces must honor the
+  // same opt-out instead of republishing the entry to AI/agent consumers.
+  const entries = [
+    fixtureEntry("skills", "indexable-skill"),
+    fixtureEntry("skills", "hidden-skill", { robotsIndex: false }),
+    fixtureEntry("skills", "explicitly-indexable-skill", { robotsIndex: true }),
+  ];
+
+  it("buildLlmsTxt omits robotsIndex:false entries and keeps the rest", () => {
+    const output = buildLlmsTxt("https://heyclau.de", {
+      categories: FIXTURE_CATEGORIES,
+      entries,
+    });
+    expect(output).toContain("/entry/skills/indexable-skill");
+    expect(output).toContain("/entry/skills/explicitly-indexable-skill");
+    expect(output).not.toContain("hidden-skill");
+  });
+
+  it("buildLlmsTxt skips a category section when every entry opted out", () => {
+    const output = buildLlmsTxt("https://heyclau.de", {
+      categories: FIXTURE_CATEGORIES,
+      entries: [fixtureEntry("agents", "hidden-agent", { robotsIndex: false })],
+    });
+    expect(output).not.toContain("## Agents");
+    expect(output).not.toContain("hidden-agent");
+  });
+
+  it("buildLlmsFullTxt omits robotsIndex:false entries and keeps the rest", () => {
+    const output = buildLlmsFullTxt("https://heyclau.de", {
+      categories: FIXTURE_CATEGORIES,
+      entries,
+      registryEntries: [],
+    });
+    expect(output).toContain("/entry/skills/indexable-skill");
+    expect(output).toContain("/entry/skills/explicitly-indexable-skill");
+    expect(output).not.toContain("hidden-skill");
+  });
+});


### PR DESCRIPTION
<!--
SUBMISSION PLAN (the comment itself is invisible on GitHub)
  Account:      rsnetworkinginc (fork: rsnetworkinginc/awesome-claude)
  PR title:     fix(web): enforce the robotsIndex:false opt-out on the entry page and llms surfaces
  Code branch:  fix/entry-noindex-enforcement-5471   (in WSL /root/awesomeclaude, worktree /root/ac-5471)
  Asset branch: pr-assets-5471-entry-noindex         (screenshots; push BEFORE opening the PR)
  Push:         cd /root/awesomeclaude
                git push <rsn-fork> fix/entry-noindex-enforcement-5471
                git push <rsn-fork> pr-assets-5471-entry-noindex
  Open:         gh pr create --repo JSONbored/awesome-claude --head rsnetworkinginc:fix/entry-noindex-enforcement-5471
  Dup-check #5471 the instant before opening (issue was uncontested at build time; zero open PRs repo-wide).
-->
## Summary

- `robotsIndex: false` is documented in `sitemap-policy-lib.ts` as the per-entry "quality gate" opt-out, but only the sitemap honored it: the entry's own detail page never emitted a `noindex` meta, and `/llms.txt` + `/llms-full.txt` still published opted-out entries in full.
- `entry.$category.$slug.tsx` `head()` now emits `{ name: "robots", content: "noindex, follow" }` when `entry.robotsIndex === false` — the exact meta shape the issue points to in `tags.$tag.tsx` / `for.$platform.$category.tsx`'s thin-content guards.
- `buildLlmsTxt` / `buildLlmsFullTxt` now filter out `robotsIndex === false` entries before listing, consistent with `isSitemapIndexableEntry`'s sitemap filtering; a category whose entries all opted out drops its section header too.
- One supporting line: the web `Entry` type (`apps/web/src/types/registry.ts`) gains the optional `robotsIndex?: boolean` field (it already exists on the registry package's `ContentEntry`) so the route guard type-checks; entries that don't set the field (the default) are unaffected on all three surfaces.

Closes #5471

## Quality Evidence

- **No visual impact** — meta tag / text-feed content only (per the issue's evidence note). For every currently indexable entry (all entries today set `robotsIndex: true` or leave it unset), the rendered page, llms.txt, and llms-full.txt output are byte-identical.
- **Acceptance criteria:**
  - Entry with `robotsIndex: false` → detail page head emits `noindex, follow` (pinned by the new `tests/entry-noindex-policy.test.ts`, which also pins that the meta shape matches the sibling thin-content guards).
  - Entry with `robotsIndex: false` → absent from `buildLlmsTxt` and `buildLlmsFullTxt` output (new unit tests in `tests/llms-surface-lib.test.ts` with a hidden/indexable/explicitly-indexable fixture trio).
  - Entry without `robotsIndex` (default) and with `robotsIndex: true` → listed exactly as before on all three surfaces (asserted in the same tests).
- **Regression tests proven RED:** all four new tests fail on pre-fix code (`tests/entry-noindex-policy.test.ts` 1 failure, `tests/llms-surface-lib.test.ts` 3 failures) and pass after the fix.
- **Out of scope honored:** `isSitemapIndexableEntry` / sitemap.xml untouched; `robotsFollow` untouched.

### Screenshot evidence

Full viewport × theme matrix for a representative entry page (`/entry/agents/agent-observability-sre-agent`, `robotsIndex` unset → indexable). Layout and theme chrome are unchanged by design — the change only adds a head meta tag for opted-out entries and filters two plain-text feeds, so before/after pairs are visually identical.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="360" alt="before desktop light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/before-desktop-light.png"> | <img width="360" alt="after desktop light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/after-desktop-light.png"> |
| Desktop · Dark | <img width="360" alt="before desktop dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/before-desktop-dark.png"> | <img width="360" alt="after desktop dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/after-desktop-dark.png"> |
| Tablet · Light | <img width="360" alt="before tablet light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/before-tablet-light.png"> | <img width="360" alt="after tablet light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/after-tablet-light.png"> |
| Tablet · Dark | <img width="360" alt="before tablet dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/before-tablet-dark.png"> | <img width="360" alt="after tablet dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/after-tablet-dark.png"> |
| Mobile · Light | <img width="360" alt="before mobile light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/before-mobile-light.png"> | <img width="360" alt="after mobile light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/after-mobile-light.png"> |
| Mobile · Dark | <img width="360" alt="before mobile dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/before-mobile-dark.png"> | <img width="360" alt="after mobile dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5471-entry-noindex/shots/after-mobile-dark.png"> |

## Validation

- [x] `pnpm exec vitest run tests/sitemap-policy.test.ts tests/sitemap-policy-lib.test.ts tests/web-non-ui-utilities.test.ts tests/llms-surface-lib.test.ts tests/entry-noindex-policy.test.ts` — 5 files / 1249 tests pass (issue's listed set + the two touched test files; the 4 new tests fail on pre-fix code)
- [x] `pnpm test` — full suite, 770 files / 39818 tests pass
- [x] `pnpm type-check` — clean
- [x] `pnpm build` — succeeds
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check` on changed files — clean; `git diff --check` — clean
