### PR TITLE
fix(registry): require safety notes for non_https_executable_source

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -51,6 +51,12 @@ const HEYCLAUDE_HOSTNAME = "heyclau.de";
 const SAFETY_NOTE_REQUIRED_FLAGS = new Set([
   "unsafe_install_pipeline",
   "mutable_script_install_source",
+  // Critical-severity sibling of the two flags above in the
+  // `unsafe_install_or_secret` capability bucket (#5589). Executing or fetching
+  // install/usage content over plain HTTP is an execution-surface risk, so it
+  // belongs here rather than in PRIVACY_NOTE_REQUIRED_FLAGS with the bucket's
+  // credential-shaped member `embedded_secret`.
+  "non_https_executable_source",
   "financial_or_identity_sensitive",
   "external_write_capability",
   "destructive_actions",

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -430,6 +430,78 @@ describe("submission risk invariants", () => {
     );
   });
 
+  it("requires safetyNotes when non_https_executable_source is raised (#5589)", () => {
+    // Plain-HTTP usage endpoint with no curl|bash pipeline, so
+    // `non_https_executable_source` is the only SAFETY_NOTE_REQUIRED_FLAGS
+    // member in play — isolating the flag this issue added to that set.
+    const missingNotes = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 5589,
+        title: "content(mcp): add plain http endpoint mcp",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Plain HTTP Endpoint MCP",
+            slug: "plain-http-endpoint-mcp",
+            usageSnippet:
+              "claude mcp add plain-http -- npx -y plain-http-endpoint-mcp --endpoint http://relay.invalid/rpc",
+            safetyNotes: [],
+          }),
+          "content/mcp/plain-http-endpoint-mcp.mdx",
+        ),
+      ],
+    });
+    const withNotes = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 5590,
+        title: "content(mcp): add plain http endpoint mcp with notes",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Plain HTTP Endpoint MCP",
+            slug: "plain-http-endpoint-mcp",
+            usageSnippet:
+              "claude mcp add plain-http -- npx -y plain-http-endpoint-mcp --endpoint http://relay.invalid/rpc",
+            safetyNotes: [
+              "Talks to a plain-HTTP relay endpoint; traffic is not transport-encrypted.",
+            ],
+          }),
+          "content/mcp/plain-http-endpoint-mcp.mdx",
+        ),
+      ],
+    });
+
+    expect(missingNotes.reviewFlags.map((flag) => flag.id)).toContain(
+      "non_https_executable_source",
+    );
+    expect(missingNotes.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "unsafe_install_pipeline",
+    );
+    expect(
+      missingNotes.classificationWarnings.map((warning) => warning.id),
+    ).toContain("missing_safety_notes");
+    expect(
+      missingNotes.classificationWarnings.find(
+        (warning) => warning.id === "missing_safety_notes",
+      )?.detail,
+    ).toContain("non_https_executable_source");
+
+    expect(withNotes.reviewFlags.map((flag) => flag.id)).toContain(
+      "non_https_executable_source",
+    );
+    expect(
+      withNotes.classificationWarnings.map((warning) => warning.id),
+    ).not.toContain("missing_safety_notes");
+  });
+
   it("keeps identity attestation risk matching narrow and synchronized with CI", () => {
     const sensitiveReport = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
## Summary

- Add `non_https_executable_source` to `SAFETY_NOTE_REQUIRED_FLAGS` in `packages/registry/src/submission-risk.js`, so a critical-severity flag about executing/fetching install content over plain HTTP now requires a `safetyNotes` disclosure like its `unsafe_install_or_secret` bucket-mates.
- Add an isolated regression covering the flag on its own (missing notes -> `missing_safety_notes` fires; notes present -> it does not).

Closes #5589

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: `SAFETY_NOTE_REQUIRED_FLAGS` in `packages/registry/src/submission-risk.js` and its focused invariant tests in `tests/submission-risk-invariants.test.ts`. No route, component, endpoint, or MCP tool changed.
- Root cause: `CAPABILITY_BUCKET_BY_FLAG` groups `embedded_secret`, `non_https_executable_source`, `unsafe_install_pipeline`, and `mutable_script_install_source` into the same `unsafe_install_or_secret` bucket, but `non_https_executable_source` was the only member of that bucket present in neither `SAFETY_NOTE_REQUIRED_FLAGS` nor `PRIVACY_NOTE_REQUIRED_FLAGS`. `addDisclosureNoteSignals` filters the raised flags through those two sets, so it could never fire `missing_safety_notes` for this flag.
- Why safety and not privacy: the flag describes execution surface (install/usage instructions executing or fetching over plain HTTP), not credential or personal-data access. That matches `unsafe_install_pipeline`/`mutable_script_install_source` in `SAFETY_NOTE_REQUIRED_FLAGS`; the bucket's credential-shaped member `embedded_secret` correctly stays in `PRIVACY_NOTE_REQUIRED_FLAGS`.
- Before/after: a direct MCP content PR whose `usageSnippet` points at `http://relay.invalid/rpc` with `safetyNotes: []` raised `non_https_executable_source` and produced **no** classification warnings. It now produces `missing_safety_notes`, with `non_https_executable_source` named in the warning `detail`. The same entry with `safetyNotes` populated raises the flag but produces no `missing_safety_notes`, so the disclosure path clears correctly.
- Regression strength: the new test was confirmed red before the source change (`AssertionError: expected [] to include 'missing_safety_notes'`) and green after. The fixture deliberately uses a plain-HTTP endpoint with no `curl | bash` pipeline, and asserts `unsafe_install_pipeline` is **not** raised, so the assertion is driven only by the flag this PR adds rather than by a pre-existing set member.
- Important invariants: `unsafe_install_pipeline`, `mutable_script_install_source`, and `embedded_secret` disclosure behavior is unchanged; the existing `malware_or_abuse_surface` (#5559) and `#5584` safe-harbor tests still pass untouched.
- Backward compatibility: additive only. The flag's detection logic, severity (`critical`), risk tier arithmetic, warning text, and report shape are all unchanged; the single change is set membership. Submissions that already carry `safetyNotes` see no behavior difference.
- Out of scope, deliberately: `scripts/ci/validate-content-policy.mjs` keeps its own narrower copy of these sets (it already omits `malware_or_abuse_surface` from #5559, so the two are not mirrored today and no test asserts parity). The issue scoped this to `submission-risk.js`, so I did not widen it.
- No visual impact: no UI, markup, or styling changed. Accessibility: not applicable, no interactive UI changed.

## Validation

- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts` — 73 passed.
- [x] `pnpm exec vitest run tests/submission-pr-first.test.ts tests/content-policy-validation.test.ts tests/non-ui-branch-matrix.test.ts tests/submission-preflight-lib.test.ts` — all passed.
- [x] `pnpm exec prettier --check` on both changed files — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed; no generated artifacts committed.

## Notes

- Linked issue: #5589.
- Local-environment caveat, not caused by this branch: `tests/submission-workflows.test.ts` reports 21 failures on my Windows checkout, but it fails identically on a clean `upstream/main` — those are child-process script-spawn tests that need a POSIX shell. Verified against the unmodified base before opening this PR; Linux CI is the authority.
