### PR TITLE
fix(registry): ignore self-referential githubUrl as source

### DIFF
--- a/packages/mcp/src/registry-trust-lib.js
+++ b/packages/mcp/src/registry-trust-lib.js
@@ -35,6 +35,16 @@ export function sourceHost(value) {
   return publicUrlHostname(String(value || "").trim());
 }
 
+// Match artifacts-lib `externalGithubUrl`: the directory always stamps a
+// self-referential github.com/JSONbored/awesome-claude link that is not a
+// real external source for trust / "verify canonical source" recommendations.
+function externalGithubUrl(entry) {
+  return entry.githubUrl &&
+    !String(entry.githubUrl).includes("github.com/JSONbored/awesome-claude")
+    ? entry.githubUrl
+    : "";
+}
+
 export function entrySourceHosts(entry) {
   // Hosts must come from the same URL field list as `source.status`
   // (`entrySourceUrls` / `ENTRY_SOURCE_URL_FIELDS`) so the two signals cannot
@@ -44,7 +54,7 @@ export function entrySourceHosts(entry) {
 
 export function sourceSummary(entry) {
   return {
-    repoUrl: entry.repoUrl || entry.githubUrl || "",
+    repoUrl: entry.repoUrl || externalGithubUrl(entry) || "",
     documentationUrl: entry.documentationUrl || "",
     downloadUrl: entry.downloadUrl || "",
     sourceHosts: unique(entrySourceHosts(entry)),

--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -488,7 +488,8 @@ function sourceUrlsForEntry(entry) {
     entry.docsUrl,
     entry.downloadUrl,
     entry.repoUrl,
-    entry.githubUrl,
+    // Self-referential directory githubUrl is not external provenance.
+    externalGithubUrl(entry),
     entry.packageUrl,
     entry.repositoryUrl,
     entry.sourceUrl,

--- a/tests/artifacts-lib.test.ts
+++ b/tests/artifacts-lib.test.ts
@@ -583,6 +583,48 @@ describe("buildEntryTrustSignals", () => {
     ]);
   });
 
+  it("does not count self-referential githubUrl as a source", () => {
+    const entry = syntheticEntry("mcp", "self-link-only", {
+      repoUrl: "",
+      documentationUrl: "",
+      downloadUrl: "",
+      docsUrl: "",
+      packageUrl: "",
+      repositoryUrl: "",
+      sourceUrl: "",
+      websiteUrl: "",
+      sourceUrls: [],
+      retrievalSources: [],
+      githubUrl:
+        "https://github.com/JSONbored/awesome-claude/blob/main/content/mcp/self-link-only.mdx",
+    });
+    const signals = buildEntryTrustSignals(entry);
+    expect(signals.sourceStatus).toBe("missing");
+    expect(signals.sourceUrlCount).toBe(0);
+    expect(signals.sourceUrls).toEqual([]);
+  });
+
+  it("still counts a real external githubUrl as a source", () => {
+    const entry = syntheticEntry("mcp", "external-gh", {
+      repoUrl: "",
+      documentationUrl: "",
+      downloadUrl: "",
+      docsUrl: "",
+      packageUrl: "",
+      repositoryUrl: "",
+      sourceUrl: "",
+      websiteUrl: "",
+      sourceUrls: [],
+      retrievalSources: [],
+      githubUrl: "https://github.com/example/real-repo",
+    });
+    const signals = buildEntryTrustSignals(entry);
+    expect(signals.sourceStatus).toBe("available");
+    expect(signals.sourceUrls).toEqual([
+      "https://github.com/example/real-repo",
+    ]);
+  });
+
   it.each([
     [
       "downloadSha256",

--- a/tests/mcp-registry-trust-lib.test.ts
+++ b/tests/mcp-registry-trust-lib.test.ts
@@ -506,6 +506,18 @@ describe("registry-trust-lib sourceSummary", () => {
     ).toBe("https://github.com/fb/r");
   });
 
+  it("ignores self-referential githubUrl when falling back for repoUrl", () => {
+    expect(
+      sourceSummary(
+        makeEntry({
+          repoUrl: "",
+          githubUrl:
+            "https://github.com/JSONbored/awesome-claude/blob/main/content/mcp/x.mdx",
+        }),
+      ).repoUrl,
+    ).toBe("");
+  });
+
   it("treats non-numeric github stats as null", () => {
     expect(
       sourceSummary(makeEntry({ githubStars: "many", githubForks: undefined }))
@@ -862,6 +874,20 @@ describe("registry-trust-lib entryTrustRecommendations", () => {
         repoUrl: "",
         documentationUrl: "",
         githubUrl: "",
+      }),
+    );
+    expect(recs).toContain(
+      "Verify a canonical source before relying on this entry.",
+    );
+  });
+
+  it("recommends verifying source when only self-referential githubUrl is present", () => {
+    const recs = entryTrustRecommendations(
+      makeEntry({
+        repoUrl: "",
+        documentationUrl: "",
+        githubUrl:
+          "https://github.com/JSONbored/awesome-claude/blob/main/content/mcp/x.mdx",
       }),
     );
     expect(recs).toContain(


### PR DESCRIPTION
## Summary
- `sourceUrlsForEntry` now uses `externalGithubUrl` instead of raw `githubUrl`, so self-referential `github.com/JSONbored/awesome-claude` links yield `sourceStatus: missing`.
- MCP `sourceSummary` uses the same exclusion for the `repoUrl` fallback so `entryTrustRecommendations` still asks to verify a canonical source.
- External `githubUrl` values remain counted; no change for entries with real `repoUrl` / docs.

Closes #5580

## Test plan
- [x] `pnpm test -- artifacts-lib` (294 passed)
- [x] `pnpm test -- mcp-registry-trust-lib` (470 passed)
- [ ] `pnpm build`