### PR TITLE
feat(registry): require safetyNotes for malware_or_abuse_surface

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -52,6 +52,11 @@ const SAFETY_NOTE_REQUIRED_FLAGS = new Set([
   "community_archive_download",
   "community_local_download_request",
   "background_worker_or_daemon",
+  // High-severity malware/abuse tooling vocabulary (#5559). Safety notes fit
+  // better than privacy notes: this flag is about dangerous tooling surface /
+  // security review, not credential or personal-data access. Sibling
+  // `malicious_data_theft_capability` stays in PRIVACY_NOTE_REQUIRED_FLAGS.
+  "malware_or_abuse_surface",
 ]);
 
 const PRIVACY_NOTE_REQUIRED_FLAGS = new Set([

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -291,6 +291,80 @@ describe("submission risk invariants", () => {
     );
   });
 
+  it("requires safetyNotes when malware_or_abuse_surface is raised (#5559)", () => {
+    const missingNotes = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 5559,
+        title: "content(mcp): add ransomware sandbox mcp",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Ransomware Sandbox MCP",
+            slug: "ransomware-sandbox-mcp",
+            description:
+              "Sandbox MCP for inspecting ransomware and trojan samples offline.",
+            safetyNotes: [],
+            privacyNotes: ["Only handles analyst-selected sample files."],
+          }),
+          "content/mcp/ransomware-sandbox-mcp.mdx",
+        ),
+      ],
+    });
+    const withNotes = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 5560,
+        title: "content(mcp): add ransomware sandbox mcp with notes",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Ransomware Sandbox MCP",
+            slug: "ransomware-sandbox-mcp",
+            description:
+              "Sandbox MCP for inspecting ransomware and trojan samples offline.",
+            safetyNotes: [
+              "Runs offline sample inspection only; no live detonation or network spread.",
+            ],
+            privacyNotes: ["Only handles analyst-selected sample files."],
+          }),
+          "content/mcp/ransomware-sandbox-mcp.mdx",
+        ),
+      ],
+    });
+
+    expect(missingNotes.reviewFlags.map((flag) => flag.id)).toContain(
+      "malware_or_abuse_surface",
+    );
+    expect(missingNotes.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "malicious_data_theft_capability",
+    );
+    expect(
+      missingNotes.classificationWarnings.map((warning) => warning.id),
+    ).toContain("missing_safety_notes");
+    expect(
+      missingNotes.classificationWarnings.map((warning) => warning.id),
+    ).not.toContain("missing_privacy_notes");
+    expect(
+      missingNotes.classificationWarnings.find(
+        (warning) => warning.id === "missing_safety_notes",
+      )?.detail,
+    ).toContain("malware_or_abuse_surface");
+
+    expect(withNotes.reviewFlags.map((flag) => flag.id)).toContain(
+      "malware_or_abuse_surface",
+    );
+    expect(
+      withNotes.classificationWarnings.map((warning) => warning.id),
+    ).not.toContain("missing_safety_notes");
+  });
+
   it("keeps identity attestation risk matching narrow and synchronized with CI", () => {
     const sensitiveReport = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
## Summary

- **Decision (a)** for #5559: add `malware_or_abuse_surface` to `SAFETY_NOTE_REQUIRED_FLAGS` so submissions that trigger that high-severity flag must provide `safetyNotes` / `safety_notes` before direct merge.
- Chose safety over privacy because the flag is raised by malware/abuse tooling vocabulary (ransomware, trojan, backdoor, botnet, malware, …) and is framed as needing security review — not credential/local-data access. Sibling `malicious_data_theft_capability` stays in `PRIVACY_NOTE_REQUIRED_FLAGS`.
- Decision comment on the issue: https://github.com/JSONbored/awesome-claude/issues/5559#issuecomment-5086237348

Closes #5559

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/registry/src/submission-risk.js` — `SAFETY_NOTE_REQUIRED_FLAGS` membership only
  - `tests/submission-risk-invariants.test.ts` — constructed malware-surface case
- **Expected behavior:** a content submission whose text raises `malware_or_abuse_surface` and has empty `safetyNotes` now gets a `missing_safety_notes` classification warning that lists `malware_or_abuse_surface` in `detail`. Providing `safetyNotes` clears that warning. Privacy notes are not required by this flag alone.
- **Important edge cases / invariants:**
  - Does **not** move `malicious_data_theft_capability` (privacy sibling unchanged).
  - Trigger terms for the flag itself are unchanged.
  - Test fixture uses ransomware/trojan wording only — avoids credential-theft patterns so the privacy gate is not conflated.
- **Backward compatibility:** submissions that already disclose safety notes for malware-adjacent tooling are unaffected; only note-less malware-surface submissions gain the new warning.
- **No visual impact.** Registry risk-policy / disclosure-gate logic only; no UI, routes, or CSS.
- **Focused tests:** `tests/submission-risk-invariants.test.ts` covers missing vs present `safetyNotes` for a `malware_or_abuse_surface`-only case.

## Validation

- [x] `pnpm build` passed
- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — 65/65 passed
- [x] `git diff --check` clean

## Notes

- Linked issue: #5559 (maintainer-authored decide issue; decision (a) recorded on the thread before this PR).
- Scope kept to the issue's listed file plus its required constructed test. `scripts/ci/validate-content-policy.mjs` does not raise `malware_or_abuse_surface` today, so it was left untouched (matches recent registry risk PRs that only edit `submission-risk.js`).

Made with [Cursor](https://cursor.com)