### PR TITLE
feat(mcp): give registry.updates tag/query/trust filters like search/list

### DIFF
--- a/packages/mcp/src/registry-handlers-lib.js
+++ b/packages/mcp/src/registry-handlers-lib.js
@@ -134,6 +134,9 @@ export function sortEntriesByUpdatedAt(entries, entryUpdatedAt) {
 export function buildRecentUpdatesResponse({
   category,
   platform,
+  tag,
+  query,
+  trustFilters,
   since,
   entries,
 }) {
@@ -141,6 +144,15 @@ export function buildRecentUpdatesResponse({
     ok: true,
     category: category || "",
     platform: platform || "",
+    tag: tag || "",
+    query: query || "",
+    filters: trustFilters || {
+      hasSafetyNotes: "all",
+      hasPrivacyNotes: "all",
+      downloadTrust: "all",
+      claimStatus: "all",
+      sourceStatus: "all",
+    },
     since,
     count: entries.length,
     entries,

--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -375,6 +375,9 @@ export async function getRecentUpdates(args = {}, options = {}) {
   }
   const limit = normalizeLimit(args.limit, 10);
   const platform = normalizePlatform(args.platform);
+  const tag = normalizeText(args.tag);
+  const query = normalizeText(args.query);
+  const trustFilters = parsedTrustArgs(args);
   const searchIndex = unwrapEntries(
     await readJsonArtifact("search-index.json", options),
   );
@@ -382,6 +385,9 @@ export async function getRecentUpdates(args = {}, options = {}) {
     searchIndex
       .filter((entry) => !category || entry.category === category)
       .filter((entry) => entryMatchesPlatform(entry, platform))
+      .filter((entry) => entryMatchesTag(entry, tag))
+      .filter((entry) => entryMatchesQuery(entry, query))
+      .filter((entry) => entryMatchesTrustFilters(entry, trustFilters))
       .filter((entry) => !since || entryUpdatedAt(entry) >= since),
     entryUpdatedAt,
   );
@@ -391,7 +397,15 @@ export async function getRecentUpdates(args = {}, options = {}) {
     entryUpdatedAt,
   );
 
-  return buildRecentUpdatesResponse({ category, platform, since, entries });
+  return buildRecentUpdatesResponse({
+    category,
+    platform,
+    tag,
+    query: args.query,
+    trustFilters,
+    since,
+    entries,
+  });
 }
 
 export async function getRelatedEntries(args = {}, options = {}) {

--- a/packages/mcp/src/schemas-lib.js
+++ b/packages/mcp/src/schemas-lib.js
@@ -294,6 +294,44 @@ export const RecentUpdatesInputSchema = z
     platform: platform
       .optional()
       .describe("Filter to entries compatible with this platform."),
+    tag: z
+      .string()
+      .trim()
+      .min(1)
+      .max(80)
+      .optional()
+      .describe("Filter to entries carrying this exact tag."),
+    query: z
+      .string()
+      .trim()
+      .max(240)
+      .optional()
+      .describe("Keyword search to narrow the listing."),
+    hasSafetyNotes: trustBooleanFilter
+      .optional()
+      .describe(
+        "Filter by whether entries include safety notes ('true', 'false', or 'all').",
+      ),
+    hasPrivacyNotes: trustBooleanFilter
+      .optional()
+      .describe(
+        "Filter by whether entries include privacy notes ('true', 'false', or 'all').",
+      ),
+    downloadTrust: downloadTrustFilter
+      .optional()
+      .describe(
+        "Filter by package download trust level ('first-party', 'external', 'none', or 'all').",
+      ),
+    claimStatus: claimStatusFilter
+      .optional()
+      .describe(
+        "Filter by claim or verification status ('unclaimed', 'pending', 'verified', or 'all').",
+      ),
+    sourceStatus: sourceStatusFilter
+      .optional()
+      .describe(
+        "Filter by whether the entry's source URL is reachable ('available', 'missing', or 'all').",
+      ),
     since: z
       .string()
       .trim()

--- a/tests/mcp-registry-tool-orchestration-lib-g.test.ts
+++ b/tests/mcp-registry-tool-orchestration-lib-g.test.ts
@@ -139,6 +139,91 @@ describe("registry-tool-orchestration getRecentUpdates", () => {
     expect(result.count).toBe(2);
     expect(result.platform).toBe("");
   });
+
+  const mixedFilterOptions = {
+    readJsonArtifact: async () => ({
+      entries: [
+        {
+          category: "mcp",
+          slug: "tagged-safe",
+          title: "Tagged Safe Server",
+          description: "postgres connector with safety notes",
+          tags: ["database", "postgres"],
+          platforms: ["claude-code"],
+          safetyNotes: [{ text: "Runs shell commands" }],
+          dateAdded: "2026-05-03",
+        },
+        {
+          category: "mcp",
+          slug: "untagged-plain",
+          title: "Plain Server",
+          description: "generic helper without notes",
+          tags: ["utility"],
+          platforms: ["cursor"],
+          dateAdded: "2026-05-02",
+        },
+      ],
+    }),
+    readTextArtifact: async () => "",
+  };
+
+  it("filters recent updates by tag, like registry.search/list", async () => {
+    const result = await getRecentUpdates(
+      { tag: "postgres" },
+      mixedFilterOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.tag).toBe("postgres");
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["tagged-safe"]);
+  });
+
+  it("filters recent updates by query, like registry.search/list", async () => {
+    const result = await getRecentUpdates(
+      { query: "postgres connector" },
+      mixedFilterOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.query).toBe("postgres connector");
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["tagged-safe"]);
+  });
+
+  it("filters recent updates by hasSafetyNotes trust filter", async () => {
+    const result = await getRecentUpdates(
+      { hasSafetyNotes: "true" },
+      mixedFilterOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.filters.hasSafetyNotes).toBe("true");
+    expect(result.entries.map((entry) => entry.slug)).toEqual(["tagged-safe"]);
+  });
+
+  it("AND-combines tag with category/platform/since and preserves omit-all behavior", async () => {
+    const narrowed = await getRecentUpdates(
+      {
+        category: "mcp",
+        platform: "claude-code",
+        tag: "database",
+        since: "2026-05-01",
+      },
+      mixedFilterOptions,
+    );
+    expect(narrowed.ok).toBe(true);
+    expect(narrowed.entries.map((entry) => entry.slug)).toEqual([
+      "tagged-safe",
+    ]);
+
+    const omitted = await getRecentUpdates({}, mixedFilterOptions);
+    expect(omitted.count).toBe(2);
+    expect(omitted.tag).toBe("");
+    expect(omitted.query).toBe("");
+    expect(omitted.filters).toEqual({
+      hasSafetyNotes: "all",
+      hasPrivacyNotes: "all",
+      downloadTrust: "all",
+      claimStatus: "all",
+      sourceStatus: "all",
+    });
+  });
 });
 
 describe("registry-tool-orchestration getRelatedEntries", () => {

--- a/tests/mcp-schemas-lib.test.ts
+++ b/tests/mcp-schemas-lib.test.ts
@@ -508,10 +508,27 @@ describe("RecentUpdatesInputSchema", () => {
     });
   });
 
+  it("accepts tag, query, and trust filters like registry.search/list", () => {
+    expectParseSuccess(RecentUpdatesInputSchema, {
+      category: VALID_CATEGORY,
+      platform: "claude-code",
+      tag: "postgres",
+      query: "connector",
+      hasSafetyNotes: "true",
+      hasPrivacyNotes: "all",
+      downloadTrust: "first-party",
+      claimStatus: "verified",
+      sourceStatus: "available",
+      since: "2026-05-01",
+      limit: 10,
+    });
+  });
+
   it.each([
     ["since too short", { since: "202" }],
     ["since over 40 chars", { since: "s".repeat(41) }],
     ["limit below 1", { limit: 0 }],
+    ["unknown param", { category: VALID_CATEGORY, unexpected: true }],
   ])("rejects %s", (_label, value) => {
     expectParseFailure(RecentUpdatesInputSchema, value);
   });


### PR DESCRIPTION
## Summary

- Extend `RecentUpdatesInputSchema` with optional `tag`, `query`, and the five trust filters (`hasSafetyNotes`, `hasPrivacyNotes`, `downloadTrust`, `claimStatus`, `sourceStatus`) — same shapes/descriptions as `registry.search` / `registry.list`.
- Apply them in `getRecentUpdates` via the shared `entryMatchesTag` / `entryMatchesQuery` / `entryMatchesTrustFilters` helpers (plus existing `category` / `platform` / `since`), AND-combined before the `limit` slice.
- Echo applied `tag` / `query` / `filters` from `buildRecentUpdatesResponse` (same pattern as #5485 echoing `platform`).

Closes #5561

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/mcp/src/schemas-lib.js` — `RecentUpdatesInputSchema`
  - `packages/mcp/src/registry-tool-orchestration-lib.js` — `getRecentUpdates`
  - `packages/mcp/src/registry-handlers-lib.js` — `buildRecentUpdatesResponse` echo fields
  - `tests/mcp-registry-tool-orchestration-lib-g.test.ts`, `tests/mcp-schemas-lib.test.ts`
- **Invariants:**
  - New filters are optional and **AND-combined** with existing `category` / `platform` / `since`.
  - Omitting them preserves prior behavior (`tag`/`query` empty; trust filters default to `"all"` via `parsedTrustArgs`).
  - `.strict()` still rejects unknown params.
  - No changes to `registry.search` / `registry.list` filter implementations (reuse only).
- **Screenshots:** **No visual impact** — MCP tool schema/filter parity only; no routes/UI.

## Validation

- [x] `pnpm exec vitest run tests/mcp-registry-tool-orchestration-lib-a.test.ts tests/mcp-registry-tool-orchestration-lib-g.test.ts` — **754 passed**
- [x] `pnpm exec vitest run tests/mcp-schemas-lib.test.ts tests/mcp-registry-handlers-lib.test.ts` — **1628 passed**
- [x] `pnpm exec vitest run tests/mcp-server.test.ts tests/non-ui-branch-matrix.test.ts tests/mcp-http-route.test.ts` — **99 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` / `node --check` on touched JS — clean

## Notes

- No prior PR for #5561 (timeline empty). Pattern follows merged #5485 (platform filter on `registry.updates`): schema + orchestration + response echo + focused tests.
- One-shot commit; no post-open pushes.

