### PR TITLE
fix(quality): recognize list-based note evidence

### DIFF
--- a/apps/web/src/lib/quality-score-lib.ts
+++ b/apps/web/src/lib/quality-score-lib.ts
@@ -22,7 +22,7 @@ export function scoreEntry(e: Entry): QualityRow {
     recs.push("Add a verifiable source URL.");
   }
   if (
-    !e.safetyNotes &&
+    !(e.safetyNotes || e.safetyNotesList?.length) &&
     (e.category === "mcp" ||
       e.category === "hooks" ||
       e.category === "skills" ||
@@ -31,7 +31,10 @@ export function scoreEntry(e: Entry): QualityRow {
     score -= 20;
     recs.push("Add safety notes for this risk-bearing category.");
   }
-  if (!e.privacyNotes && (e.category === "mcp" || e.category === "skills")) {
+  if (
+    !(e.privacyNotes || e.privacyNotesList?.length) &&
+    (e.category === "mcp" || e.category === "skills")
+  ) {
     score -= 10;
     recs.push("Add privacy notes covering data flow.");
   }

--- a/tests/quality-score-lib.test.ts
+++ b/tests/quality-score-lib.test.ts
@@ -48,6 +48,38 @@ describe("scoreEntry", () => {
     expect(scoreEntry(entry({ category: "rules" })).score).toBe(100);
   });
 
+  it("accepts list-only safety notes without a deduction or recommendation", () => {
+    const row = scoreEntry(
+      entry({
+        category: "mcp",
+        safetyNotesList: ["Runs local commands"],
+        privacyNotes: ["Stays local"],
+        installCommand: "npx x",
+      }),
+    );
+
+    expect(row.score).toBe(100);
+    expect(row.recommendations).not.toContain(
+      "Add safety notes for this risk-bearing category.",
+    );
+  });
+
+  it("accepts list-only privacy notes without a deduction or recommendation", () => {
+    const row = scoreEntry(
+      entry({
+        category: "mcp",
+        safetyNotes: ["Runs local commands"],
+        privacyNotesList: ["Stays local"],
+        installCommand: "npx x",
+      }),
+    );
+
+    expect(row.score).toBe(100);
+    expect(row.recommendations).not.toContain(
+      "Add privacy notes covering data flow.",
+    );
+  });
+
   it("covers hooks (safety only) and commands (safety + install) categories", () => {
     expect(scoreEntry(entry({ category: "hooks" })).score).toBe(80); // -20 safety
     expect(scoreEntry(entry({ category: "commands" })).score).toBe(70); // -20 safety -10 install


### PR DESCRIPTION
## Summary

- Treat `safetyNotesList` as valid safety evidence in `scoreEntry`, matching the scalar field and the rest of the registry.
- Treat `privacyNotesList` as valid privacy evidence under the same rule.
- Add isolated regressions for both list-only cases while retaining the existing neither-present deduction coverage.

Closes #5597

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: `scoreEntry` in `apps/web/src/lib/quality-score-lib.ts` and its focused unit tests in `tests/quality-score-lib.test.ts`.
- Before/after safety example: an otherwise complete MCP entry with only `safetyNotesList` previously scored 80 and received “Add safety notes”; it now scores 100 with no safety recommendation.
- Before/after privacy example: an otherwise complete MCP entry with only `privacyNotesList` previously scored 90 and received “Add privacy notes”; it now scores 100 with no privacy recommendation.
- Important invariant: entries with neither scalar nor list evidence still receive the existing -20/-10 deductions and recommendations; the pre-existing missing-notes test remains unchanged and passes.
- Backward compatibility: scalar `safetyNotes`/`privacyNotes`, category gates, all other deductions, recommendation text, and return shape are unchanged.
- No visual impact beyond corrected `/quality` scores and recommendations for affected entries; no markup or styling changed.
- Accessibility: not applicable; no interactive UI changed.

## Validation

- [x] `pnpm exec vitest run tests/quality-score-lib.test.ts` — 9 passed.
- [x] Focused tests rerun after rebasing onto the latest `upstream/main` — passed.
- [x] `pnpm exec prettier --check apps/web/src/lib/quality-score-lib.ts tests/quality-score-lib.test.ts` — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed.
- [x] Generated artifacts were not committed.

## Notes

- Linked issue: #5597.
- Scope is limited to safety/privacy evidence recognition and focused regressions.