### PR TITLE
fix(web): fall back empty OG title/eyebrow to HeyClaude

### DIFF
--- a/apps/web/src/lib/api/contracts-lib.ts
+++ b/apps/web/src/lib/api/contracts-lib.ts
@@ -845,7 +845,15 @@ export const communitySignalsBatchQueryBodySchema = z.object({
 });
 
 export const ogQuerySchema = z.object({
-  title: z.string().trim().max(120).optional().default("HeyClaude"),
+  // `.default` only fills when the key is absent; empty/whitespace `title=`
+  // survives `.trim()` as "" and must still resolve to HeyClaude (#5555).
+  title: z
+    .string()
+    .trim()
+    .max(120)
+    .optional()
+    .default("HeyClaude")
+    .transform((value) => value || "HeyClaude"),
   description: z
     .string()
     .trim()

--- a/apps/web/src/lib/og-query-fields-lib.ts
+++ b/apps/web/src/lib/og-query-fields-lib.ts
@@ -20,10 +20,13 @@ export function resolveOgQueryFields(
   params: URLSearchParams,
   siteDescription: string,
 ): OgQueryFields {
-  const title = clampOgText(params.get("title") ?? "HeyClaude", OG_TEXT_LIMITS.title);
+  // `URLSearchParams.get` returns "" (not null) for present-but-empty params
+  // like `?title=`; `??` would keep the blank. Trim so whitespace-only also
+  // falls back to the documented HeyClaude default (#5555).
+  const title = clampOgText(params.get("title")?.trim() || "HeyClaude", OG_TEXT_LIMITS.title);
   const rawDescription = params.get("description") ?? params.get("subtitle") ?? siteDescription;
   const description = clampOgText(rawDescription, OG_TEXT_LIMITS.description);
-  const eyebrow = clampOgText(params.get("eyebrow") ?? "HeyClaude", OG_TEXT_LIMITS.eyebrow);
+  const eyebrow = clampOgText(params.get("eyebrow")?.trim() || "HeyClaude", OG_TEXT_LIMITS.eyebrow);
   const accent = safeAccent(params.get("accent"));
   return { title, description, eyebrow, accent };
 }

--- a/tests/og-query-fields-lib.test.ts
+++ b/tests/og-query-fields-lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { ogQuerySchema } from "../apps/web/src/lib/api/contracts-lib";
 import { resolveOgQueryFields } from "../apps/web/src/lib/og-query-fields-lib";
 
 const params = (init: Record<string, string>) => new URLSearchParams(init);
@@ -30,6 +31,21 @@ describe("resolveOgQueryFields", () => {
     expect(fields.description).toBe("The registry tagline");
   });
 
+  // Regression for #5555: present-but-empty (and whitespace-only) params must
+  // not bypass the documented HeyClaude default the way `??` did.
+  it.each([
+    [{ title: "" }, "title"],
+    [{ title: "   " }, "title"],
+    [{ eyebrow: "" }, "eyebrow"],
+    [{ eyebrow: "\t  " }, "eyebrow"],
+  ] as const)(
+    "falls back empty/whitespace %j to HeyClaude for %s",
+    (init, field) => {
+      const fields = resolveOgQueryFields(params(init), "site");
+      expect(fields[field]).toBe("HeyClaude");
+    },
+  );
+
   it("prefers description over subtitle over the site description", () => {
     expect(
       resolveOgQueryFields(
@@ -49,5 +65,23 @@ describe("resolveOgQueryFields", () => {
     expect(
       resolveOgQueryFields(params({ accent: "red" }), "s").accent,
     ).not.toBe("red");
+  });
+});
+
+describe("ogQuerySchema title default", () => {
+  // Regression for #5555: Zod `.default` alone leaves present-but-empty title
+  // as ""; the transform restores HeyClaude before the renderer.
+  it.each([undefined, "", "   "] as const)(
+    "resolves title %j to HeyClaude",
+    (title) => {
+      const parsed = ogQuerySchema.parse(title === undefined ? {} : { title });
+      expect(parsed.title).toBe("HeyClaude");
+    },
+  );
+
+  it("keeps a non-empty title unchanged", () => {
+    expect(ogQuerySchema.parse({ title: "Custom Card" }).title).toBe(
+      "Custom Card",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Fix `resolveOgQueryFields` so present-but-empty / whitespace-only `title` and `eyebrow` query params fall back to the documented `"HeyClaude"` default (previously `??` let `""` through).
- Fix `/api/og` `ogQuerySchema.title` the same way: keep `.default("HeyClaude")` for absent keys, and `.transform((v) => v || "HeyClaude")` so empty/whitespace still resolves before the renderer.
- Leave `/api/og` `label` → eyebrow (`"Registry"`) untouched per issue scope.

Closes #5555

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots: **No visual impact** — text-fallback correctness only; no layout/CSS/route chrome changes.
- [x] Links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `apps/web/src/lib/og-query-fields-lib.ts` — `/og` title/eyebrow empty fallback
  - `apps/web/src/lib/api/contracts-lib.ts` — `/api/og` `title` schema empty fallback
  - `tests/og-query-fields-lib.test.ts` — empty/whitespace + schema coverage
- **Before → after (empty-string cases):**

  | Route / field | Input | Before | After |
  |---|---|---|---|
  | `/og` `title` | `?title=` | `""` | `"HeyClaude"` |
  | `/og` `eyebrow` | `?eyebrow=` | `""` | `"HeyClaude"` |
  | `/og` `title` | `?title=%20%20` | `""` (after clamp) | `"HeyClaude"` |
  | `/api/og` `title` | `title=""` | `""` | `"HeyClaude"` |
  | both | absent / non-empty | unchanged | unchanged |

- **Screenshots:** No visual impact — fallback string correctness only; unit tests are the proof. (Related prior OG PR #5447 was auto-closed after a false screenshot demand + CI flake; this change is non-visual by design.)
- **Out of scope:** description fallback chain; `/api/og` `label`/`Registry` default; accent/`clampOgText` truncation logic.

## Validation

- [x] `pnpm exec vitest run tests/og-query-fields-lib.test.ts` — **12 passed**
- [x] `pnpm exec vitest run tests/og-api-query-lib.test.ts` — **4 passed**
- [x] `pnpm exec vitest run tests/api-contracts.test.ts` — **15 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean

## Notes

- Linked issue: #5555
- Opened with **0** other open PRs from this account (avoids the open-PR-limit auto-close that hit #5520 on the related reserved-owner work).
