### PR TITLE
fix(mcp): reject reserved GitHub owners in bare contact handles

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -9,6 +9,7 @@
  * existing MCP imports stay unchanged.
  */
 import {
+  RESERVED_OWNERS,
   isPublicGitHubProfileUrl,
   isPublicHttpsUrl,
 } from "./public-url-lib.js";
@@ -144,6 +145,9 @@ function isGitHubHandle(value) {
     : normalizeText(value);
   if (!handle || handle.length > 39) return false;
   if (handle.startsWith("-") || handle.endsWith("-")) return false;
+  // Parity with isPublicGitHubProfileUrl: bare "settings"/"sponsors"/… are
+  // GitHub product surfaces, not accounts (see RESERVED_OWNERS / #5562).
+  if (RESERVED_OWNERS.has(handle.toLowerCase())) return false;
   return [...handle].every(
     (char) =>
       (char >= "a" && char <= "z") ||

--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -165,6 +165,35 @@ describe("submissions-lib spec validation", () => {
     );
   });
 
+  // Regression for #5562: bare reserved owners must match the URL-form reject.
+  it.each([
+    "settings",
+    "sponsors",
+    "marketplace",
+    "Settings",
+    "@settings",
+    "https://github.com/settings",
+  ])("rejects reserved-owner public contact %j", (contact_email) => {
+    const result = validateSubmissionDraftFromSpec(submissionSpec, {
+      fields: { ...validMcpFields, contact_email },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join("\n")).toContain(
+      "Invalid public contact: use a GitHub handle, GitHub profile URL, or email.",
+    );
+  });
+
+  it.each(["octocat", "@octocat", "https://github.com/octocat"])(
+    "still accepts a real GitHub contact %j",
+    (contact_email) => {
+      const result = validateSubmissionDraftFromSpec(submissionSpec, {
+        fields: { ...validMcpFields, contact_email },
+      });
+      expect(result.valid).toBe(true);
+      expect(result.errors.join("\n")).not.toContain("Invalid public contact");
+    },
+  );
+
   it("requires collections items and guide content", () => {
     expect(
       validateSubmissionDraftFromSpec(submissionSpec, {


### PR DESCRIPTION
## Summary

- Propagate the existing `RESERVED_OWNERS` check into bare GitHub-handle contact validation (`isGitHubHandle`), matching the URL-form reject already done by `isPublicGitHubProfileUrl`.
- Reuse the shared set from `public-url-lib.js` — no duplication, no change to `RESERVED_OWNERS` contents or the URL path.
- Add regression coverage so bare `settings` / `sponsors` / `@settings` (and the URL form) all reject, while real handles like `octocat` stay accepted.

Closes #5562

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots: **No visual impact** (MCP package validation only; no routes/UI).
- [x] Links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/mcp/src/submissions-lib.js` — import `RESERVED_OWNERS`; reject reserved bare handles in `isGitHubHandle`
  - `tests/mcp-submissions-lib.test.ts` — reserved-owner reject + real-handle accept cases
- **Expected behavior / invariants:**

  | Contact value | Before | After |
  |---|---|---|
  | `settings` | accepted | rejected |
  | `sponsors` | accepted | rejected |
  | `@settings` | accepted | rejected |
  | `https://github.com/settings` | rejected | rejected (unchanged) |
  | `octocat` / `@octocat` | accepted | accepted (unchanged) |

- **Screenshots:** No visual impact — package-internal validation fix; unit tests are the proof.
- **Out of scope:** `isPublicGitHubProfileUrl` (already correct); `RESERVED_OWNERS` membership; email-contact path.

## Validation

- [x] `pnpm exec vitest run tests/mcp-submissions-lib.test.ts` — **39 passed**
- [x] `pnpm exec vitest run tests/mcp-public-url-lib.test.ts` — **170 passed**
- [x] `pnpm test:mcp` — **72 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean

## Notes

- Follow-up to #5525 / #5507 (URL-path reserved-owner reject). That first attempt (#5520) was auto-closed solely for exceeding the open-PR limit of 2; this PR opens with **0** other open PRs from this account.
- Linked issue: #5562
