### PR TITLE
fix(registry): safe-harbor malware_or_abuse_surface for defensive tools

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -90,8 +90,17 @@ const IDENTITY_ATTESTATION_REVERSE_PATTERN = new RegExp(
   `\\b(?:${SENSITIVE_ATTESTATION_REVERSE_TERMS})s?\\b[\\s\\S]{0,120}\\battestations?\\b`,
   "i",
 );
+// Also covers malware/abuse-tooling vocabulary on the action→threat direction
+// (#5584) so defensive anti-malware phrasing ("detects ransomware", "removes
+// keyloggers") gets the same safe harbor as credential-theft mitigation.
+// Malware terms are intentionally NOT added to the reverse (threat→action)
+// alternative: titles like "Ransomware …" plus a later "review" token in a
+// docs URL would false-harbor. Verb forms include optional trailing `s`
+// (`detects?`/`blocks?`/`removes?`) to match natural defensive prose.
 const DEFENSIVE_SECURITY_MITIGATION_PATTERN =
-  /\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b[\s\S]{0,160}\b(?:(?:credential|password|cookie|session|token|wallet|secret|leak)s?|expos(?:e|ing|ure))\b|\b(?:credential|password|cookie|session|token|wallet|secret)s?\b[\s\S]{0,160}\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+  /\b(prevent|protect|warn(?:s|ing)? before|blocks?|detects?|detection|redact|sanitize|audit|review|remediate|remediation|removes?|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b[\s\S]{0,160}\b(?:(?:credential|password|cookie|session|token|wallet|secret|leak)s?|expos(?:e|ing|ure)|ransomware|trojans?|keyloggers?|backdoors?|botnets?|worms?|cryptojackers?|malware)\b|\b(?:credential|password|cookie|session|token|wallet|secret)s?\b[\s\S]{0,160}\b(prevent|protect|warn(?:s|ing)? before|blocks?|detects?|detection|redact|sanitize|audit|review|remediate|remediation|removes?|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+const MALWARE_OR_ABUSE_SURFACE_PATTERN =
+  /\b(ransomware|trojan|keylogger|credential stealer|password stealer|cookie stealer|backdoor|botnet|worm|cryptojacker|malware)\b/i;
 const RESOURCE_THEFT_CAPABILITY_PATTERN =
   /\b(?:this|the|our)?\s*(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b[\s\S]{0,40}\b(?:can|will|does|advertises?|offers?|enables?|designed to|built to)\b[\s\S]{0,80}\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b|\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(?:with|using|through|by)\b[\s\S]{0,40}\b(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b/i;
 // Adult "xxx" only in an explicit adult context, so legitimate developer idioms
@@ -1299,10 +1308,12 @@ function addContentRiskSignals(report, fields, text) {
     );
   }
 
+  // Same defensive safe-harbor gate as malicious_data_theft_capability (#5584):
+  // anti-malware/security tools that mitigate ransomware/trojans/keyloggers must
+  // not be treated as malware/abuse surface themselves.
   if (
-    /\b(ransomware|trojan|keylogger|credential stealer|password stealer|cookie stealer|backdoor|botnet|worm|cryptojacker|malware)\b/i.test(
-      text,
-    )
+    !hasDefensiveSecuritySafeHarbor(text) &&
+    MALWARE_OR_ABUSE_SURFACE_PATTERN.test(text)
   ) {
     addFlag(
       report,

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -73,8 +73,12 @@ const IDENTITY_ATTESTATION_REVERSE_PATTERN = new RegExp(
   `\\b(?:${SENSITIVE_ATTESTATION_REVERSE_TERMS})s?\\b[\\s\\S]{0,${SENSITIVE_ATTESTATION_WINDOW}}\\battestations?\\b`,
   "i",
 );
+// Keep in sync with packages/registry/src/submission-risk.js (#5584): malware
+// terms only on the action→threat alternative; optional trailing `s` on
+// detect/block/remove. Do not put malware terms on the reverse alternative
+// (avoids title+docs-URL "review" false harbors).
 const DEFENSIVE_SECURITY_MITIGATION_PATTERN =
-  /\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b[\s\S]{0,160}\b(?:(?:credential|password|cookie|session|token|wallet|secret|leak)s?|expos(?:e|ing|ure))\b|\b(?:credential|password|cookie|session|token|wallet|secret)s?\b[\s\S]{0,160}\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+  /\b(prevent|protect|warn(?:s|ing)? before|blocks?|detects?|detection|redact|sanitize|audit|review|remediate|remediation|removes?|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b[\s\S]{0,160}\b(?:(?:credential|password|cookie|session|token|wallet|secret|leak)s?|expos(?:e|ing|ure)|ransomware|trojans?|keyloggers?|backdoors?|botnets?|worms?|cryptojackers?|malware)\b|\b(?:credential|password|cookie|session|token|wallet|secret)s?\b[\s\S]{0,160}\b(prevent|protect|warn(?:s|ing)? before|blocks?|detects?|detection|redact|sanitize|audit|review|remediate|remediation|removes?|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
 const RESOURCE_THEFT_CAPABILITY_PATTERN =
   /\b(?:this|the|our)?\s*(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b[\s\S]{0,40}\b(?:can|will|does|advertises?|offers?|enables?|designed to|built to)\b[\s\S]{0,80}\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b|\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(?:with|using|through|by)\b[\s\S]{0,40}\b(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b/i;
 const CREDENTIAL_THEFT_PATTERN =

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -365,6 +365,71 @@ describe("submission risk invariants", () => {
     ).not.toContain("missing_safety_notes");
   });
 
+  it("applies defensive safe harbor to malware_or_abuse_surface (#5584)", () => {
+    // Safe-harbor condition: hasDefensiveSecuritySafeHarbor(text) after the
+    // action→threat mitigation pattern matches defensive verbs near
+    // malware/abuse vocabulary (and no theft/abuse-enablement overrides).
+    // True-negative: defensive anti-malware tool — must NOT flag.
+    const defensive = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 5584,
+        title: "content(mcp): add malware scanner mcp",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Malware Scanner MCP",
+            slug: "malware-scanner-mcp",
+            description:
+              "Malware Scanner — detects and removes ransomware, trojans, and keyloggers from downloaded files.",
+            repoUrl: "https://github.com/example/malware-scanner-mcp",
+            docsUrl: "https://example.com/malware-scanner-mcp",
+            safetyNotes: [
+              "Scans local downloads offline; does not execute sample payloads.",
+            ],
+            privacyNotes: ["Only handles user-selected downloaded files."],
+          }),
+          "content/mcp/malware-scanner-mcp.mdx",
+        ),
+      ],
+    });
+    // True-positive: offensive malware/abuse capability — must still flag.
+    const offensive = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 5585,
+        title: "content(mcp): add botnet operator mcp",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Botnet Operator MCP",
+            slug: "botnet-operator-mcp",
+            description:
+              "Operator MCP that deploys ransomware and trojan backdoors for botnet malware campaigns.",
+            repoUrl: "https://github.com/example/botnet-operator-mcp",
+            docsUrl: "https://example.com/botnet-operator-mcp",
+            safetyNotes: ["Runs remote payloads on target hosts."],
+            privacyNotes: ["Collects host identifiers from infected machines."],
+          }),
+          "content/mcp/botnet-operator-mcp.mdx",
+        ),
+      ],
+    });
+
+    expect(defensive.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "malware_or_abuse_surface",
+    );
+    expect(offensive.reviewFlags.map((flag) => flag.id)).toContain(
+      "malware_or_abuse_surface",
+    );
+  });
+
   it("keeps identity attestation risk matching narrow and synchronized with CI", () => {
     const sensitiveReport = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
## Summary

- Gate `malware_or_abuse_surface` with the same `hasDefensiveSecuritySafeHarbor(text)` check its sibling `malicious_data_theft_capability` already uses.
- Extend `DEFENSIVE_SECURITY_MITIGATION_PATTERN` (action→threat direction only) with malware/abuse-tooling vocabulary and optional trailing `s` on `detect`/`block`/`remove`, mirrored into `scripts/ci/validate-content-policy.mjs`.
- Malware terms are intentionally **not** added to the reverse (threat→action) alternative, so a title like “Ransomware …” plus a later `review` token in a docs URL cannot false-harbor.

Closes #5584

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/registry/src/submission-risk.js`
  - `scripts/ci/validate-content-policy.mjs` (pattern sync only)
  - `tests/submission-risk-invariants.test.ts`
- **Safe-harbor condition applied:** `!hasDefensiveSecuritySafeHarbor(text) && MALWARE_OR_ABUSE_SURFACE_PATTERN.test(text)`
  - Safe harbor requires the extended mitigation pattern (defensive verb within 160 chars **before** malware/abuse vocabulary) and still fails closed on resource-theft / abuse-enablement / explicit-stealing overrides.
- **True-negative (must not flag):** `Malware Scanner — detects and removes ransomware, trojans, and keyloggers from downloaded files.`
- **True-positive (must still flag):** `Operator MCP that deploys ransomware and trojan backdoors for botnet malware campaigns.`
- **No visual impact.** Registry/CI risk-policy logic only — no UI, routes, or CSS.
- **Focused tests:** `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — 66/66; also `tests/submission-pr-first.test.ts` + `tests/content-policy-validation.test.ts` — 70/70.

## Validation

- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts` passed
- [x] `pnpm exec vitest run tests/submission-pr-first.test.ts tests/content-policy-validation.test.ts` passed
- [x] `pnpm build` passed
- [x] `pnpm exec prettier --check` on changed files passed
- [x] `trunk check --upstream origin/main` — ✔ No issues
- [x] `git diff --check` clean

## Notes

- Linked issue: #5584 (`gittensor:priority`).
- No prior PR claimed this issue.
- Avoids the #5600 failure mode (Trunk/Prettier) by running `prettier --check` + `trunk check` locally before opening.
