### PR TITLE
fix(registry): require https for skills documentationUrl

### DIFF
--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -816,7 +816,8 @@ export function validateEntry(category, data, inferred = {}) {
   for (const field of [
     "authorProfileUrl",
     "repoUrl",
-    "documentationUrl",
+    // skills: https-only below — matches retrievalSources auto-derived from it
+    ...(category === "skills" ? [] : ["documentationUrl"]),
     "sourceUrl",
     "docsUrl",
     "packageUrl",
@@ -826,6 +827,10 @@ export function validateEntry(category, data, inferred = {}) {
     if (!isPublicHttpUrl(merged[field])) {
       semanticErrors.push(`${field} must use http or https`);
     }
+  }
+
+  if (category === "skills" && !isPublicHttpsUrl(merged.documentationUrl)) {
+    semanticErrors.push("documentationUrl must use https");
   }
 
   if (Array.isArray(merged.sourceUrls)) {

--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -1209,6 +1209,45 @@ describe("validateEntry category-specific recommended/semantic rules", () => {
     expect(result.missingRecommended).not.toContain("installCommand");
   });
 
+  it("rejects http documentationUrl on skills (retrievalSources fallback needs https)", () => {
+    const inferred = inferStructuredFields(
+      {
+        slug: "s",
+        title: "S",
+        description: "D",
+        documentationUrl: "http://docs.example/skill",
+      },
+      "",
+      "skills",
+    );
+    const result = validateEntry(
+      "skills",
+      {
+        slug: "s",
+        title: "S",
+        description: "D",
+        documentationUrl: "http://docs.example/skill",
+      },
+      inferred,
+    );
+    expect(result.semanticErrors).toContain("documentationUrl must use https");
+  });
+
+  it("still allows http documentationUrl on non-skills categories", () => {
+    const result = validateEntry("agents", {
+      slug: "a",
+      title: "A",
+      description: "D",
+      documentationUrl: "http://docs.example/agent",
+    });
+    expect(result.semanticErrors).not.toContain(
+      "documentationUrl must use https",
+    );
+    expect(result.semanticErrors).not.toContain(
+      "documentationUrl must use http or https",
+    );
+  });
+
   it("requires verifiedAt on a capability-pack skill", () => {
     const result = validateEntry("skills", {
       slug: "s",


### PR DESCRIPTION
## Summary
- Chose fix direction **(a)**: require `isPublicHttpsUrl` for `documentationUrl` on the `skills` category only.
- Why: smaller, localized change at the field the author actually sets; matches the https-only `retrievalSources` auto-derived from that URL.
- Non-skills categories still accept http or https for `documentationUrl`.
- Regression test covers http `documentationUrl` on skills (with inferred fallback) and confirms non-skills unchanged.

Closes #5592

## Test plan
- [x] `pnpm test -- content-schema-lib` (396 passed)
- [ ] `pnpm run validate:content`
- [ ] `pnpm build`