### PR TITLE
fix(web): derive browse confidence lowRefs from full scored set

### DIFF
--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -214,6 +214,9 @@ export function browseDecisionConfidenceState(
     mediumCount: scored.filter((row) => row.band === "medium").length,
     lowCount: scored.filter((row) => row.band === "low").length,
     entries: mapped,
-    lowRefs: mapped.filter((row) => row.band === "low").map((row) => row.entryRef),
+    // Same full-population rule as lowCount (#5551): refs must not be limited
+    // to the display-truncated `mapped` slice or low-band entries sorted below
+    // maxEntries disappear from lowRefs while lowCount still counts them.
+    lowRefs: scored.filter((row) => row.band === "low").map((row) => row.entryRef),
   };
 }

--- a/tests/browse-decision-confidence-lib.test.ts
+++ b/tests/browse-decision-confidence-lib.test.ts
@@ -262,4 +262,21 @@ describe("summary population", () => {
       state.scannedCount,
     );
   });
+
+  it("includes lowRefs for low-band entries that fall outside the display slice (#5551)", () => {
+    // 8 strong rows fill maxEntries (default 8); all 12 weak rows sort below
+    // the visible cutoff. Before: lowRefs=[]. After: lowRefs lists every weak
+    // entry, matching lowCount.
+    const state = browseDecisionConfidenceState(population(8, 12), "balanced");
+    const expectedLowRefs = Array.from(
+      { length: 12 },
+      (_, index) => `tools/weak-${index}`,
+    );
+
+    expect(state.entries).toHaveLength(8);
+    expect(state.entries.every((row) => row.band !== "low")).toBe(true);
+    expect(state.lowCount).toBe(12);
+    expect(state.lowRefs).toHaveLength(12);
+    expect([...state.lowRefs].sort()).toEqual([...expectedLowRefs].sort());
+  });
 });


### PR DESCRIPTION
## Summary

- Finish the leftover gap from #5465: `highCount`/`mediumCount`/`lowCount` already read from the full `scored` population, but `lowRefs` still filtered the display-truncated `mapped = scored.slice(0, maxEntries)` slice.
- Change `lowRefs` to filter `scored`, matching `lowCount`, so a low-band entry ranked below `maxEntries` still appears in the ref list.

Closes #5551

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `apps/web/src/lib/browse-decision-confidence-lib.ts` — `lowRefs` line only
  - `tests/browse-decision-confidence-lib.test.ts` — regression for outside-slice low refs
- **Expected behavior:** `lowRefs` lists every low-band entry in the scanned population, not only those visible in the top-`maxEntries` panel rows.
- **Constructed before/after** (`population(8, 12)`, default `maxEntries = 8`):
  - Display `entries`: 8 strong rows (no low-band rows visible)
  - `lowCount`: `12` (already correct)
  - **Before:** `lowRefs = []`
  - **After:** `lowRefs` has length `12` and contains `tools/weak-0` … `tools/weak-11`
- **No visual impact.** Pure data-computation fix in a lib helper; panel markup/CSS unchanged. The panel may now surface correct low refs when consumers read `lowRefs`, but no UI layout/theme change is in this PR.
- **Focused tests:** `pnpm exec vitest run tests/browse-decision-confidence-lib.test.ts` — 20/20 passed.

## Validation

- [x] `pnpm build` passed
- [x] `pnpm exec vitest run tests/browse-decision-confidence-lib.test.ts` passed
- [x] `git diff --check` clean

## Notes

- Linked issue: #5551.
- Related prior work: #5361 (summary population) and #5465 (band counts). This PR only closes the remaining `lowRefs` hole called out in #5551.
- No open competing PR referenced #5551 at open time (avoiding the duplicate-open-PR auto-close pattern from #4677).

