### PR TITLE
fix(registry): classify sub-day placement expiry

### DIFF
--- a/packages/registry/src/commercial-lib.js
+++ b/packages/registry/src/commercial-lib.js
@@ -582,6 +582,10 @@ export function summarizePlacementExpiry(
           ? Math.ceil((expiryTime - nowTime) / 86_400_000)
           : null;
       const status = normalizeCommercialStatus(placement.status || "active");
+      const isExpired =
+        expiryTime !== null &&
+        Number.isFinite(expiryTime) &&
+        expiryTime <= nowTime;
 
       return {
         targetKind: placement.targetKind || placement.target_kind || "",
@@ -592,13 +596,11 @@ export function summarizePlacementExpiry(
         daysUntilExpiry,
         needsRenewalReminder:
           status === "active" &&
+          !isExpired &&
           daysUntilExpiry !== null &&
           daysUntilExpiry >= 0 &&
           daysUntilExpiry <= Math.ceil(windowMs / 86_400_000),
-        expired:
-          status === "active" &&
-          daysUntilExpiry !== null &&
-          daysUntilExpiry < 0,
+        expired: status === "active" && isExpired,
       };
     })
     .sort((left, right) => {

--- a/tests/commercial-lib.test.ts
+++ b/tests/commercial-lib.test.ts
@@ -888,6 +888,26 @@ describe("summarizePlacementExpiry", () => {
     });
   });
 
+  it("treats a sub-day past expiry as expired instead of a renewal", () => {
+    const [summary] = summarizePlacementExpiry(
+      [
+        {
+          targetKind: "tool",
+          targetKey: "just-expired",
+          status: "active",
+          expiresAt: "2026-05-31T23:00:00.000Z",
+        },
+      ],
+      NOW,
+    );
+
+    expect(summary).toMatchObject({
+      expired: true,
+      needsRenewalReminder: false,
+    });
+    expect(Object.is(summary.daysUntilExpiry, -0)).toBe(true);
+  });
+
   it("accepts a string now and custom reminder window", () => {
     const [summary] = summarizePlacementExpiry(
       [


### PR DESCRIPTION
## Summary

- Compare the raw placement expiry timestamp with `now` before applying rounded day-count presentation.
- Mark active placements expired immediately at or before their expiry time.
- Prevent already-expired placements from being classified as renewal reminders.
- Add a regression test for the `now - 1h` boundary that previously produced JavaScript `-0`.

Closes #5586

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: `summarizePlacementExpiry` in `packages/registry/src/commercial-lib.js` and its focused regression coverage in `tests/commercial-lib.test.ts`.
- Expected behavior: an active placement expiring at `2026-05-31T23:00:00.000Z` with `now = 2026-06-01T00:00:00.000Z` previously produced `daysUntilExpiry: -0`, `expired: false`, and `needsRenewalReminder: true`; it now produces `expired: true` and `needsRenewalReminder: false`.
- Important invariant: `daysUntilExpiry` remains the rounded display/sort value, while expiry state uses the finite raw timestamp. Non-active, missing-expiry, invalid-expiry, future-expiry, and reminder-window behavior remain unchanged.
- Backward compatibility: no API shape or type changes.
- No visual impact: registry expiry-classification logic only; no route, component, or styling changes.
- Accessibility: not applicable; no UI changed.
- Focused regression coverage explicitly confirms the original `-0` condition while asserting the corrected flags.

## Validation

- [x] `pnpm exec vitest run tests/commercial-lib.test.ts` — 51 passed.
- [x] `pnpm exec vitest run tests/commercial-lib.test.ts tests/commercial-intake.test.ts tests/non-ui-branch-matrix.test.ts` — 84 passed.
- [x] `pnpm exec prettier --check packages/registry/src/commercial-lib.js tests/commercial-lib.test.ts` — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed.
- [x] Generated artifacts were not committed.

## Notes

- Linked issue: #5586.
- The fix is intentionally scoped to `summarizePlacementExpiry`; `isPlacementActive` is unchanged.