### PR TITLE
fix(web): label docker run for unpinned-package warnings

### DIFF
--- a/apps/web/src/lib/mcp-config-validator-lib.ts
+++ b/apps/web/src/lib/mcp-config-validator-lib.ts
@@ -291,6 +291,11 @@ export function packageRunnerName(command: string, args: string[]) {
   if (lower === "npm" && args.some((arg) => ["exec", "x"].includes(arg))) {
     return "npm exec";
   }
+  // Match packageFromRunner's docker detection so unpinned `docker run <image>`
+  // configs get the same pin-version warning as npx/uvx/bunx runners.
+  if (lower === "docker" && args.includes("run")) {
+    return "docker run";
+  }
   return "";
 }
 

--- a/tests/mcp-config-validator-lib.test.ts
+++ b/tests/mcp-config-validator-lib.test.ts
@@ -234,7 +234,8 @@ describe("MCP config validator lib", () => {
       expect(packageRunnerName("npm", ["exec", "@scope/pkg"])).toBe("npm exec");
       expect(packageRunnerName("npx", ["-y", "@example/mcp"])).toBe("npx");
       expect(packageRunnerName("bunx", ["@example/mcp"])).toBe("bunx");
-      expect(packageRunnerName("docker", ["run", "image"])).toBe("");
+      expect(packageRunnerName("docker", ["run", "image"])).toBe("docker run");
+      expect(packageRunnerName("docker", ["pull", "image"])).toBe("");
       expect(packageFromRunner("yarn", ["dlx", "@example/mcp"])).toBe(
         "@example/mcp",
       );
@@ -439,12 +440,31 @@ describe("MCP config validator lib", () => {
     });
 
     it("warns on unpinned docker image operands", () => {
-      const report = validateServer("dock", {
+      const unpinned = validateServer("dock", {
         command: "docker",
         args: ["run", "ghcr.io/example/mcp:latest"],
       });
-      expect(report.packageName).toBe("ghcr.io/example/mcp:latest");
-      expect(report.warnings.join("\n")).not.toContain("runs unpinned package");
+      expect(unpinned.packageName).toBe("ghcr.io/example/mcp:latest");
+      expect(unpinned.warnings.join("\n")).toContain(
+        "docker run runs unpinned package ghcr.io/example/mcp:latest",
+      );
+
+      const untagged = validateServer("dock-untagged", {
+        command: "docker",
+        args: ["run", "some/image"],
+      });
+      expect(untagged.warnings.join("\n")).toContain(
+        "docker run runs unpinned package some/image",
+      );
+
+      // isPinnedPackageSpec is npm @semver-only (out of scope to change). A
+      // docker image that happens to use that pin form should not warn.
+      const pinned = validateServer("dock-pinned", {
+        command: "docker",
+        args: ["run", "mcp-image@1.2.3"],
+      });
+      expect(pinned.packageName).toBe("mcp-image@1.2.3");
+      expect(pinned.warnings.join("\n")).not.toContain("runs unpinned package");
     });
 
     it("uses stdio transport when only command is present", () => {

--- a/tests/mcp-config-validator.test.ts
+++ b/tests/mcp-config-validator.test.ts
@@ -469,6 +469,10 @@ describe("MCP config validator", () => {
             command: "docker",
             args: ["run", "ghcr.io/example/mcp:1.2.3"],
           },
+          dockerPinned: {
+            command: "docker",
+            args: ["run", "mcp-image@1.2.3"],
+          },
         },
       }),
     );
@@ -488,11 +492,16 @@ describe("MCP config validator", () => {
         expect.stringContaining(
           "windowsUvx: uvx runs unpinned package windows-python-mcp",
         ),
+        // docker `:tag` is not an npm @semver pin (isPinnedPackageSpec out of
+        // scope), so once packageRunnerName labels docker run it warns too.
+        expect.stringContaining(
+          "dockerTagged: docker run runs unpinned package ghcr.io/example/mcp:1.2.3",
+        ),
       ]),
     );
     expect(result.warnings.join("\n")).not.toContain("pinnedUvx");
     expect(result.warnings.join("\n")).not.toContain("pinnedPnpm");
-    expect(result.warnings.join("\n")).not.toContain("dockerTagged");
+    expect(result.warnings.join("\n")).not.toContain("dockerPinned");
   });
 
   it("wraps bare server objects and warns on placeholders", () => {


### PR DESCRIPTION
## Summary

- Add a `docker` + `run` branch to `packageRunnerName` returning `"docker run"`, matching `packageFromRunner`'s existing detection.
- Unpinned `docker run <image>` configs now emit the same pin-version warning class as unpinned npx/uvx/bunx runners.
- Update tests that previously encoded the bug (expected empty runner label / no warning).

Closes #5552

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:** `apps/web/src/lib/mcp-config-validator-lib.ts` (`packageRunnerName` only); tests.
- **Before → after warnings:**

  | Config | Before | After |
  |---|---|---|
  | `docker run ghcr.io/example/mcp:latest` | `warnings = []` (no unpinned warning) | `["docker run runs unpinned package ghcr.io/example/mcp:latest; pin an exact version such as ghcr.io/example/mcp:latest@1.2.3 before granting MCP tool access."]` |
  | `docker run mcp-image@1.2.3` (npm-style pin recognized by `isPinnedPackageSpec`) | n/a | no unpinned-package warning |

- Note: `isPinnedPackageSpec` is npm `@semver`-only (out of scope per the issue). Docker `:tag` / `:1.2.3` forms remain unpinned under that helper; once `packageRunnerName` labels docker they correctly warn. A true no-warning docker case uses an npm-style `@1.2.3` pin the existing helper already accepts.
- `packageRunnerName("docker", ["run", "some/image"])` → `"docker run"`; `["pull", …]` still → `""`.
- Existing npx/uvx/bunx/pnpm/yarn/npm behavior unchanged.
- **Screenshots:** **No visual impact** — MCP config validator warning logic only.

## Validation

- [x] `pnpm exec vitest run tests/mcp-config-validator-lib.test.ts tests/mcp-config-validator.test.ts` — **54 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean

## Notes

- Linked issue: #5552
- No prior PR targeted this issue; related tests had been asserting the broken “no docker warning” behavior and are corrected here.
- No follow-up commits planned (oneshot PR).
