### PR TITLE
fix(web): align MCP Source-backed stat with index + export

### DIFF
--- a/apps/web/src/lib/mcp-servers-stats-lib.ts
+++ b/apps/web/src/lib/mcp-servers-stats-lib.ts
@@ -31,9 +31,7 @@ export function buildMcpServersReport(entries: ReadonlyArray<Entry>, asOf: strin
   const local = mcp.filter(
     (entry) => hostingOf(classifyTransport(entry)) === "Local (stdio)",
   ).length;
-  const sourceBacked = mcp.filter(
-    (entry) => entry.source === "source-backed" || entry.source === "first-party",
-  ).length;
+  const sourceBacked = mcp.filter((entry) => entry.source !== "unverified").length;
 
   const trustRows = TRUST_ORDER.map((trust) => {
     const count = mcp.filter((entry) => entry.trust === trust).length;

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -123,9 +123,8 @@ const TRUST_DIST: DistRow[] = withTrustDrilldown(
 );
 
 const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
-const SOURCE_BACKED = MCP.filter(
-  (e) => e.source === "source-backed" || e.source === "first-party",
-).length;
+// Match index.tsx / QUALITY_STATS / mcp-servers-stats-lib: anything not unverified (#5579).
+const SOURCE_BACKED = MCP.filter((e) => e.source !== "unverified").length;
 const SOURCE_DIST: DistRow[] = withSourceDrilldown(
   SOURCE_ORDER.map((status) => {
     const count = MCP.filter((e) => e.source === status).length;

--- a/tests/mcp-servers-stats-lib.test.ts
+++ b/tests/mcp-servers-stats-lib.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildMcpServersReport } from "@/lib/mcp-servers-stats-lib";
 import { buildMcpServersReport as buildFromWrapper } from "@/lib/mcp-servers-stats";
 import { ENTRIES } from "@/data/entries";
+import type { Entry } from "@/types/registry";
 
 describe("mcp-servers-stats-lib", () => {
   it("builds a deterministic MCP servers report model", () => {
@@ -26,5 +27,22 @@ describe("mcp-servers-stats-lib", () => {
     expect(buildFromWrapper(ENTRIES, "2026-07-16")).toEqual(
       buildMcpServersReport(ENTRIES, "2026-07-16"),
     );
+  });
+
+  it("counts external sources toward Source-backed like index.tsx (#5579)", () => {
+    const fixtures = [
+      { category: "mcp", source: "first-party" },
+      { category: "mcp", source: "source-backed" },
+      { category: "mcp", source: "external" },
+      { category: "mcp", source: "unverified" },
+      { category: "skills", source: "external" },
+    ] as Entry[];
+    const report = buildMcpServersReport(fixtures, "2026-07-28");
+    const sourceBacked = report.stats.find(
+      (stat) => stat.key === "source-backed",
+    );
+    // Before: only first-party + source-backed => 2. After: anything not unverified => 3.
+    expect(sourceBacked?.value).toBe(3);
+    expect(report.total).toBe(4);
   });
 });


### PR DESCRIPTION
﻿## Summary

`/state-of-mcp-servers` and its JSON/CSV export (`buildMcpServersReport`) computed Source-backed as only first-party + source-backed, while `/` and `/state-of-claude-tooling` use anything not unverified (includes external). #5615 fixed only the page and was closed for leaving the export out of sync — this PR updates both.

## Change

- `state-of-mcp-servers.tsx`: `SOURCE_BACKED = MCP.filter((e) => e.source !== "unverified").length`
- `mcp-servers-stats-lib.ts`: same filter for the exported report stat
- Regression test: fixture with external counts toward Source-backed (3 of 4 MCP entries)
- `index.tsx` / `data/entries.ts` left untouched (already correct)

## Before / after

- Before: first-party + source-backed only (external excluded)
- After: all non-unverified (external included), page and export match

## Quality evidence

No visual impact beyond the corrected Source-backed count/% on the existing stat card and matching export.

## Validation

`pnpm test -- mcp-servers-stats-lib` — 3/3 pass
`npx prettier --write` on touched files

Closes #5579
