### PR TITLE
fix(web): use radio semantics for the browse density toggle

### DIFF
--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -999,11 +999,17 @@ function Browse() {
                   role="radiogroup"
                   aria-label="Result density"
                 >
+                  {/* role="radio" + aria-checked to match the radiogroup container,
+                      like this file's other radiogroups (FilterChip). Note: none of
+                      them implement arrow-key roving tabindex — each radio stays
+                      individually tab-focusable; that is a separate concern from the
+                      mislabeled attributes fixed here (#5454). */}
                   {(["compact", "row", "grid"] as const).map((v) => (
                     <button
                       key={v}
+                      role="radio"
                       onClick={() => onViewSelect(v)}
-                      aria-pressed={sp.view === v}
+                      aria-checked={sp.view === v}
                       className={cn(
                         "px-2 py-1 text-xs capitalize transition-colors duration-200 ease-out motion-safe:active:scale-[0.97]",
                         sp.view === v

--- a/tests/browse-density-radiogroup.test.ts
+++ b/tests/browse-density-radiogroup.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+describe("browse density toggle radiogroup semantics (#5454)", () => {
+  // The density toggle's container is a role="radiogroup", but its buttons used
+  // aria-pressed (the toggle-button pattern) instead of role="radio" +
+  // aria-checked, so assistive tech saw a radiogroup whose children expose no
+  // radio semantics. Routes are not importable in the node suite, so pin the
+  // corrected attributes at the source level, the same way
+  // web-platform-pages.test.ts pins the #5537 noindex guard.
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/browse.tsx"),
+    "utf8",
+  );
+  const densityStart = source.indexOf('aria-label="Result density"');
+  // The density toggle block: from the radiogroup label through the mapped
+  // buttons' closing tag.
+  const densityBlock = source.slice(
+    densityStart,
+    source.indexOf("</button>", densityStart),
+  );
+
+  it("locates the density radiogroup", () => {
+    expect(densityStart).toBeGreaterThan(-1);
+  });
+
+  it("density buttons expose role=radio with aria-checked selection state", () => {
+    expect(densityBlock).toContain('role="radio"');
+    expect(densityBlock).toContain("aria-checked={sp.view === v}");
+  });
+
+  it("density buttons no longer use the toggle-button aria-pressed pattern", () => {
+    expect(densityBlock).not.toContain("aria-pressed");
+    // The whole file has no other aria-pressed either — every remaining
+    // single-select group in browse.tsx uses the radio pattern (FilterChip).
+    expect(source).not.toContain("aria-pressed");
+  });
+});


### PR DESCRIPTION
<!--
SUBMISSION PLAN (the comment itself is invisible on GitHub)
  Account:      tryeverything24 (fork: tryeverything24/awesome-claude)
  PR title:     fix(web): use radio semantics for the browse density toggle
  Code branch:  fix/browse-density-radio-5454        (in WSL /root/awesomeclaude, worktree /root/ac-5454)
  Asset branch: pr-assets-5454-browse-density        (screenshots; push BEFORE opening the PR)
  Push:         cd /root/awesomeclaude
                git push <t24-fork> fix/browse-density-radio-5454
                git push <t24-fork> pr-assets-5454-browse-density
  Open:         gh pr create --repo JSONbored/awesome-claude --head tryeverything24:fix/browse-density-radio-5454
  Dup-check #5454 the instant before opening (issue was uncontested at build time; zero open PRs repo-wide).
-->
## Summary

- The `/browse` result-density toggle (Compact/List/Card) wraps its buttons in `role="radiogroup"`, but the buttons themselves used `aria-pressed` — the toggle-button pattern — instead of `role="radio"` + `aria-checked`, so assistive tech announced a radio group whose children expose no radio semantics.
- The three mapped buttons now set `role="radio"` and `aria-checked={sp.view === v}` (the exact comparison already driving the active styling), with the mismatched `aria-pressed` removed — consistent with the file's three other radiogroups, which all use `role="radio"` children via `FilterChip`.
- Per the issue's out-of-scope note: arrow-key roving tabindex is indeed not implemented — but that's equally true of the file's other radiogroups (`FilterChip` children are all individually tab-focusable), so it's noted in a code comment at the toggle rather than expanded into this fix.

Closes #5454

## Quality Evidence

- **No visual regression** — ARIA-attribute correction only; buttons render and behave identically for mouse/touch users (matrices below are visually identical by design). Click handling is untouched.
- **Accessibility-tree confirmation (per the issue's evidence requirement):** the route component is outside the node test suite, so the corrected semantics are pinned at the source level by the new `tests/browse-density-radiogroup.test.ts` (same pattern `tests/web-platform-pages.test.ts` uses for the #5537 noindex guard): within the `aria-label="Result density"` block the buttons expose `role="radio"` + `aria-checked={sp.view === v}` and no `aria-pressed`; the test also asserts `browse.tsx` as a whole is now `aria-pressed`-free, since every remaining single-select group in the file uses the radio pattern. With `role="radio"` + `aria-checked` bound to the selection comparison, the accessibility tree reports exactly one checked radio per state.
- **Acceptance criteria:** density buttons use `role="radio"` + `aria-checked`, not `aria-pressed`; keyboard focus behavior unchanged (buttons remain natively focusable, as before and as in the sibling radiogroups).
- **Regression test proven RED:** 2 of the 3 new tests fail on pre-fix code (the block-locator test passes, as expected) and all pass after the fix.
- **Out of scope honored:** no other control in `browse.tsx` touched; no styling change; no keyboard-navigation change (noted in-code per the issue's instruction).

### Screenshot evidence

Full viewport × theme matrix for `/browse`. `role`/`aria-checked` render no pixels, so before/after pairs are visually identical by design.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="360" alt="before desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/before-desktop-light.png"> | <img width="360" alt="after desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/after-desktop-light.png"> |
| Desktop · Dark | <img width="360" alt="before desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/before-desktop-dark.png"> | <img width="360" alt="after desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/after-desktop-dark.png"> |
| Tablet · Light | <img width="360" alt="before tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/before-tablet-light.png"> | <img width="360" alt="after tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/after-tablet-light.png"> |
| Tablet · Dark | <img width="360" alt="before tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/before-tablet-dark.png"> | <img width="360" alt="after tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/after-tablet-dark.png"> |
| Mobile · Light | <img width="360" alt="before mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/before-mobile-light.png"> | <img width="360" alt="after mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/after-mobile-light.png"> |
| Mobile · Dark | <img width="360" alt="before mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/before-mobile-dark.png"> | <img width="360" alt="after mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5454-browse-density/shots/after-mobile-dark.png"> |

## Validation

- [x] `pnpm build` — succeeds (issue's listed set)
- [x] `git diff --check` — clean (issue's listed set)
- [x] `pnpm exec vitest run tests/browse-density-radiogroup.test.ts` — 3/3 pass (2 fail on pre-fix code)
- [x] `pnpm test` — full suite, 770 files / 39816 tests pass
- [x] `pnpm type-check` — clean
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check` on changed files — clean
