### PR TITLE
fix(web): use hasSafetyNotes in command-center readiness

### DIFF
--- a/apps/web/src/lib/entry-detail-command-center-lib.ts
+++ b/apps/web/src/lib/entry-detail-command-center-lib.ts
@@ -64,7 +64,7 @@ function hasPrivacyNotes(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">
 }
 
 export function resolveDetailReadinessItems(
-  entry: Pick<Entry, "trust" | "source" | "safetyNotes" | "reviewed">,
+  entry: Pick<Entry, "trust" | "source" | "safetyNotes" | "safetyNotesList" | "reviewed">,
 ): DetailReadinessItem[] {
   return [
     {
@@ -82,8 +82,9 @@ export function resolveDetailReadinessItems(
     {
       id: "safety",
       label: "Safety notes",
-      value: entry.safetyNotes ? "Present" : "Missing",
-      ok: Boolean(entry.safetyNotes),
+      // Use hasSafetyNotes so safetyNotesList counts the same as scalar safetyNotes (#5596).
+      value: hasSafetyNotes(entry) ? "Present" : "Missing",
+      ok: hasSafetyNotes(entry),
     },
     {
       id: "reviewed",

--- a/tests/entry-detail-command-center-lib.test.ts
+++ b/tests/entry-detail-command-center-lib.test.ts
@@ -40,6 +40,24 @@ describe("entry detail command center lib", () => {
     ]);
   });
 
+  it("treats safetyNotesList-only as Present in readiness (#5596)", () => {
+    // Before: ok:false / Missing because resolveDetailReadinessItems ignored the list field.
+    // After: uses hasSafetyNotes — list-only counts as Present.
+    const items = resolveDetailReadinessItems(
+      entry({
+        trust: "trusted",
+        reviewed: true,
+        safetyNotesList: ["Runs shell commands."],
+      }),
+    );
+    expect(items.find((item) => item.id === "safety")).toEqual({
+      id: "safety",
+      label: "Safety notes",
+      value: "Present",
+      ok: true,
+    });
+  });
+
   it("orders quick links with docs and source before registry helpers", () => {
     const links = resolveDetailQuickLinks(
       entry({


### PR DESCRIPTION
﻿## Summary

`resolveDetailReadinessItems` inlined a scalar-only `safetyNotes` check while the same file's `hasSafetyNotes` helper already treats `safetyNotesList` as documented. An entry with only `safetyNotesList` showed Missing / ok:false in the readiness checklist.

## Change

- Route the safety readiness row through `hasSafetyNotes(entry)` for both value and ok
- Widen the Pick type to include `safetyNotesList`
- Regression test: list-only entry shows Present / ok:true
- Prettier-formatted (prior #5613 closed for trunk/prettier on the test file)

## Before / after

- Before (list-only): Safety notes = Missing
- After (list-only): Safety notes = Present

## Quality evidence

No visual impact beyond the corrected readiness-row state for list-only entries.

## Validation

`pnpm test -- entry-detail-command-center-lib` — pass
`npx prettier --write` on touched files

Closes #5596
