### PR TITLE
fix(web): escape compatibility-matrix CSV header client labels

### DIFF
--- a/apps/web/src/lib/compatibility-matrix-csv-lib.ts
+++ b/apps/web/src/lib/compatibility-matrix-csv-lib.ts
@@ -8,16 +8,17 @@ import type { MatrixClient, MatrixRow, Support } from "@/components/compatibilit
 /**
  * Serialize the compatibility matrix to CSV text: a
  * `Capability,Detail,<client label>…` header followed by one row per
- * capability. The capability and blurb cells are escaped via `csvEscape`; each
- * client cell is resolved to its support label with `labelFor`. The result ends
- * with a trailing newline.
+ * capability. Header cells (including client labels) and the capability /
+ * blurb data cells are escaped via `csvEscape`; each client cell is resolved
+ * to its support label with `labelFor`. The result ends with a trailing
+ * newline.
  */
 export function buildCompatibilityCsv(
   clients: readonly MatrixClient[],
   rows: readonly MatrixRow[],
   labelFor: (support: Support) => string,
 ): string {
-  const header = ["Capability", "Detail", ...clients.map((c) => c.label)].join(",");
+  const header = ["Capability", "Detail", ...clients.map((c) => c.label)].map(csvEscape).join(",");
   const body = rows
     .map((r) =>
       [

--- a/tests/compatibility-matrix-csv-lib.test.ts
+++ b/tests/compatibility-matrix-csv-lib.test.ts
@@ -56,6 +56,19 @@ describe("buildCompatibilityCsv", () => {
     expect(dataLine).toBe('"MCP, ""stdio""","one, two",Manual,Unsupported');
   });
 
+  it("escapes commas and quotes in client-label header cells (#5554)", () => {
+    // Before: Capability,Detail,Foo, Inc.,Desktop  (three columns mis-parsed as four)
+    // After:  Capability,Detail,"Foo, Inc.",Desktop
+    const awkwardClients: MatrixClient[] = [
+      { id: "x", label: "Foo, Inc." },
+      { id: "desktop", label: 'Desk"top' },
+    ];
+    const csv = buildCompatibilityCsv(awkwardClients, [], label);
+    expect(csv.split("\n")[0]).toBe(
+      'Capability,Detail,"Foo, Inc.","Desk""top"',
+    );
+  });
+
   it("emits one line per row and always ends with a trailing newline", () => {
     const rows: MatrixRow[] = [
       {


### PR DESCRIPTION
## Summary

- Escape compatibility-matrix CSV header cells (including client labels) via `csvEscape`, matching the capability/blurb data-cell path.
- Keeps scope to `buildCompatibilityCsv` header construction only — no UI/component changes.

Closes #5554

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `apps/web/src/lib/compatibility-matrix-csv-lib.ts` — header-row construction only
  - `tests/compatibility-matrix-csv-lib.test.ts` — comma/quote client-label cases
- **Expected behavior:** client labels with `,` or `"` round-trip as properly quoted CSV header cells.
- **Before/after header** for `{ id: "x", label: "Foo, Inc." }` (+ a quote case):
  - **Before:** `Capability,Detail,Foo, Inc.,Desk"top`
  - **After:** `Capability,Detail,"Foo, Inc.","Desk""top"`
- **No visual impact.** Pure CSV serialization helper — no `.tsx`, CSS, or route changes.
- **Focused tests:** `pnpm exec vitest run tests/compatibility-matrix-csv-lib.test.ts` — 7/7 passed.

## Validation

- [x] `pnpm build` passed
- [x] `pnpm exec vitest run tests/compatibility-matrix-csv-lib.test.ts` passed
- [x] `pnpm exec prettier --check` on changed files passed
- [x] `trunk check --upstream origin/main` — ✔ No issues
- [x] `git diff --check` clean

## Notes

- Linked issue: #5554.
- Replaces closed #5600. That PR’s code review was fine; LoopOver closed it because `validate-ci` failed Trunk/Prettier formatting (`Incorrect formatting, autoformat by running 'trunk fmt'`). This resubmit keeps the same logic with Prettier-compliant single-line `.map(csvEscape).join(",")` and verified `trunk check` clean locally before opening.
