### PR TITLE
fix(web): make saved-search removal filter matching honest

### DIFF
--- a/apps/web/src/lib/registry-event-classify-lib.ts
+++ b/apps/web/src/lib/registry-event-classify-lib.ts
@@ -28,6 +28,11 @@ export type RegistryEventAction = RegistryEvent["action"];
  * 2. A `content/changelog…` path that did not match rule 1, or any path ending
  *    in `registry-changelog.json` → `changelog`.
  * 3. Any remaining path containing `validators` → `validator`.
+ *
+ * Entry events from this classifier are path-only: they do not carry
+ * trust/source/platforms. Saved-search removal matching therefore cannot
+ * satisfy filters on those dimensions unless a different producer enriches
+ * the event (see `removalEventSupportsSearchFilters`).
  */
 export function classifyRegistryPath(
   path: string,

--- a/apps/web/src/lib/saved-search-alerts-lib.ts
+++ b/apps/web/src/lib/saved-search-alerts-lib.ts
@@ -59,6 +59,16 @@ export interface SavedSearchAlertEvent {
   action?: string;
   date?: string;
   title?: string;
+  /**
+   * Optional match fields for removal fallbacks. The GitHub webhook path
+   * classifier (`classifyRegistryPath`) only emits category/slug/action/date
+   * today, so these are usually absent on real removal events. When a producer
+   * does supply them, trust/source/platform-filtered saved searches can match
+   * removals the same way category/query searches already do.
+   */
+  trust?: string;
+  source?: string;
+  platforms?: Array<Platform | string>;
 }
 
 export type SavedSearchAlertSeverity = "info" | "warning" | "blocker";
@@ -173,6 +183,44 @@ function eventAction(event: SavedSearchAlertEvent) {
   return event.action === "removed" ? "removed" : event.action === "added" ? "added" : "updated";
 }
 
+/**
+ * Build the synthetic entry used when a removed event has no live detail JSON.
+ * Carries category/slug/title (always present on entry events) plus any
+ * trust/source/platforms the event producer attached.
+ */
+export function removedEntryFromEvent(event: SavedSearchAlertEvent): SavedSearchAlertEntry {
+  const platforms = (event.platforms ?? [])
+    .map((platform) => String(platform || "").trim())
+    .filter(Boolean);
+  const trust = String(event.trust || "").trim();
+  const source = String(event.source || "").trim();
+  return {
+    category: event.category ?? "",
+    slug: event.slug ?? "",
+    title: event.title ?? "",
+    ...(trust ? { trust } : {}),
+    ...(source ? { source } : {}),
+    ...(platforms.length ? { platforms } : {}),
+  };
+}
+
+/**
+ * Whether a removal synthetic entry can satisfy a search's trust/source/platform
+ * filters. Category/query-only searches always can; filtered searches require
+ * the event to actually carry the matching field(s). Without this gate,
+ * `savedSearchMatchesEntry` would silently reject (entry field undefined ≠
+ * filter), contradicting the "match against carried fields" comment.
+ */
+export function removalEventSupportsSearchFilters(
+  search: SavedSearchAlertSearch,
+  entry: SavedSearchAlertEntry,
+): boolean {
+  if (search.trust && (entry.trust == null || entry.trust === "")) return false;
+  if (search.source && (entry.source == null || entry.source === "")) return false;
+  if (search.platform && !(entry.platforms ?? []).length) return false;
+  return true;
+}
+
 export function buildSavedSearchAlerts(
   searches: SavedSearchAlertSearch[],
   events: SavedSearchAlertEvent[],
@@ -189,22 +237,24 @@ export function buildSavedSearchAlerts(
     const action = eventAction(event);
     // A removed entry's detail JSON is gone, so `entriesByRef` never has it.
     // Match "removed" events against the event's own carried fields instead of
-    // requiring a live fetch, so a matching saved search can still surface the
-    // removal. Added/updated events keep needing the live entry (their payload
-    // doesn't carry the fields matching relies on).
+    // requiring a live fetch:
+    // - category / slug / title are always available from the path classifier
+    //   and power category- + query-only saved searches (unchanged).
+    // - trust / source / platforms are NOT emitted by `classifyRegistryPath` /
+    //   the GitHub webhook today (path-only push payload). Searches that filter
+    //   on those dimensions are explicitly skipped for synthetic removals unless
+    //   a producer enriched the event — see `removalEventSupportsSearchFilters`.
+    // Added/updated events keep needing the live entry.
     const liveEntry = entriesByRef.get(ref);
+    const usingRemovalFallback = action === "removed" && !liveEntry;
     const entry: SavedSearchAlertEntry | null =
-      liveEntry ??
-      (action === "removed"
-        ? {
-            category: event.category ?? "",
-            slug: event.slug ?? "",
-            title: event.title ?? "",
-          }
-        : null);
+      liveEntry ?? (action === "removed" ? removedEntryFromEvent(event) : null);
     if (!entry) continue;
 
     for (const search of activeSearches) {
+      if (usingRemovalFallback && !removalEventSupportsSearchFilters(search, entry)) {
+        continue;
+      }
       if (!savedSearchMatchesEntry(search, entry)) continue;
       const title = event.title || entry.title;
       alerts.push({

--- a/apps/web/src/lib/saved-search-alerts.ts
+++ b/apps/web/src/lib/saved-search-alerts.ts
@@ -18,5 +18,7 @@ export {
   activeInAppSavedSearches,
   savedSearchQueryMatchesEntry,
   savedSearchMatchesEntry,
+  removedEntryFromEvent,
+  removalEventSupportsSearchFilters,
   buildSavedSearchAlerts,
 } from "@/lib/saved-search-alerts-lib";

--- a/apps/web/src/lib/watch-events-lib.ts
+++ b/apps/web/src/lib/watch-events-lib.ts
@@ -11,6 +11,10 @@ export interface RegistryEvent {
   date?: string;
   title?: string;
   commit?: string;
+  /** Optional; see saved-search removal matching. Not set by path classifier. */
+  trust?: string;
+  source?: string;
+  platforms?: string[];
 }
 
 /** Stable watch-target id for an entry event, or null for non-entry events. */

--- a/tests/saved-search-alerts-lib.test.ts
+++ b/tests/saved-search-alerts-lib.test.ts
@@ -5,6 +5,8 @@ import {
   activeInAppSavedSearches,
   savedSearchQueryMatchesEntry,
   savedSearchMatchesEntry,
+  removedEntryFromEvent,
+  removalEventSupportsSearchFilters,
   buildSavedSearchAlerts,
   type SavedSearchAlertEntry,
   type SavedSearchAlertSearch,
@@ -262,6 +264,76 @@ describe("savedSearchMatchesEntry", () => {
   });
 });
 
+describe("removedEntryFromEvent / removalEventSupportsSearchFilters", () => {
+  it("copies optional trust/source/platforms when the event carries them", () => {
+    expect(
+      removedEntryFromEvent({
+        category: "mcp",
+        slug: "x",
+        title: "X",
+        trust: "trusted",
+        source: "source-backed",
+        platforms: ["claude-code", ""],
+      }),
+    ).toEqual({
+      category: "mcp",
+      slug: "x",
+      title: "X",
+      trust: "trusted",
+      source: "source-backed",
+      platforms: ["claude-code"],
+    });
+  });
+
+  it("omits blank optional fields so filter availability stays honest", () => {
+    expect(
+      removedEntryFromEvent({
+        category: "mcp",
+        slug: "x",
+        title: "X",
+        trust: "  ",
+        source: "",
+        platforms: [],
+      }),
+    ).toEqual({ category: "mcp", slug: "x", title: "X" });
+  });
+
+  it("reports whether a synthetic removal can satisfy search filters", () => {
+    const bare = removedEntryFromEvent({
+      category: "mcp",
+      slug: "x",
+      title: "X",
+    });
+    const enriched = removedEntryFromEvent({
+      category: "mcp",
+      slug: "x",
+      title: "X",
+      trust: "trusted",
+      source: "source-backed",
+      platforms: ["claude-code"],
+    });
+    expect(removalEventSupportsSearchFilters(search(), bare)).toBe(true);
+    expect(
+      removalEventSupportsSearchFilters(search({ trust: "trusted" }), bare),
+    ).toBe(false);
+    expect(
+      removalEventSupportsSearchFilters(search({ trust: "trusted" }), enriched),
+    ).toBe(true);
+    expect(
+      removalEventSupportsSearchFilters(
+        search({ platform: "claude-code" }),
+        bare,
+      ),
+    ).toBe(false);
+    expect(
+      removalEventSupportsSearchFilters(
+        search({ platform: "claude-code" }),
+        enriched,
+      ),
+    ).toBe(true);
+  });
+});
+
 describe("buildSavedSearchAlerts", () => {
   const entries = new Map([["mcp/postgres-memory", entry]]);
 
@@ -338,6 +410,94 @@ describe("buildSavedSearchAlerts", () => {
       title: "Postgres Memory MCP removed",
       href: "/entry/mcp/postgres-memory",
     });
+  });
+
+  it("does not alert trust/source/platform-filtered searches on path-only removals", () => {
+    // Webhook/path-classifier removal events only carry category/slug/title.
+    // Searches that filter on trust/source/platform are explicitly skipped for
+    // that synthetic fallback rather than silently failing inside the matcher.
+    const removedEvent = {
+      id: "evt-removed-filters",
+      kind: "entry",
+      category: "mcp",
+      slug: "postgres-memory",
+      action: "removed" as const,
+      date: "2026-06-19T11:00:00.000Z",
+      title: "Postgres Memory MCP",
+    };
+    expect(
+      buildSavedSearchAlerts(
+        [search({ trust: "trusted", q: "postgres" })],
+        [removedEvent],
+        new Map(),
+      ),
+    ).toEqual([]);
+    expect(
+      buildSavedSearchAlerts(
+        [search({ source: "source-backed", q: "postgres" })],
+        [removedEvent],
+        new Map(),
+      ),
+    ).toEqual([]);
+    expect(
+      buildSavedSearchAlerts(
+        [search({ platform: "claude-code", q: "postgres" })],
+        [removedEvent],
+        new Map(),
+      ),
+    ).toEqual([]);
+    // Category- and query-only searches still match on carried fields.
+    expect(
+      buildSavedSearchAlerts(
+        [search({ category: "mcp", q: "postgres" })],
+        [removedEvent],
+        new Map(),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("alerts trust/source/platform-filtered searches when the removal event carries those fields", () => {
+    const enrichedRemoval = {
+      id: "evt-removed-enriched",
+      kind: "entry",
+      category: "mcp",
+      slug: "postgres-memory",
+      action: "removed" as const,
+      date: "2026-06-19T12:00:00.000Z",
+      title: "Postgres Memory MCP",
+      trust: "trusted",
+      source: "source-backed",
+      platforms: ["claude-code", "claude-desktop"],
+    };
+    expect(
+      buildSavedSearchAlerts(
+        [search({ trust: "trusted", q: "postgres" })],
+        [enrichedRemoval],
+        new Map(),
+      ),
+    ).toHaveLength(1);
+    expect(
+      buildSavedSearchAlerts(
+        [search({ source: "source-backed", q: "postgres" })],
+        [enrichedRemoval],
+        new Map(),
+      ),
+    ).toHaveLength(1);
+    expect(
+      buildSavedSearchAlerts(
+        [search({ platform: "claude-code", q: "postgres" })],
+        [enrichedRemoval],
+        new Map(),
+      ),
+    ).toHaveLength(1);
+    // Wrong filter value still rejects.
+    expect(
+      buildSavedSearchAlerts(
+        [search({ trust: "blocked", q: "postgres" })],
+        [enrichedRemoval],
+        new Map(),
+      ),
+    ).toEqual([]);
   });
 
   it("does not fall back for non-removed events with a missing entry", () => {


### PR DESCRIPTION
## Summary

- Extend `SavedSearchAlertEvent` with optional `trust` / `source` / `platforms` and build the removal synthetic entry from those fields when present (`removedEntryFromEvent`).
- Explicitly skip trust/source/platform-filtered saved searches for path-only removal fallbacks via `removalEventSupportsSearchFilters`, instead of silently failing inside `savedSearchMatchesEntry`.
- Document that `classifyRegistryPath` / the GitHub webhook are path-only and do not emit those filter fields today.
- Category- and query-only removal alerts are unchanged.

Closes #5553

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `apps/web/src/lib/saved-search-alerts-lib.ts` — optional event fields, `removedEntryFromEvent`, `removalEventSupportsSearchFilters`, honest removal-fallback comments
  - `apps/web/src/lib/saved-search-alerts.ts` — re-exports
  - `apps/web/src/lib/watch-events-lib.ts` — optional fields on `RegistryEvent` so enriched producers can flow through
  - `apps/web/src/lib/registry-event-classify-lib.ts` — documents path-only emission
  - `tests/saved-search-alerts-lib.test.ts`
- **Data source:** GitHub push webhook → `classifyRegistryPath` only has changed paths (`category`/`slug`/`action`/`date`). Entry detail JSON 404s after removal, so trust/source/platforms are not available unless a future producer enriches the event.
- **Before → after:**

  | Saved search | Path-only removal event | Enriched removal (`trust`/`source`/`platforms` set) |
  |---|---|---|
  | category / query only | warning alert (unchanged) | warning alert |
  | `trust` / `source` / `platform` filter | **explicit skip** (documented) | warning alert when filters match |

- **Screenshots:** **No visual impact** — pure alert-matching lib logic; no UI/routes/rendering changes.

## Validation

- [x] `pnpm exec vitest run tests/saved-search-alerts-lib.test.ts tests/saved-search-alerts.test.ts tests/watch-events-lib.test.ts tests/registry-event-classify-lib.test.ts` — **49 passed**
- [x] `pnpm exec vitest run tests/saved-search-alerts-lib.test.ts tests/watch-alert-lib.test.ts` — **41 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean

## Notes

- Linked issue: #5553
- No failed PR existed for #5553; related removal work was merged in #5428 (which already noted trust/source/platform couldn't match). This makes that limitation explicit in code and enables matching when fields are present.
- No follow-up commits planned (oneshot PR).
