### PR TITLE
fix(web): count external sources in MCP Source-backed stat

### DIFF
--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -123,9 +123,8 @@ const TRUST_DIST: DistRow[] = withTrustDrilldown(
 );
 
 const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
-const SOURCE_BACKED = MCP.filter(
-  (e) => e.source === "source-backed" || e.source === "first-party",
-).length;
+// Match index.tsx / QUALITY_STATS: "Source-backed" means anything not unverified (#5579).
+const SOURCE_BACKED = MCP.filter((e) => e.source !== "unverified").length;
 const SOURCE_DIST: DistRow[] = withSourceDrilldown(
   SOURCE_ORDER.map((status) => {
     const count = MCP.filter((e) => e.source === status).length;


### PR DESCRIPTION
﻿## Summary

`/state-of-mcp-servers` computed Source-backed as only first-party + source-backed, while `/` and `/state-of-claude-tooling` use anything not unverified (includes external). Same label, different denominator.

## Change

- SOURCE_BACKED filter now excludes only source === "unverified"
- index.tsx and data/entries.ts left untouched (already correct)

## Quality evidence

No visual impact beyond the corrected Source-backed count/percentage on the existing stat card.

## Validation

One-line filter alignment with index.tsx / QUALITY_STATS.

Closes #5579
