### PR TITLE
fix(web): add distribution to the state-of-claude-tooling and state-of-mcp-servers Dataset JSON-LD

### DIFF
--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types/registry";
 import { ENTRIES, QUALITY_STATS, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { installMethodDistribution, notesCoverage } from "@/lib/ecosystem-stats";
+import { reportExportUrl } from "@/lib/data-reports";
 import { pctOf } from "@/lib/pct-of-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
@@ -187,6 +188,18 @@ export const Route = createFileRoute("/state-of-claude-tooling")({
         "Platform coverage",
         "Install-method distribution",
         "Safety and privacy notes coverage",
+      ],
+      distribution: [
+        {
+          "@type": "DataDownload",
+          encodingFormat: "application/json",
+          contentUrl: reportExportUrl("claude-tooling", "json"),
+        },
+        {
+          "@type": "DataDownload",
+          encodingFormat: "text/csv",
+          contentUrl: reportExportUrl("claude-tooling", "csv"),
+        },
       ],
     };
     const breadcrumbs = {

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -10,6 +10,7 @@ import {
   classifyTransport,
   hostingOf,
 } from "@/lib/mcp-stats";
+import { reportExportUrl } from "@/lib/data-reports";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -199,6 +200,18 @@ export const Route = createFileRoute("/state-of-mcp-servers")({
         "Source provenance distribution",
         "Install-method distribution",
         "Most common integration tags",
+      ],
+      distribution: [
+        {
+          "@type": "DataDownload",
+          encodingFormat: "application/json",
+          contentUrl: reportExportUrl("mcp-servers", "json"),
+        },
+        {
+          "@type": "DataDownload",
+          encodingFormat: "text/csv",
+          contentUrl: reportExportUrl("mcp-servers", "csv"),
+        },
       ],
     };
     const breadcrumbs = {

--- a/tests/state-report-dataset-distribution.test.ts
+++ b/tests/state-report-dataset-distribution.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// /state-of-claude-tooling and /state-of-mcp-servers hand-roll their
+// "@type": "Dataset" JSON-LD blocks instead of calling buildReportDataset(),
+// and those blocks never got the `distribution` array linking the pages'
+// already-working JSON/CSV exports — so structured-data consumers could not
+// discover them, unlike the three sibling report pages. Routes are not
+// importable in the node suite, so pin the corrected blocks at the source
+// level, the same way browse-density-radiogroup.test.ts pins #5454.
+const PAGES = [
+  {
+    route: "apps/web/src/routes/state-of-claude-tooling.tsx",
+    exportSlug: "claude-tooling",
+  },
+  {
+    route: "apps/web/src/routes/state-of-mcp-servers.tsx",
+    exportSlug: "mcp-servers",
+  },
+] as const;
+
+for (const { route, exportSlug } of PAGES) {
+  describe(`${path.basename(route)} Dataset JSON-LD advertises its exports (#5455)`, () => {
+    const source = fs.readFileSync(path.join(repoRoot, route), "utf8");
+    const datasetStart = source.indexOf('"@type": "Dataset"');
+    // The hand-rolled dataset literal: from the @type key through the closing
+    // `};` of the `const dataset = { ... };` statement.
+    const datasetBlock = source.slice(
+      datasetStart,
+      source.indexOf("};", datasetStart),
+    );
+
+    it("locates the hand-rolled Dataset block", () => {
+      expect(datasetStart).toBeGreaterThan(-1);
+    });
+
+    it("links both export formats in a distribution array", () => {
+      expect(datasetBlock).toContain("distribution: [");
+      expect(datasetBlock).toContain('"@type": "DataDownload"');
+      expect(datasetBlock).toContain('encodingFormat: "application/json"');
+      expect(datasetBlock).toContain('encodingFormat: "text/csv"');
+      expect(datasetBlock).toContain(
+        `reportExportUrl("${exportSlug}", "json")`,
+      );
+      expect(datasetBlock).toContain(`reportExportUrl("${exportSlug}", "csv")`);
+    });
+  });
+}


### PR DESCRIPTION
<!--
SUBMISSION PLAN (the comment itself is invisible on GitHub)
  Account:      tryeverything24 (fork: tryeverything24/awesome-claude)
  PR title:     fix(web): add distribution to the state-of-claude-tooling and state-of-mcp-servers Dataset JSON-LD
  Code branch:  fix/state-of-dataset-distribution-5455   (in WSL Ubuntu-22.04 /root/awesomeclaude, worktree /root/ac-5455)
  Asset branch: pr-assets-5455-state-dataset             (screenshots; push BEFORE opening the PR)
  Push:         cd /root/awesomeclaude
                git push <t24-fork> fix/state-of-dataset-distribution-5455
                git push <t24-fork> pr-assets-5455-state-dataset
  Open:         gh pr create --repo JSONbored/awesome-claude --head tryeverything24:fix/state-of-dataset-distribution-5455
  Dup-check #5455 the instant before opening (issue was OPEN + uncontested at build time; only open PR repo-wide was our #5546 on a different issue).
-->
## Summary

- `/state-of-claude-tooling` and `/state-of-mcp-servers` both have real, working JSON/CSV exports (`REPORT_BUILDERS["claude-tooling"]` / `["mcp-servers"]`, both render `<ReportDownloads>`), but their hand-rolled `"@type": "Dataset"` JSON-LD blocks never got the `distribution` field — so structured-data consumers can't discover those exports, while the three sibling report pages that call `buildReportDataset()` advertise theirs for free.
- Each page's Dataset block now carries a `distribution` array of two `DataDownload` objects (`application/json` + `text/csv`) whose `contentUrl` comes from the existing `reportExportUrl()` helper with the page's export slug — exactly the shape `buildReportDataset()` (`apps/web/src/lib/data-reports-lib.ts`) already produces for the siblings.
- The issue's preferred alternative (switching wholesale to `buildReportDataset()`) was deliberately not taken: both pages' hand-rolled blocks carry richer page-specific `variableMeasured` lists (e.g. "Local vs hosted split", "Safety and privacy notes coverage") that the model-derived helper output would flatten. Adding the equivalent `distribution` field — the issue's explicitly sanctioned second option — closes the gap without losing that metadata.

Closes #5455

## Quality Evidence

- **Rendered JSON-LD diff (per the issue's evidence requirement)** — diff of the two pages' rendered `<script type="application/ld+json">` Dataset blocks, served from the built worker (`wrangler dev`) before vs after:

  ```diff
  --- /state-of-claude-tooling Dataset JSON-LD (before)
  +++ /state-of-claude-tooling Dataset JSON-LD (after)
     "variableMeasured": [ ... unchanged ... ],
  +  "distribution": [
  +    {
  +      "@type": "DataDownload",
  +      "encodingFormat": "application/json",
  +      "contentUrl": "https://heyclau.de/api/reports/claude-tooling.json"
  +    },
  +    {
  +      "@type": "DataDownload",
  +      "encodingFormat": "text/csv",
  +      "contentUrl": "https://heyclau.de/api/reports/claude-tooling.csv"
  +    }
  +  ]
  ```

  and identically for `/state-of-mcp-servers` with `mcp-servers.json` / `mcp-servers.csv`. Both `contentUrl`s point at the pages' existing, working `/api/reports/*` exports (same URLs `<ReportDownloads>` already links).
- **No change to visible content** (acceptance criterion): JSON-LD renders zero pixels; the matrices below are visually identical by design. No copy, layout, or component change.
- **Regression test proven RED**: the new `tests/state-report-dataset-distribution.test.ts` pins both pages' Dataset blocks at the source level (same pattern as `tests/browse-density-radiogroup.test.ts`): the block must contain a `distribution` array with both `DataDownload` encodings and the page's `reportExportUrl("<slug>", ...)` calls. On pre-fix code the 2 distribution assertions fail (2 locator tests pass); all 4 pass after the fix.
- **Out of scope honored**: the three `buildReportDataset()` pages and `/mcp-security-report` untouched; no report content/copy changed.

### Screenshot evidence

Full viewport × theme matrices for both touched pages. The change is JSON-LD-only (renders no pixels), so before/after pairs are visually identical by design.

`/state-of-claude-tooling`:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="360" alt="before tooling desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-tooling-desktop-light.png"> | <img width="360" alt="after tooling desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-tooling-desktop-light.png"> |
| Desktop · Dark | <img width="360" alt="before tooling desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-tooling-desktop-dark.png"> | <img width="360" alt="after tooling desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-tooling-desktop-dark.png"> |
| Tablet · Light | <img width="360" alt="before tooling tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-tooling-tablet-light.png"> | <img width="360" alt="after tooling tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-tooling-tablet-light.png"> |
| Tablet · Dark | <img width="360" alt="before tooling tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-tooling-tablet-dark.png"> | <img width="360" alt="after tooling tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-tooling-tablet-dark.png"> |
| Mobile · Light | <img width="360" alt="before tooling mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-tooling-mobile-light.png"> | <img width="360" alt="after tooling mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-tooling-mobile-light.png"> |
| Mobile · Dark | <img width="360" alt="before tooling mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-tooling-mobile-dark.png"> | <img width="360" alt="after tooling mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-tooling-mobile-dark.png"> |

`/state-of-mcp-servers`:

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="360" alt="before mcp desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-mcp-desktop-light.png"> | <img width="360" alt="after mcp desktop light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-mcp-desktop-light.png"> |
| Desktop · Dark | <img width="360" alt="before mcp desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-mcp-desktop-dark.png"> | <img width="360" alt="after mcp desktop dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-mcp-desktop-dark.png"> |
| Tablet · Light | <img width="360" alt="before mcp tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-mcp-tablet-light.png"> | <img width="360" alt="after mcp tablet light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-mcp-tablet-light.png"> |
| Tablet · Dark | <img width="360" alt="before mcp tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-mcp-tablet-dark.png"> | <img width="360" alt="after mcp tablet dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-mcp-tablet-dark.png"> |
| Mobile · Light | <img width="360" alt="before mcp mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-mcp-mobile-light.png"> | <img width="360" alt="after mcp mobile light" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-mcp-mobile-light.png"> |
| Mobile · Dark | <img width="360" alt="before mcp mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/before-mcp-mobile-dark.png"> | <img width="360" alt="after mcp mobile dark" src="https://raw.githubusercontent.com/tryeverything24/awesome-claude/pr-assets-5455-state-dataset/shots/after-mcp-mobile-dark.png"> |

## Validation

- [x] `pnpm exec vitest run tests/data-reports-lib.test.ts tests/web-data-reports.test.ts` — pass (issue's listed set)
- [x] `pnpm build` — succeeds (issue's listed set)
- [x] `git diff --check` — clean (issue's listed set)
- [x] `pnpm exec vitest run tests/state-report-dataset-distribution.test.ts` — 4/4 pass (2 fail on pre-fix code)
- [x] `pnpm test` — full suite, 772 files / 39826 tests pass
- [x] `pnpm type-check` — clean
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check` on changed files — clean
