### PR TITLE
fix(jobs): scale million compensation shorthand

### DIFF
--- a/apps/web/src/lib/jobs-utils-lib.ts
+++ b/apps/web/src/lib/jobs-utils-lib.ts
@@ -56,10 +56,13 @@ export function isFresh(iso: string, now = Date.now()): boolean {
 
 /** Thousands multiplier for a trailing `k`/`K` compensation shorthand (e.g. `$210k`). */
 const COMPENSATION_K_MULTIPLIER = 1000;
+/** Millions multiplier for a trailing `m`/`M` or `million` compensation shorthand. */
+const COMPENSATION_M_MULTIPLIER = 1_000_000;
 
 /**
  * Real-dollar sort value for a free-text compensation string, so mixed-format
- * listings compare on one scale: `"$210k"` and `"$210,000"` both yield `210000`.
+ * listings compare on one scale: `"$210k"` and `"$210,000"` both yield `210000`,
+ * while `"$1.2M"` yields `1200000`.
  *
  * Ranges sort by their leading figure only (e.g. `"$100k-$150k"` → `100000`) —
  * a deliberate pre-existing limitation of the salary sort, preserved here.
@@ -68,11 +71,16 @@ const COMPENSATION_K_MULTIPLIER = 1000;
  */
 export function compensationSortValue(compensation?: string | null): number {
   if (!compensation) return -1;
-  // Capture the optional trailing k/K so `"$210k"` scales to 210000, not 210.
-  const m = compensation.match(/\$?(\d[\d,]*)(k)?/i);
-  if (!m) return 0;
-  const base = parseInt(m[1].replace(/,/g, ""), 10);
-  return m[2] ? base * COMPENSATION_K_MULTIPLIER : base;
+  const match = compensation.match(/\$?(?:(\d[\d,]*(?:\.\d+)?)\s*(million|m)\b|(\d[\d,]*)(k)?)/i);
+  if (!match) return 0;
+
+  const base = Number.parseFloat((match[1] ?? match[3]).replace(/,/g, ""));
+  const suffix = (match[2] ?? match[4])?.toLowerCase();
+  if (suffix === "k") return base * COMPENSATION_K_MULTIPLIER;
+  if (suffix === "m" || suffix === "million") {
+    return base * COMPENSATION_M_MULTIPLIER;
+  }
+  return base;
 }
 
 export function sortJobs(jobs: JobListing[]): JobListing[] {

--- a/tests/jobs-utils-lib.test.ts
+++ b/tests/jobs-utils-lib.test.ts
@@ -196,6 +196,12 @@ describe("compensationSortValue", () => {
     );
   });
 
+  it('scales "M" and "million" shorthand, including decimal amounts', () => {
+    expect(compensationSortValue("$1M")).toBe(1_000_000);
+    expect(compensationSortValue("$1.2M")).toBe(1_200_000);
+    expect(compensationSortValue("1.2 million")).toBe(1_200_000);
+  });
+
   it("handles uppercase K, unprefixed amounts, and full-dollar figures", () => {
     expect(compensationSortValue("$95K")).toBe(95_000);
     expect(compensationSortValue("180k")).toBe(180_000);


### PR DESCRIPTION
## Summary

- Extend `compensationSortValue` with a `1_000_000` multiplier for `m`/`M` and `million` suffixes.
- Parse decimal million values such as `$1.2M` while preserving the existing integer `k`/plain-number branch.
- Add focused regression coverage for `$1M`, `$1.2M`, and `1.2 million`.

Closes #5582

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: `compensationSortValue` in `apps/web/src/lib/jobs-utils-lib.ts` and its unit tests in `tests/jobs-utils-lib.test.ts`.
- Multiplier logic: `k` remains `1_000`; `m`, `M`, and case-insensitive `million` use `1_000_000`.
- Before/after: `$1.2M` previously matched only the leading `1` and sorted as `$1`; it now resolves to `1_200_000`. `$1M` resolves to `1_000_000`.
- Important invariant: the existing integer `k`/plain-number branch and leading-figure range behavior are preserved; all pre-existing `k`, plain, range, empty, and fallback tests pass unchanged.
- Backward compatibility: no API shape or call-site changes.
- No visual impact: salary sort values change only for previously misparsed million shorthand; no UI or styling changes.
- Accessibility: not applicable; no rendered markup changed.

## Validation

- [x] `pnpm exec vitest run tests/jobs-utils-lib.test.ts` — 22 passed.
- [x] `pnpm exec prettier --check apps/web/src/lib/jobs-utils-lib.ts tests/jobs-utils-lib.test.ts` — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed.
- [x] Generated artifacts were not committed.

## Notes

- Linked issue: #5582.
- Scope is limited to compensation parsing and its focused regression tests.