### PR TITLE
fix(registry): resolve paren/brace wraps and env-then-sudo in command safety

### DIFF
--- a/packages/registry/src/command-safety-lib.js
+++ b/packages/registry/src/command-safety-lib.js
@@ -182,11 +182,27 @@ export function isEnvironmentAssignment(token) {
 // Resolve a pipe segment's lead command, stepping over POSIX environment
 // assignments and optional `sudo`/`env` prefixes (so `HTTPS_PROXY=x curl`,
 // `sudo -E bash`, and `env VAR=x curl` read as the command they execute).
+// Prefix stripping loops until stable so `env VAR=x sudo <cmd>` is handled the
+// same as `sudo env VAR=x <cmd>` (#5585). Leading `(`/`{`/whitespace are also
+// skipped so a subshell/group wrap like `(rm -rf /)` still resolves to `rm`
+// instead of an empty command word (#5585).
 // Returns the lowercased command word plus `argStart`, the index where the
 // command's own argument tokens begin — so callers can walk `rm`/`chmod` flags
 // token-by-token instead of pattern-matching one bundled-flag spelling.
 export function resolveSegmentCommand(line, lowerLine, start, end) {
   let index = start;
+
+  const skipGroupingOpeners = () => {
+    while (
+      index < end &&
+      (/\s/.test(line[index] || "") ||
+        line[index] === "(" ||
+        line[index] === "{")
+    ) {
+      index += 1;
+    }
+  };
+
   const skipAssignments = () => {
     for (;;) {
       const token = shellToken(line, lowerLine, index, end);
@@ -195,9 +211,9 @@ export function resolveSegmentCommand(line, lowerLine, start, end) {
     }
   };
 
-  skipAssignments();
-  const first = shellToken(line, lowerLine, index, end);
-  if (first?.lower === "sudo") {
+  const skipSudoPrefix = () => {
+    const first = shellToken(line, lowerLine, index, end);
+    if (first?.lower !== "sudo") return false;
     index = first.end;
     for (;;) {
       const flag = shellToken(line, lowerLine, index, end);
@@ -211,11 +227,12 @@ export function resolveSegmentCommand(line, lowerLine, start, end) {
         if (value) index = value.end;
       }
     }
-    skipAssignments();
-  }
+    return true;
+  };
 
-  const maybeEnv = shellToken(line, lowerLine, index, end);
-  if (maybeEnv?.lower === "env") {
+  const skipEnvPrefix = () => {
+    const maybeEnv = shellToken(line, lowerLine, index, end);
+    if (maybeEnv?.lower !== "env") return false;
     index = maybeEnv.end;
     for (;;) {
       const token = shellToken(line, lowerLine, index, end);
@@ -232,7 +249,20 @@ export function resolveSegmentCommand(line, lowerLine, start, end) {
         break;
       }
     }
+    return true;
+  };
+
+  // Re-check after each strip so `env … sudo …` and `(sudo …)` both resolve to
+  // the real command rather than stopping at a fixed sudo-then-env order.
+  for (;;) {
+    skipGroupingOpeners();
+    skipAssignments();
+    if (skipSudoPrefix()) continue;
+    if (skipEnvPrefix()) continue;
+    break;
   }
+  skipGroupingOpeners();
+  skipAssignments();
 
   const command = shellToken(line, lowerLine, index, end);
   if (!command) return { command: "", argStart: index };

--- a/tests/command-safety-lib.test.ts
+++ b/tests/command-safety-lib.test.ts
@@ -626,6 +626,13 @@ describe("token-aware rm/chmod flag detection", () => {
     ["rm -rfv /", true], // bundled with extra verbose flag
     ["sudo rm -Rf /", true], // uppercase -R via sudo prefix
     ["env FOO=1 rm -r -f /", true], // env prefix + split flags
+    // #5585: paren/brace wrap used to resolve the lead command to "" and evade
+    // every detector that depends on resolveSegmentCommand.
+    ["(rm -rf /)", true],
+    ["{rm -rf /}", true],
+    // #5585: sudo after env was missed because stripping was a fixed
+    // sudo-then-env order rather than a loop.
+    ["env FOO=bar sudo rm -rf /", true],
     ["rm -r /tmp", false], // recursive only, no force — not flagged
     ["rm --force /tmp", false], // force only, no recursive
     ["rm file.txt", false], // benign remove
@@ -684,6 +691,46 @@ describe("token-aware rm/chmod flag detection", () => {
     expect(
       segmentLeadCommand(line, lower(line), segment.start, segment.end),
     ).toBe("rm");
+  });
+});
+
+describe("resolveSegmentCommand grouping + prefix loop (#5585)", () => {
+  function resolvedCommand(line: string) {
+    const [segment] = pipeChainSegments(line);
+    return resolveSegmentCommand(line, lower(line), segment.start, segment.end)
+      .command;
+  }
+
+  it("resolves paren-wrapped rm to the real command word", () => {
+    expect(resolvedCommand("(rm -rf /)")).toBe("rm");
+    expect(hasRecursiveForceRemove("(rm -rf /)", lower("(rm -rf /)"))).toBe(
+      true,
+    );
+  });
+
+  it("resolves brace-wrapped and spaced subshell forms", () => {
+    expect(resolvedCommand("{rm -rf /}")).toBe("rm");
+    expect(resolvedCommand("( rm -rf / )")).toBe("rm");
+    expect(resolvedCommand("((rm -rf /))")).toBe("rm");
+  });
+
+  it("strips sudo that appears after an env prefix", () => {
+    const line = "env FOO=bar sudo rm -rf /";
+    expect(resolvedCommand(line)).toBe("rm");
+    expect(hasRecursiveForceRemove(line, lower(line))).toBe(true);
+  });
+
+  it("still strips the classic sudo-then-env order", () => {
+    const line = "sudo env FOO=bar rm -rf /";
+    expect(resolvedCommand(line)).toBe("rm");
+    expect(hasRecursiveForceRemove(line, lower(line))).toBe(true);
+  });
+
+  it("strips sudo inside a paren wrap", () => {
+    expect(resolvedCommand("(sudo rm -rf /)")).toBe("rm");
+    expect(
+      hasRecursiveForceRemove("(sudo rm -rf /)", lower("(sudo rm -rf /)")),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix `resolveSegmentCommand` so leading `(`/`{`/whitespace are skipped before reading the command word — `(rm -rf /)` resolves to `rm` instead of `""`.
- Loop `sudo`/`env` prefix stripping until stable so `env VAR=x sudo <cmd>` is handled the same as `sudo env VAR=x <cmd>`.
- Every shell-safety detector that depends on the resolver (`hasRecursiveForceRemove`, `hasWorldWritableChmod`, `hasPipeToShellInstall`, `hasBase64DecodedShell`) benefits without per-detector changes.

Closes #5585

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `packages/registry/src/command-safety-lib.js` — `resolveSegmentCommand` grouping skip + sudo/env loop
  - `tests/command-safety-lib.test.ts` — #5585 regression cases
- **Resolver change:** skip leading `(`/`{`/whitespace on each prefix-loop iteration and before the final command read; re-check `sudo`/`env` after each strip instead of a fixed sudo-then-env order.
- **Expected behavior / before→after:**

  | input | before (`resolveSegmentCommand` → `hasRecursiveForceRemove`) | after |
  |---|---|---|
  | `(rm -rf /)` | `""` → **false** | `rm` → **true** |
  | `env FOO=bar sudo rm -rf /` | `sudo` → **false** | `rm` → **true** |
  | `sudo env FOO=bar rm -rf /` | `rm` → true | `rm` → true (unchanged) |
  | `rm -rf /` | `rm` → true | `rm` → true (unchanged) |

- **Invariants:** individual detector logic untouched; only the shared resolver changed (per issue scope).
- **Screenshots:** **No visual impact** — registry command-safety correctness only; no routes/UI.

## Validation

- [x] `pnpm exec vitest run tests/command-safety-lib.test.ts tests/command-safety.test.ts tests/command-safety-posix-shell.test.ts` — **98 passed**
- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — **72 passed**
- [x] `pnpm build` — passed
- [x] `pnpm validate:clean` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `trunk check --upstream origin/main` — no issues
- [x] `git diff --check` / `node --check packages/registry/src/command-safety-lib.js` — clean

## Notes

- No open or closed PR existed for #5585 at start (timeline empty aside from labels/milestone).
- Failure modes avoided from related closes: #5600 (CI/`required-pr-gate` auto-close), #5566 (LoopOver reject). This PR: two-file focused diff, one-shot commit, local trunk + build + focused tests green before open, no post-open pushes.
