### PR TITLE
fix(mcp): share one source URL field list for status and hosts

### DIFF
--- a/packages/mcp/src/registry-trust-lib.js
+++ b/packages/mcp/src/registry-trust-lib.js
@@ -6,6 +6,7 @@ import {
   entryClaimStatusValue,
   entryPackageTrustValue,
   entrySourceStatusValue,
+  entrySourceUrls,
 } from "./search-ranking.js";
 
 // Deterministic, disclosure-only trust signals. Each signal reflects whether a
@@ -35,16 +36,10 @@ export function sourceHost(value) {
 }
 
 export function entrySourceHosts(entry) {
-  return [
-    entry.documentationUrl,
-    entry.repoUrl,
-    entry.url,
-    entry.canonicalUrl,
-    entry.llmsUrl,
-    entry.apiUrl,
-  ]
-    .map(sourceHost)
-    .filter(Boolean);
+  // Hosts must come from the same URL field list as `source.status`
+  // (`entrySourceUrls` / `ENTRY_SOURCE_URL_FIELDS`) so the two signals cannot
+  // disagree for a single entry.
+  return entrySourceUrls(entry).map(sourceHost).filter(Boolean);
 }
 
 export function sourceSummary(entry) {

--- a/packages/mcp/src/search-ranking-lib.js
+++ b/packages/mcp/src/search-ranking-lib.js
@@ -220,14 +220,31 @@ function matchingIntentProfiles(tokens) {
   );
 }
 
-function sourceUrls(entry) {
-  return [
-    entry.documentationUrl,
-    entry.docsUrl,
-    entry.repoUrl,
-    entry.githubUrl,
-    entry.sourceUrl,
-  ].filter((value) => String(value || "").trim());
+/**
+ * Canonical entry URL fields shared by `source.status` and `source.sourceHosts`.
+ *
+ * This is the union of the historical status list (`documentationUrl`, `docsUrl`,
+ * `repoUrl`, `githubUrl`, `sourceUrl`) and the historical hosts list
+ * (`documentationUrl`, `repoUrl`, `url`, `canonicalUrl`, `llmsUrl`, `apiUrl`).
+ * Keeping one list prevents contradictory trust summaries such as
+ * `status: "missing"` with a non-empty `sourceHosts` array.
+ */
+export const ENTRY_SOURCE_URL_FIELDS = Object.freeze([
+  "documentationUrl",
+  "docsUrl",
+  "repoUrl",
+  "githubUrl",
+  "sourceUrl",
+  "url",
+  "canonicalUrl",
+  "llmsUrl",
+  "apiUrl",
+]);
+
+export function entrySourceUrls(entry) {
+  return ENTRY_SOURCE_URL_FIELDS.map((field) => entry?.[field]).filter(
+    (value) => String(value || "").trim(),
+  );
 }
 
 function buildEntrySearchSignals(entry) {
@@ -430,7 +447,7 @@ export function entryPackageTrustValue(entry) {
 export function entrySourceStatusValue(entry) {
   return (
     entry?.trustSignals?.sourceStatus ||
-    (sourceUrls(entry ?? {}).length ? "available" : "missing")
+    (entrySourceUrls(entry ?? {}).length ? "available" : "missing")
   );
 }
 

--- a/packages/mcp/src/search-ranking.d.ts
+++ b/packages/mcp/src/search-ranking.d.ts
@@ -30,6 +30,10 @@ export type RegistrySearchDocumentLike = {
   repoUrl?: string;
   githubUrl?: string;
   sourceUrl?: string;
+  url?: string;
+  canonicalUrl?: string;
+  llmsUrl?: string;
+  apiUrl?: string;
   dateAdded?: string;
   trustSignals?: {
     hasSafetyNotes?: boolean;
@@ -38,6 +42,13 @@ export type RegistrySearchDocumentLike = {
     sourceStatus?: string;
   };
 };
+
+/** Canonical URL fields shared by `source.status` and `source.sourceHosts`. */
+export const ENTRY_SOURCE_URL_FIELDS: readonly string[];
+
+export function entrySourceUrls(
+  entry: RegistrySearchDocumentLike | null | undefined,
+): string[];
 
 export type RankedRegistrySearchEntry<T extends RegistrySearchDocumentLike> = {
   entry: T;

--- a/packages/mcp/src/search-ranking.js
+++ b/packages/mcp/src/search-ranking.js
@@ -6,12 +6,14 @@
  * `@heyclaude/mcp/search-ranking` imports stay unchanged.
  */
 export {
+  ENTRY_SOURCE_URL_FIELDS,
   entryClaimStatusValue,
   entryHasPrivacyNotes,
   entryHasSafetyNotes,
   entryIsInstallable,
   entryPackageTrustValue,
   entrySourceStatusValue,
+  entrySourceUrls,
   matchesRegistryPlatform,
   matchesRegistryQuery,
   normalizeRegistryPlatform,

--- a/tests/mcp-registry-trust-lib.test.ts
+++ b/tests/mcp-registry-trust-lib.test.ts
@@ -11,6 +11,11 @@ import {
   sourceHost,
   sourceSummary,
 } from "../packages/mcp/src/registry-trust-lib.js";
+import {
+  ENTRY_SOURCE_URL_FIELDS,
+  entrySourceStatusValue,
+  entrySourceUrls,
+} from "../packages/mcp/src/search-ranking-lib.js";
 
 function makeEntry(overrides: Record<string, unknown> = {}) {
   return {
@@ -167,8 +172,11 @@ describe("registry-trust-lib entrySourceHosts", () => {
     expect(
       entrySourceHosts(
         makeEntry({
-          repoUrl: "",
           documentationUrl: "",
+          docsUrl: "",
+          repoUrl: "",
+          githubUrl: "",
+          sourceUrl: "",
           url: "",
           canonicalUrl: "",
           llmsUrl: "",
@@ -176,6 +184,63 @@ describe("registry-trust-lib entrySourceHosts", () => {
         }),
       ),
     ).toEqual([]);
+  });
+
+  it("keeps source.status and source.sourceHosts consistent for url-only entries", () => {
+    // Before: status used a narrower field list than hosts, so url-only entries
+    // reported status "missing" while sourceHosts was non-empty.
+    const entry = makeEntry({
+      documentationUrl: "",
+      docsUrl: "",
+      repoUrl: "",
+      githubUrl: "",
+      sourceUrl: "",
+      url: "https://heyclau.de/entry/mcp/browser-bridge",
+      canonicalUrl: "",
+      llmsUrl: "",
+      apiUrl: "",
+    });
+    const trust = entryTrustSummary(entry);
+    expect(entrySourceUrls(entry)).toEqual([
+      "https://heyclau.de/entry/mcp/browser-bridge",
+    ]);
+    expect(entrySourceStatusValue(entry)).toBe("available");
+    expect(trust.source.status).toBe("available");
+    expect(trust.source.sourceHosts).toEqual(["heyclau.de"]);
+    expect(entrySourceHosts(entry)).toEqual(["heyclau.de"]);
+  });
+
+  it("includes status-only fields (docsUrl/githubUrl/sourceUrl) in hosts", () => {
+    const entry = makeEntry({
+      documentationUrl: "",
+      docsUrl: "https://docs-only.example.com/guide",
+      repoUrl: "",
+      githubUrl: "https://github.com/org/from-github-url",
+      sourceUrl: "https://source-only.example.com",
+      url: "",
+      canonicalUrl: "",
+      llmsUrl: "",
+      apiUrl: "",
+    });
+    const trust = entryTrustSummary(entry);
+    expect(trust.source.status).toBe("available");
+    expect(trust.source.sourceHosts).toEqual(
+      expect.arrayContaining([
+        "docs-only.example.com",
+        "github.com",
+        "source-only.example.com",
+      ]),
+    );
+    // status and hosts always agree: both non-empty here
+    expect(Boolean(trust.source.sourceHosts.length)).toBe(
+      trust.source.status === "available",
+    );
+  });
+
+  it("derives hosts from the shared ENTRY_SOURCE_URL_FIELDS list", () => {
+    expect(ENTRY_SOURCE_URL_FIELDS).toContain("url");
+    expect(ENTRY_SOURCE_URL_FIELDS).toContain("docsUrl");
+    expect(ENTRY_SOURCE_URL_FIELDS).toContain("githubUrl");
   });
 
   it("extracts hosts for mcp variant 0", () => {

--- a/tests/mcp-search-ranking-lib.test.ts
+++ b/tests/mcp-search-ranking-lib.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  ENTRY_SOURCE_URL_FIELDS,
   entryClaimStatusValue,
   entryHasPrivacyNotes,
   entryHasSafetyNotes,
   entryIsInstallable,
   entryPackageTrustValue,
   entrySourceStatusValue,
+  entrySourceUrls,
   matchesRegistryPlatform,
   matchesRegistryQuery,
   normalizeRegistryPlatform,
@@ -103,6 +105,48 @@ describe("search-ranking-lib trust and install signals", () => {
       entrySourceStatusValue(makeEntry({ repoUrl: "https://x.test" })),
     ).toBe("available");
     expect(entrySourceStatusValue(makeEntry({ repoUrl: "" }))).toBe("missing");
+  });
+
+  it("treats url-only entries as source-available via the shared field list", () => {
+    // Historical bug: hosts counted `url`, status did not — they disagreed.
+    expect(
+      entrySourceStatusValue(
+        makeEntry({
+          documentationUrl: "",
+          docsUrl: "",
+          repoUrl: "",
+          githubUrl: "",
+          sourceUrl: "",
+          url: "https://heyclau.de/entry/mcp/browser-bridge",
+        }),
+      ),
+    ).toBe("available");
+    expect(
+      entrySourceUrls(
+        makeEntry({
+          documentationUrl: "",
+          docsUrl: "",
+          repoUrl: "",
+          githubUrl: "",
+          sourceUrl: "",
+          url: "https://heyclau.de/entry/mcp/browser-bridge",
+        }),
+      ),
+    ).toEqual(["https://heyclau.de/entry/mcp/browser-bridge"]);
+  });
+
+  it("exports the canonical shared ENTRY_SOURCE_URL_FIELDS union", () => {
+    expect(ENTRY_SOURCE_URL_FIELDS).toEqual([
+      "documentationUrl",
+      "docsUrl",
+      "repoUrl",
+      "githubUrl",
+      "sourceUrl",
+      "url",
+      "canonicalUrl",
+      "llmsUrl",
+      "apiUrl",
+    ]);
   });
 
   it("reads package trust, claim status, and safety/privacy notes", () => {


### PR DESCRIPTION
## Summary

- Introduce a shared `ENTRY_SOURCE_URL_FIELDS` / `entrySourceUrls()` union covering both historical lists (`documentationUrl`, `docsUrl`, `repoUrl`, `githubUrl`, `sourceUrl`, `url`, `canonicalUrl`, `llmsUrl`, `apiUrl`).
- Drive `entrySourceStatusValue` (`source.status`) and `entrySourceHosts` (`source.sourceHosts`) from that single list so the two signals cannot disagree.
- Add regression tests for the url-only contradiction and for status-only fields (`docsUrl` / `githubUrl` / `sourceUrl`) appearing in hosts.

Closes #5560

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/mcp/src/search-ranking-lib.js` — shared `ENTRY_SOURCE_URL_FIELDS` + `entrySourceUrls`; `entrySourceStatusValue` uses it
  - `packages/mcp/src/search-ranking.js` / `.d.ts` — re-export + types
  - `packages/mcp/src/registry-trust-lib.js` — `entrySourceHosts` maps hosts from `entrySourceUrls`
  - `tests/mcp-search-ranking-lib.test.ts`, `tests/mcp-registry-trust-lib.test.ts`
- **Shared field list (final):** `documentationUrl`, `docsUrl`, `repoUrl`, `githubUrl`, `sourceUrl`, `url`, `canonicalUrl`, `llmsUrl`, `apiUrl`
- **Before → after (url-only entry):**

  | Signal | Before | After |
  |---|---|---|
  | `source.status` | `"missing"` | `"available"` |
  | `source.sourceHosts` | `["heyclau.de"]` | `["heyclau.de"]` |

  Constructed entry: only `url: "https://heyclau.de/entry/mcp/browser-bridge"` set; all other source URL fields empty.
- **Invariant:** for the same entry, `source.status === "available"` iff `source.sourceHosts.length > 0` (when `trustSignals.sourceStatus` is unset).
- **Backward compatibility:** `registry.search` / `registry.list` `sourceStatus: "available"` now includes entries whose only source evidence is `url` / `canonicalUrl` / `llmsUrl` / `apiUrl` / `docsUrl` / `githubUrl` / `sourceUrl` — matching what `sourceHosts` already exposed. Entries that already had `documentationUrl`/`repoUrl`/etc. are unchanged.
- **Screenshots:** **No visual impact** — MCP trust-summary / filter field-list reconciliation only; no UI, routes, or rendered pages changed.

## Validation

- [x] `pnpm exec vitest run tests/mcp-search-ranking-lib.test.ts tests/mcp-registry-trust-lib.test.ts` — **496 passed**
- [x] `pnpm exec vitest run tests/mcp-registry-filter-lib.test.ts tests/mcp-registry-projection-lib.test.ts tests/mcp-registry-toolbox-lib.test.ts` — **551 passed**
- [x] `pnpm exec vitest run tests/mcp-registry-discovery-projection-lib.test.ts tests/mcp-server.test.ts` — **444 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean

## Notes

- Linked issue: #5560
- No follow-up commits planned (oneshot PR).

Made with [Cursor](https://cursor.com)