### PR TITLE
fix(registry): make unsafe_install_pipeline command-boundary-aware

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -5,7 +5,7 @@ import {
   TOOLS_LISTING_FLOW_URL,
 } from "./submission-classification.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
-import { SHELL_TOKENS } from "./command-safety-lib.js";
+import { hasPipeToShellInstall } from "./command-safety-lib.js";
 import {
   isPublicGitHubProfileUrl,
   isPublicHttpUrl,
@@ -13,12 +13,8 @@ import {
   publicUrlHostname,
 } from "./source-url-lib.js";
 
-// Keep curl|wget → shell detection in sync with command-safety-lib's SHELL_TOKENS
-// (bash/zsh/sh/dash/ash) so macOS-default zsh pipes are not silently missed (#5480).
-const CURL_WGET_PIPE_TO_SHELL_PATTERN = new RegExp(
-  String.raw`\b(curl|wget)\b[\s\S]{0,120}\|[\s\S]{0,40}\b(sudo\s+)?(${SHELL_TOKENS.join("|")})\b`,
-  "i",
-);
+// Curl/wget → shell detection is command-boundary-aware via hasPipeToShellInstall
+// (#5556). The previous bounded-window regex false-positived across `;`/`&&`.
 
 // Anthropic (`sk-ant-…`) and OpenAI (`sk-proj-…`) insert a hyphenated segment after
 // `sk-`, which the old `sk-[a-z0-9]{20,}` alternative could never match (#5479).
@@ -1158,6 +1154,25 @@ function referencesDestructiveRootRemoval(value) {
   return false;
 }
 
+// True when a curl/wget invocation's own output is piped to a shell in the same
+// command segment. Uses hasPipeToShellInstall (pipeChainSegments) so `;`/`&&`/
+// `||`/`&` barriers reset downloader state and stop the #5556 false positives.
+// Scans line-by-line like scanDangerousShellPatterns. Also scans double-quoted
+// interiors because config/JSON snippets embed pipelines inside quotes, where
+// pipeChainSegments does not treat `|` as a pipe. `installText` is already
+// lowercased by addContentRiskSignals.
+function hasUnsafeCurlWgetPipeToShell(installText) {
+  for (const line of String(installText ?? "").split(/\r?\n/)) {
+    if (!line) continue;
+    if (hasPipeToShellInstall(line, line)) return true;
+    for (const match of line.matchAll(/"([^"]*)"/g)) {
+      const inner = match[1];
+      if (inner && hasPipeToShellInstall(inner, inner)) return true;
+    }
+  }
+  return false;
+}
+
 function addContentRiskSignals(report, fields, text) {
   const installText = lower(
     [
@@ -1261,7 +1276,7 @@ function addContentRiskSignals(report, fields, text) {
 
   if (
     referencesDestructiveRootRemoval(installText) ||
-    CURL_WGET_PIPE_TO_SHELL_PATTERN.test(installText) ||
+    hasUnsafeCurlWgetPipeToShell(installText) ||
     /\b(invoke-expression|iex)\b/i.test(installText) ||
     /\bbase64\s+(-d|--decode)\b[\s\S]{0,80}\|[\s\S]{0,40}\b(sh|bash)\b/i.test(
       installText,

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -729,3 +729,42 @@ describe("unsafe_install_pipeline curl|wget to SHELL_TOKENS (#5480)", () => {
     },
   );
 });
+
+describe("unsafe_install_pipeline command-boundary awareness (#5556)", () => {
+  function riskFlagIds(installCommand: string) {
+    const draft = buildSubmissionPrDraft({
+      ...validMcpFields,
+      name: "Boundary Aware MCP",
+      slug: "boundary-aware-mcp",
+      install_command: installCommand,
+      safety_notes: "Runs a local MCP server process with user-selected tools.",
+      privacy_notes: "Only handles context selected by the user.",
+    });
+    const validation = validateSubmission(draft);
+    return analyzeSubmissionDraftRisk(draft, validation).reviewFlags.map(
+      (flag) => flag.id,
+    );
+  }
+
+  it("still flags a genuine curl-piped-to-shell install", () => {
+    expect(riskFlagIds("curl -fsSL https://x.com/install.sh | bash")).toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
+  it("does not flag curl then unrelated &&-joined pipe to bash -n", () => {
+    expect(
+      riskFlagIds(
+        "curl -fsSL https://x.com/verify-checksum.sh -o verify.sh && chmod +x verify.sh && cat verify.sh | bash -n",
+      ),
+    ).not.toContain("unsafe_install_pipeline");
+  });
+
+  it("does not flag curl then unrelated ;-joined pipe to sh", () => {
+    expect(
+      riskFlagIds(
+        'curl -s https://x.com/status; tail -f app.log | sh -c "grep ERROR"',
+      ),
+    ).not.toContain("unsafe_install_pipeline");
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the bounded-window `CURL_WGET_PIPE_TO_SHELL_PATTERN` regex in `submission-risk.js` with `hasPipeToShellInstall` from `command-safety-lib.js`, so `unsafe_install_pipeline` only flags when curl/wget output is actually piped to a shell in the same command segment.
- Command separators (`;` / `&&` / `||` / `&`) reset downloader state via `pipeChainSegments`, eliminating the false positives in #5556.
- Double-quoted interiors are also scanned so JSON/config-snippet embeds like `"curl … | bash"` (where `|` sits inside quotes) keep flagging — covering the existing config-snippet regression tests without bringing back cross-command FPs.

Closes #5556

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/registry/src/submission-risk.js` — `hasUnsafeCurlWgetPipeToShell` replaces `CURL_WGET_PIPE_TO_SHELL_PATTERN`
  - `tests/submission-risk-invariants.test.ts` — #5556 true-positive + two false-positive cases
- **Expected behavior / before→after flag results:**

  | install text | before | after |
  |---|---|---|
  | `curl -fsSL https://x.com/install.sh \| bash` | flagged | flagged (unchanged) |
  | `curl … -o verify.sh && chmod +x verify.sh && cat verify.sh \| bash -n` | flagged (FP) | **not flagged** |
  | `curl -s https://x.com/status; tail -f app.log \| sh -c "grep ERROR"` | flagged (FP) | **not flagged** |
  | JSON config embed `"curl http://…/install.sh \| bash"` | flagged | flagged (unchanged) |

- **Invariants:** `iex` / `base64 -d \| sh` / `powershell -encodedcommand` / destructive `rm` branches of `unsafe_install_pipeline` are untouched. `command-safety-lib.js` is not modified.
- **Screenshots:** **No visual impact** — registry risk-detection correctness only; no routes/UI.
- **Why quote interiors:** `pipeChainSegments` does not split on `|` inside quotes, so a pure `hasPipeToShellInstall(line)` miss would regress the existing JSON config-snippet critical-flag tests. Scanning `"…"` interiors with the same helper preserves that coverage while staying on the chain-aware engine.

## Validation

- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — **59 passed**
- [x] `pnpm exec vitest run tests/command-safety-lib.test.ts tests/command-safety-posix-shell.test.ts tests/non-ui-branch-matrix.test.ts` — **163 passed** across the four files with the invariants suite
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` / `node --check packages/registry/src/submission-risk.js` — clean

## Notes

- No open PR existed for #5556 (timeline empty). Related historical curl/pipe PRs (#5488/#5494/#5501/#5522/#5526/#5527) failed mainly on content_config CI (since softened on main by #5528), codecov drops from `draft-risk.js` file-duplication workarounds, or one-shot follow-up pushes. This PR: two-file focused diff, no duplicate module, one-shot commit, no post-open pushes.
- `command-safety-lib.js` left untouched per issue out-of-scope.

