### PR TITLE
fix(registry): share one affiliate-param set across risk and source URL

### DIFF
--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -11,7 +11,7 @@
 
 import { RESERVED_OWNERS } from "./source-repo-lib.js";
 
-const AFFILIATE_PARAMS = new Set([
+export const AFFILIATE_PARAMS = new Set([
   "aff",
   "affiliate",
   "affiliate_id",
@@ -19,9 +19,11 @@ const AFFILIATE_PARAMS = new Set([
   "coupon",
   "irclickid",
   "partner",
+  "partner_id",
   "ref",
   "referral",
   "referral_code",
+  "tag",
   "via",
 ]);
 

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -7,6 +7,7 @@ import {
 import { parseSafeFrontmatter } from "./frontmatter.js";
 import { hasPipeToShellInstall } from "./command-safety-lib.js";
 import {
+  AFFILIATE_PARAMS,
   isPublicGitHubProfileUrl,
   isPublicHttpUrl,
   isPublicHttpsUrl,
@@ -925,24 +926,11 @@ function isLikelyAffiliateUrl(value) {
 
   try {
     const url = new URL(raw);
-    const affiliateParams = new Set([
-      "aff",
-      "affiliate",
-      "affiliate_id",
-      "irclickid",
-      "partner",
-      "partner_id",
-      "ref",
-      "referral",
-      "referral_code",
-      "tag",
-      "via",
-    ]);
 
     for (const key of url.searchParams.keys()) {
       const normalizedKey = key.toLowerCase();
       if (
-        affiliateParams.has(normalizedKey) ||
+        AFFILIATE_PARAMS.has(normalizedKey) ||
         normalizedKey.startsWith("utm_aff")
       ) {
         return true;

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -24,9 +24,11 @@ const AFFILIATE_PARAMS = [
   "coupon",
   "irclickid",
   "partner",
+  "partner_id",
   "ref",
   "referral",
   "referral_code",
+  "tag",
   "via",
 ];
 
@@ -631,6 +633,26 @@ describe("hasAffiliateParam partner and coupon campaigns", () => {
       );
     },
   );
+});
+
+describe("shared affiliate param union (#5558)", () => {
+  it.each(["tag", "partner_id"])(
+    "treats previously risk-only %s as affiliate for hasAffiliateParam and canonicalize",
+    (name) => {
+      const url = `https://example.com/p?${name}=mytag-20&keep=1`;
+      expect(isAffiliateParam(name)).toBe(true);
+      expect(hasAffiliateParam(url)).toBe(true);
+      expect(canonicalizeSourceUrl(url)).toBe("https://example.com/p?keep=1");
+      expect(stripTrackingParams(url)).toBe("https://example.com/p?keep=1");
+    },
+  );
+
+  it("still treats campaign and coupon as affiliate after the union", () => {
+    expect(hasAffiliateParam("https://example.com/p?campaign=spring")).toBe(
+      true,
+    );
+    expect(hasAffiliateParam("https://example.com/p?coupon=SAVE10")).toBe(true);
+  });
 });
 
 describe("canonicalizeSourceUrl registry comparison scenarios", () => {

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -11,6 +11,7 @@ import {
   formatSubmissionRiskMarkdown,
   tierFromFlags,
 } from "@heyclaude/registry/submission-risk";
+import { hasAffiliateParam } from "../packages/registry/src/source-url-lib.js";
 
 const dayMs = 86_400_000;
 
@@ -556,6 +557,20 @@ describe("checks ported from validate-content-policy", () => {
       expect(
         flags.find((flag) => flag.id === "affiliate_referral_url")?.severity,
       ).toBe("high");
+    }
+  });
+
+  it("agrees with hasAffiliateParam on tag and partner_id query params (#5558)", () => {
+    for (const url of [
+      "https://x.com/p?tag=mytag-20",
+      "https://x.com/p?partner_id=42",
+      "https://x.com/p?campaign=spring",
+      "https://x.com/p?coupon=SAVE10",
+    ]) {
+      expect(hasAffiliateParam(url), url).toBe(true);
+      expect(flagsFor({ github_url: url }).ids, url).toContain(
+        "affiliate_referral_url",
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

- Expand `AFFILIATE_PARAMS` in `source-url-lib.js` to the union of both lists (adds `tag` and `partner_id`; keeps `campaign`/`coupon`).
- Export that shared set and reuse it from `submission-risk.js`'s `isLikelyAffiliateUrl` instead of maintaining a second inline copy.
- Path-segment affiliate detection in `submission-risk.js` is unchanged (out of scope).

Closes #5558

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/registry/src/source-url-lib.js` — exported union `AFFILIATE_PARAMS`
  - `packages/registry/src/submission-risk.js` — import shared set; drop inline duplicate
  - `tests/source-url-lib.test.ts`, `tests/submission-risk-invariants.test.ts`
- **Before → after agreement:**

  | URL | `hasAffiliateParam` before | risk `affiliate_referral_url` before | both after |
  |---|---|---|---|
  | `https://x.com/p?tag=mytag-20` | false | flagged | **both true/flagged** |
  | `https://x.com/p?partner_id=42` | false | flagged | **both true/flagged** |
  | `?campaign=` / `?coupon=` | true | not flagged (gap) | **both true/flagged** |
  | originally shared 9 params (`ref`, `aff`, …) | true | flagged | unchanged |

- `canonicalizeSourceUrl` / `stripTrackingParams` now strip `tag`/`partner_id` the same way as `ref`/`aff`.
- **Screenshots:** **No visual impact** — registry URL classification only.

## Validation

- [x] `pnpm exec vitest run tests/source-url-lib.test.ts tests/submission-risk-invariants.test.ts` — **295 passed**
- [x] `pnpm exec vitest run tests/source-url.test.ts tests/submission-lib.test.ts tests/submission-pr-first.test.ts` — **411 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` / `node --check` — clean

## Notes

- No prior PR for #5558 (timeline empty). One-shot commit; no post-open pushes.
- Kept path-segment `/referral|affiliate|partners?/` and bare `/ref` logic in `submission-risk.js` untouched per issue out-of-scope.


Made with [Cursor](https://cursor.com)