### PR TITLE
fix(registry): allowlist URL protocols in parseGitHubRepoUrl

### DIFF
--- a/packages/registry/src/source-repo-lib.js
+++ b/packages/registry/src/source-repo-lib.js
@@ -18,6 +18,15 @@ const OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
 // GitHub repository names: alphanumeric plus "-", "_", and ".".
 const REPO_PATTERN = /^[A-Za-z0-9._-]+$/;
 
+// URL schemes this parser actually supports: the two web schemes plus the git
+// transports authors paste from clone dialogs ("git+https://" is normalized to
+// "https:" before parsing). Anything outside this set is rejected before the
+// checks below run, so a scheme the parser never intended to accept — ftp:,
+// file:, data: — cannot slip an embedded-credential URL past the http/https
+// userinfo guard by simply changing its scheme (#5588). Mirrors the protocol
+// allowlist `isPublicGitHubHostUrl` in `source-url-lib.js` already applies.
+const ALLOWED_URL_PROTOCOLS = new Set(["http:", "https:", "git:", "ssh:"]);
+
 // First path segments that are GitHub product surfaces, never repo owners.
 // GitHub reserves these names, so "github.com/sponsors/x" or
 // "github.com/features/copilot" is a product/marketing/auth page, not a
@@ -122,6 +131,7 @@ export function parseGitHubRepoUrl(value) {
     } catch {
       return null;
     }
+    if (!ALLOWED_URL_PROTOCOLS.has(url.protocol)) return null;
     const ownerRepo = ownerRepoFromPath(url.pathname);
     if (!ownerRepo) return null;
     if (

--- a/tests/source-repo-lib.test.ts
+++ b/tests/source-repo-lib.test.ts
@@ -477,6 +477,29 @@ describe("parseGitHubRepoUrl enterprise and typo rejection", () => {
     expect(parseGitHubRepoUrl(input)).toBeNull();
   });
 
+  // Regression (#5588): the embedded-userinfo guard only runs for http:/https:,
+  // so before the protocol allowlist any other scheme carried credentials
+  // straight through to a successful parse.
+  it.each([
+    "ftp://user:pass@github.com/OpenAI/whisper",
+    "ftp://github.com/OpenAI/whisper",
+    "file://github.com/OpenAI/whisper",
+    "data://user:pass@github.com/OpenAI/whisper",
+    "ws://token@github.com/OpenAI/whisper",
+  ])("rejects URLs using a non-allowlisted scheme: %s", (input) => {
+    expect(parseGitHubRepoUrl(input)).toBeNull();
+  });
+
+  it.each([
+    "https://github.com/OpenAI/whisper",
+    "http://github.com/OpenAI/whisper",
+    "git://github.com/OpenAI/whisper.git",
+    "ssh://git@github.com/OpenAI/whisper.git",
+    "git+https://github.com/OpenAI/whisper.git",
+  ])("keeps allowlisted schemes parsing: %s", (input) => {
+    expect(parseGitHubRepoUrl(input)).toEqual(whisper);
+  });
+
   it.each([
     "github.com/OpenAI/whisper",
     "www.github.com/OpenAI/whisper",


### PR DESCRIPTION
## Summary

- Add an explicit URL-protocol allowlist to `parseGitHubRepoUrl` so schemes the parser never intended to accept cannot carry an embedded-credential URL past the http/https userinfo guard.
- Add regressions for the rejected schemes and a companion case pinning the supported schemes (`http:`, `https:`, `git:`, `ssh:`, `git+https://`) so the allowlist cannot be tightened into a break later.

Closes #5588

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: `parseGitHubRepoUrl` in `packages/registry/src/source-repo-lib.js` and its focused unit tests in `tests/source-repo-lib.test.ts`. No route, component, endpoint, or MCP tool changed.
- Root cause: the embedded-userinfo guard was written as `(url.protocol === "http:" || url.protocol === "https:") && hasEmbeddedUrlUserinfo(...)`, and nothing else constrained the scheme. Any scheme `new URL()` accepts therefore skipped the credential check outright.
- Before/after: `parseGitHubRepoUrl("ftp://user:pass@github.com/OpenAI/whisper")` previously returned a valid canonical record `{ host: "github.com", owner: "OpenAI", repo: "whisper", url: "https://github.com/OpenAI/whisper" }`, laundering a credential-stuffed URL into a clean-looking one, while its `https://` twin was correctly rejected as `null`. It now returns `null`. Same for `file://`, `data://`, and `ws://token@...`.
- Fix shape and why the allowlist is not http/https-only: the issue's wording suggests rejecting every non-HTTP(S) scheme, but `git://` and `ssh://` are supported, intentional, and covered by existing tests (`ssh://git@github.com/OpenAI/whisper.git`, `git://github.com/Org3/repo-three.git`, and the `git+https://` clone-dialog form that is normalized to `https:` before parsing). Rejecting them outright would have broken those tests, which the issue also requires to pass. The self-consistent fix is an allowlist of the schemes the parser actually supports — `http:`, `https:`, `git:`, `ssh:` — which closes the reported bypass while keeping every documented input working. This mirrors the protocol allowlist the sibling `isPublicGitHubHostUrl` in `source-url-lib.js` already applies, which is exactly the parity the issue asks for.
- Ordering matters: the allowlist is checked before the userinfo guard, so a non-web scheme cannot be used to reach the credential check on a path where the check does not apply.
- Regression strength: the five rejection cases were confirmed red before the source change (`AssertionError: expected { host: 'github.com', …(3) } to be null`) and green after. The paired "keeps allowlisted schemes parsing" case guards the other direction.
- Important invariants: the scp short form (`git@github.com:OpenAI/whisper.git`) bypasses the URL parser via `fromScpLike` and is untouched. Host normalization (`www.` stripping), `RESERVED_OWNERS`, owner/repo pattern checks, `.git` trimming, query/fragment stripping, and the canonical `https://github.com/owner/repo` output are all unchanged.
- Backward compatibility: no valid GitHub repo reference that parsed before stops parsing. The only behavior change is that previously-accepted non-web schemes now return `null`, which is the reported bug. All 280 existing `source-repo-lib` tests pass unmodified.
- No visual impact: no UI, markup, or styling changed. Accessibility: not applicable, no interactive UI changed.

## Validation

- [x] `pnpm exec vitest run tests/source-repo-lib.test.ts tests/source-repo.test.ts tests/registry-source-repo.test.ts tests/source-repo-signals-lib.test.ts` — 889 passed.
- [x] `pnpm exec vitest run tests/source-url-lib.test.ts tests/content-schema-lib.test.ts tests/non-ui-branch-matrix.test.ts` — passed, covering the consumers of this parser.
- [x] `pnpm exec prettier --check` on both changed files — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed; no generated artifacts committed.

## Notes

- Linked issue: #5588.
- If maintainers would rather have `git:`/`ssh:` dropped from the allowlist as well, that is a deliberate behavior change to the existing clone-URL support and would need the corresponding existing tests updated. I kept them supported to satisfy the issue's "existing tests pass" criterion.
