### PR TITLE
fix(web): accept www GitHub URLs for repo stats

### DIFF
--- a/apps/web/src/lib/github-repo-url-lib.ts
+++ b/apps/web/src/lib/github-repo-url-lib.ts
@@ -9,7 +9,7 @@
 export function parseRepo(url: string): { owner: string; repo: string } | null {
   try {
     const parsed = new URL(url);
-    if (parsed.hostname !== "github.com") return null;
+    if (parsed.hostname.replace(/^www\./, "") !== "github.com") return null;
     const [owner, repo] = parsed.pathname.split("/").filter(Boolean);
     if (!owner || !repo) return null;
     return { owner, repo: repo.replace(/\.git$/, "") };

--- a/tests/github-repo-url-lib.test.ts
+++ b/tests/github-repo-url-lib.test.ts
@@ -10,6 +10,13 @@ describe("parseRepo", () => {
     });
   });
 
+  it("parses owner/repo from a www.github.com URL", () => {
+    expect(parseRepo("https://www.github.com/acme/widgets")).toEqual({
+      owner: "acme",
+      repo: "widgets",
+    });
+  });
+
   it("strips a trailing .git and extra path segments", () => {
     expect(parseRepo("https://github.com/acme/widgets.git")).toEqual({
       owner: "acme",


### PR DESCRIPTION
## Summary

- Normalize a single leading `www.` before validating GitHub repository URL hosts.
- Add a regression test proving `https://www.github.com/acme/widgets` parses like the canonical host.
- Preserve the existing handling for canonical GitHub URLs, `.git` suffixes, extra path segments, invalid URLs, and non-GitHub hosts.

Closes #5598

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- **Changed surface:**
  - `apps/web/src/lib/github-repo-url-lib.ts` — normalize `www.github.com` to the canonical host before the host guard.
  - `tests/github-repo-url-lib.test.ts` — regression coverage for the `www.github.com` form.
- **Before:** `parseRepo("https://www.github.com/acme/widgets")` returned `null`, so `/api/github-stats` omitted stats.
- **After:** the same input returns `{ owner: "acme", repo: "widgets" }`, matching `https://github.com/acme/widgets`.
- **Scope:** the GitHub stats fetch/cache route and the already-correct registry URL parser were left untouched.
- **Screenshots:** **No visual impact** beyond GitHub stats appearing for previously affected entries; layout and styling are unchanged.

## Validation

- [x] `pnpm exec vitest run tests/github-repo-url-lib.test.ts` — 6 passed.
- [x] `pnpm --filter web type-check` — passed.
- [x] `pnpm exec prettier --check apps/web/src/lib/github-repo-url-lib.ts tests/github-repo-url-lib.test.ts` — clean.
- [x] `git diff --check` — clean.
- [ ] `pnpm build` — local Vite/Rolldown native logger failed after transforming all 3,220 modules and rendering chunks: `The function returned undefined, but expected object`. Reproduced twice; no parser/type/test failure was reported. CI is expected to provide a clean runner result.

## Notes

- Issue #5598 was unassigned and had no linked branch or pull request when work began.
- Focused two-file diff; generated artifacts remain unchanged.