### PR TITLE
fix(registry): make relation graph timestamp order-independent

### DIFF
--- a/packages/registry/src/relationships-lib.js
+++ b/packages/registry/src/relationships-lib.js
@@ -416,23 +416,21 @@ export function buildRegistryRelationGraph(entries, params = {}) {
     url: entryUrl(entry),
     related: buildEntryRelations(entry, candidatesFor(entry), { limit }),
   }));
+  const latestEntryDate = entries
+    .map((entry) =>
+      String(entry.contentUpdatedAt || entry.dateAdded || "").slice(0, 10),
+    )
+    .filter(Boolean)
+    .sort()
+    .at(-1);
 
   return {
     schemaVersion: 1,
     kind: "registry-relation-graph",
     generatedAt:
       params.generatedAt ||
-      (entries[0]?.dateAdded
-        ? `${entries
-            .map((entry) =>
-              String(entry.contentUpdatedAt || entry.dateAdded || "").slice(
-                0,
-                10,
-              ),
-            )
-            .filter(Boolean)
-            .sort()
-            .at(-1)}T00:00:00.000Z`
+      (latestEntryDate
+        ? `${latestEntryDate}T00:00:00.000Z`
         : "1970-01-01T00:00:00.000Z"),
     relationTypes: REGISTRY_RELATION_TYPES,
     maxRelationsPerEntry: limit,

--- a/tests/relationships-lib.test.ts
+++ b/tests/relationships-lib.test.ts
@@ -738,6 +738,21 @@ describe("buildRegistryRelationGraph", () => {
     expect(graph.generatedAt).toBe("2025-06-01T00:00:00.000Z");
   });
 
+  it("derives the same generatedAt regardless of entry order", () => {
+    const undated = entry({ slug: "undated" });
+    const dated = entry({
+      slug: "dated",
+      dateAdded: "2025-06-01",
+      contentUpdatedAt: "2026-02-03",
+    });
+
+    const undatedFirst = buildRegistryRelationGraph([undated, dated]);
+    const datedFirst = buildRegistryRelationGraph([dated, undated]);
+
+    expect(undatedFirst.generatedAt).toBe("2026-02-03T00:00:00.000Z");
+    expect(undatedFirst.generatedAt).toBe(datedFirst.generatedAt);
+  });
+
   it("indexes candidates via shared repo, url, domain, token, and collection refs", () => {
     const member = entry({
       category: "skills",


### PR DESCRIPTION
## Summary

- derive the relation graph timestamp from the latest available entry date across the complete input
- remove the `entries[0].dateAdded` gate that made `generatedAt` depend on entry ordering
- preserve the explicit `generatedAt` override and epoch fallback
- add a regression test covering undated-first and dated-first permutations

## Before / after

Before, placing an undated entry first forced `generatedAt` to `1970-01-01T00:00:00.000Z`, even when a later entry had `contentUpdatedAt: 2026-02-03`.

After, both permutations produce `2026-02-03T00:00:00.000Z`; inputs with no dates still use the epoch.

## Validation

- `pnpm exec vitest run tests/relationships-lib.test.ts` (57 tests passed)
- `pnpm build`
- `git diff --check`

Closes #5587