### PR TITLE
fix(registry): route unsafe_install_pipeline base64 through hasBase64DecodedShell

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -5,7 +5,10 @@ import {
   TOOLS_LISTING_FLOW_URL,
 } from "./submission-classification.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
-import { hasPipeToShellInstall } from "./command-safety-lib.js";
+import {
+  hasBase64DecodedShell,
+  hasPipeToShellInstall,
+} from "./command-safety-lib.js";
 import {
   AFFILIATE_PARAMS,
   isPublicGitHubProfileUrl,
@@ -16,6 +19,9 @@ import {
 
 // Curl/wget → shell detection is command-boundary-aware via hasPipeToShellInstall
 // (#5556). The previous bounded-window regex false-positived across `;`/`&&`.
+// Base64 → shell uses hasBase64DecodedShell for the same reason (#5591): the old
+// `\bbase64\s+(-d|--decode)\b` regex missed bundled flags (`-di`), `sudo`, and
+// pipe-chain passthroughs that the shared helper already handles.
 
 // Anthropic (`sk-ant-…`) and OpenAI (`sk-proj-…`) insert a hyphenated segment after
 // `sk-`, which the old `sk-[a-z0-9]{20,}` alternative could never match (#5479).
@@ -1178,6 +1184,22 @@ function hasUnsafeCurlWgetPipeToShell(installText) {
   return false;
 }
 
+// True when a base64-decode segment feeds a shell later in the same pipe chain.
+// Mirrors hasUnsafeCurlWgetPipeToShell: line-by-line + double-quoted interiors,
+// so config/JSON embeds keep flagging while bundled flags (`-di`), `sudo`, and
+// passthrough commands are handled by hasBase64DecodedShell (#5591).
+function hasUnsafeBase64DecodedShell(installText) {
+  for (const line of String(installText ?? "").split(/\r?\n/)) {
+    if (!line) continue;
+    if (hasBase64DecodedShell(line, line)) return true;
+    for (const match of line.matchAll(/"([^"]*)"/g)) {
+      const inner = match[1];
+      if (inner && hasBase64DecodedShell(inner, inner)) return true;
+    }
+  }
+  return false;
+}
+
 function addContentRiskSignals(report, fields, text) {
   const installText = lower(
     [
@@ -1283,9 +1305,7 @@ function addContentRiskSignals(report, fields, text) {
     referencesDestructiveRootRemoval(installText) ||
     hasUnsafeCurlWgetPipeToShell(installText) ||
     /\b(invoke-expression|iex)\b/i.test(installText) ||
-    /\bbase64\s+(-d|--decode)\b[\s\S]{0,80}\|[\s\S]{0,40}\b(sh|bash)\b/i.test(
-      installText,
-    ) ||
+    hasUnsafeBase64DecodedShell(installText) ||
     /\bpowershell\b[\s\S]{0,80}\b-encodedcommand\b/i.test(installText)
   ) {
     addFlag(

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -973,3 +973,60 @@ describe("unsafe_install_pipeline command-boundary awareness (#5556)", () => {
     ).not.toContain("unsafe_install_pipeline");
   });
 });
+
+describe("unsafe_install_pipeline base64 via hasBase64DecodedShell (#5591)", () => {
+  function riskFlagIds(installCommand: string) {
+    const draft = buildSubmissionPrDraft({
+      ...validMcpFields,
+      name: "Base64 Pipeline MCP",
+      slug: "base64-pipeline-mcp",
+      install_command: installCommand,
+      safety_notes: "Runs a local MCP server process with user-selected tools.",
+      privacy_notes: "Only handles context selected by the user.",
+    });
+    const validation = validateSubmission(draft);
+    return analyzeSubmissionDraftRisk(draft, validation).reviewFlags.map(
+      (flag) => flag.id,
+    );
+  }
+
+  it("still flags the classic base64 -d | bash form", () => {
+    expect(riskFlagIds("echo cGF5 | base64 -d | bash")).toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
+  it("still flags base64 --decode | sh", () => {
+    expect(riskFlagIds("echo cGF5 | base64 --decode | sh")).toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
+  // The stale `\bbase64\s+(-d|--decode)\b` regex required a word boundary
+  // immediately after `-d`, so bundled short flags like `-di` never matched.
+  it("flags bundled decode+ignore-garbage: base64 -di | bash", () => {
+    expect(riskFlagIds("echo cGF5 | base64 -di | bash")).toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
+  // Pipe-chain barriers + sudo prefix are handled by hasBase64DecodedShell;
+  // the old bounded-window regex had no notion of either.
+  it("flags base64 -d | sudo -E bash", () => {
+    expect(riskFlagIds("echo cGF5 | base64 -d | sudo -E bash")).toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
+  it("flags base64 -d | cat | bash pipe-chain passthrough", () => {
+    expect(riskFlagIds("echo cGF5 | base64 -d | cat | bash")).toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+
+  it("does not flag base64 decode piped to a non-shell consumer", () => {
+    expect(riskFlagIds("echo cGF5 | base64 -d | jq .")).not.toContain(
+      "unsafe_install_pipeline",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the stale bounded-window `base64 … | sh|bash` regex in `submission-risk.js` with `hasBase64DecodedShell` from `command-safety-lib.js`, so `unsafe_install_pipeline` catches the same evasions the shared helper already handles for shell-safety triage.
- Mirror the `#5556` curl/wget pattern: scan line-by-line and double-quoted interiors via a small `hasUnsafeBase64DecodedShell` wrapper (bundled flags, `sudo`, pipe-chain passthroughs).
- Leave `command-safety-lib.js` untouched (out of scope); curl/wget / `iex` / powershell / destructive-`rm` branches unchanged.

Closes #5591

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/registry/src/submission-risk.js` — `hasUnsafeBase64DecodedShell` replaces the stale base64 regex
  - `tests/submission-risk-invariants.test.ts` — #5591 true-positives + non-shell negative
- **Expected behavior / before→after flag results:**

  | install text | before | after |
  |---|---|---|
  | `echo cGF5 \| base64 -d \| bash` | flagged | flagged (unchanged) |
  | `echo cGF5 \| base64 --decode \| sh` | flagged | flagged (unchanged) |
  | `echo cGF5 \| base64 -di \| bash` | **not flagged** | **flagged** |
  | `echo cGF5 \| base64 -d \| sudo -E bash` | **not flagged** | **flagged** |
  | `echo cGF5 \| base64 -d \| cat \| bash` | **not flagged** | **flagged** |
  | `echo cGF5 \| base64 -d \| jq .` | not flagged | not flagged (unchanged) |

- **Invariants:** curl/wget, `iex`, `powershell -encodedcommand`, and destructive `rm` branches of `unsafe_install_pipeline` are untouched. `command-safety-lib.js` is not modified.
- **Screenshots:** **No visual impact** — registry risk-detection correctness only; no routes/UI.

## Validation

- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — **72 passed**
- [x] `pnpm exec vitest run tests/command-safety-lib.test.ts tests/command-safety.test.ts tests/command-safety-posix-shell.test.ts` — **90 passed**
- [x] `pnpm exec vitest run tests/non-ui-branch-matrix.test.ts` — **20 passed**
- [x] `pnpm build` — passed
- [x] `pnpm validate:clean` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `trunk check --upstream origin/main` — no issues
- [x] `git diff --check` / `node --check packages/registry/src/submission-risk.js` — clean

## Notes

- No open or closed PR existed for #5591 at start (timeline empty). Closest sibling is merged #5563 (curl/wget → `hasPipeToShellInstall`); this PR applies the same wiring pattern to the base64 branch.
- Related historical failures to avoid: #4921 (CI/`required-pr-gate` auto-close before retry as #4923), #5600 (CI failing → LoopOver close). This PR: two-file focused diff, one-shot commit, local trunk + build + focused tests green before open, no post-open pushes.
- `command-safety-lib.js` left untouched per issue out-of-scope.

