### PR TITLE
fix(quality): associate method disclosure details

### DIFF
--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -10,7 +10,7 @@ import {
   ChevronDown,
   MessageSquareWarning,
 } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { CATEGORIES } from "@/types/registry";
 import { ENTRIES, QUALITY_STATS } from "@/data/entries";
 import { scoreEntry, type QualityRow } from "@/lib/quality-score-lib";
@@ -455,6 +455,7 @@ function Method({
   detail: string;
 }) {
   const [open, setOpen] = useState(false);
+  const detailId = useId();
   return (
     <button
       type="button"
@@ -468,6 +469,7 @@ function Method({
       }}
       className="w-full rounded-lg border border-border bg-surface p-3 text-left transition-colors duration-200 ease-out hover:bg-surface-2"
       aria-expanded={open}
+      aria-controls={detailId}
     >
       <div className="flex items-center justify-between gap-2">
         <span className="text-sm font-medium text-ink">{label}</span>
@@ -475,7 +477,11 @@ function Method({
           className={cn("h-4 w-4 text-ink-subtle transition-transform", open && "rotate-180")}
         />
       </div>
-      {open && <p className="mt-2 text-xs text-ink-muted">{detail}</p>}
+      {open && (
+        <p id={detailId} className="mt-2 text-xs text-ink-muted">
+          {detail}
+        </p>
+      )}
     </button>
   );
 }

--- a/tests/quality-methodology.test.ts
+++ b/tests/quality-methodology.test.ts
@@ -49,6 +49,17 @@ describe("quality methodology page", () => {
     );
   });
 
+  it("associates each method disclosure toggle with its revealed detail", () => {
+    const methodSource = qualitySource.slice(
+      qualitySource.indexOf("function Method({"),
+      qualitySource.indexOf("function Stat({"),
+    );
+
+    expect(methodSource).toContain("const detailId = useId();");
+    expect(methodSource).toContain("aria-controls={detailId}");
+    expect(methodSource).toContain("<p id={detailId}");
+  });
+
   it("links entry trust and citation surfaces to the methodology anchors", () => {
     const trustDrilldownSource = readRepoFile(
       "apps/web/src/components/trust-drilldown.tsx",


### PR DESCRIPTION
## Summary

- Generate a stable React `useId()` value for each `/quality` Method disclosure.
- Connect the toggle's `aria-controls` to the revealed detail paragraph's matching `id`.
- Add an accessibility contract test that protects the ID/control pairing.

Closes #5595

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: the `Method` disclosure in `apps/web/src/routes/quality.tsx` and its accessibility contract in `tests/quality-methodology.test.ts`.
- Expected behavior: every Method button now exposes both `aria-expanded` state and an `aria-controls` reference to the detail paragraph it reveals.
- Stable pairing: React `useId()` supplies the per-instance ID; the same `detailId` is applied to `aria-controls` and the paragraph `id`.
- Accessibility verification: the focused contract test asserts `useId`, `aria-controls={detailId}`, and `<p id={detailId}` remain paired.
- Keyboard/focus behavior is unchanged: the native `<button>` remains the interactive control, its click/state logic is untouched, and no focus-moving behavior was added.
- Backward compatibility: show/hide state, analytics, markup order, and styling remain unchanged.
- No visual impact: this adds accessibility attributes only; no layout or CSS changes.

## Validation

- [x] `pnpm exec vitest run tests/quality-methodology.test.ts` — 4 passed, including the new accessibility contract.
- [x] Focused test rerun after rebasing onto the latest `upstream/main` — passed.
- [x] `pnpm exec prettier --check apps/web/src/routes/quality.tsx tests/quality-methodology.test.ts` — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed.
- [x] Generated artifacts were not committed.

## Notes

- Linked issue: #5595.
- Scope is limited to the Method disclosure relationship and its regression guard.