### PR TITLE
fix(mcp): read docsUrl and sourceUrl in duplicate detection

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -834,11 +834,20 @@ function normalizeSubmissionUrlForMatch(value) {
 // `llmsUrl`/`apiUrl` stay in the list because a submitter who pastes the
 // HeyClaude canonical URL of an existing entry is still describing the same
 // resource and should be flagged as a duplicate.
+//
+// `docsUrl` and `sourceUrl` are separate top-level fields, not aliases folded
+// into `documentationUrl`/`repoUrl` (`content-builder-lib.js` sets each one
+// straight from frontmatter), so they have to be read explicitly (#5590).
+// Without them `collectSubmissionCandidateUrls` accepted a submitter's
+// `docsUrl` that this side never compared against, and the sibling
+// trust/source-status list `ENTRY_SOURCE_URL_FIELDS` already reads both.
 function collectEntrySourceUrls(entry) {
   const candidates = [
     entry.documentationUrl,
+    entry.docsUrl,
     entry.repoUrl,
     entry.githubUrl,
+    entry.sourceUrl,
     entry.websiteUrl,
     entry.downloadUrl,
     entry.url,

--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -368,6 +368,62 @@ describe("submissions-lib duplicate review", () => {
     expect(duplicates.matches[0].reasons).toContain("source_url");
   });
 
+  // Regression (#5590): `collectSubmissionCandidateUrls` accepts a submitter's
+  // `docsUrl`/`sourceUrl`, but `collectEntrySourceUrls` never read either field
+  // off the indexed entry, so these matches were silently missed. Both fixtures
+  // clear `documentationUrl`/`repoUrl` and vary the slug/title so the only path
+  // to a match is the field under test.
+  it("flags a duplicate matching only the indexed entry's docsUrl (#5590)", () => {
+    const entry = indexedEntry({
+      slug: "airtable-connector",
+      title: "Airtable Connector",
+      documentationUrl: undefined,
+      repoUrl: undefined,
+      docsUrl: "https://airtable-mcp.example.com/docs",
+    });
+    const duplicates = searchDuplicateEntries([entry], {
+      docsUrl: "https://airtable-mcp.example.com/docs",
+    });
+    expect(duplicates.count).toBe(1);
+    expect(duplicates.matches[0].reasons).toContain("source_url");
+  });
+
+  it("flags a duplicate matching only the indexed entry's sourceUrl (#5590)", () => {
+    const entry = indexedEntry({
+      slug: "airtable-connector",
+      title: "Airtable Connector",
+      documentationUrl: undefined,
+      repoUrl: undefined,
+      sourceUrl: "https://airtable-mcp.example.com/source",
+    });
+    const duplicates = searchDuplicateEntries([entry], {
+      sourceUrl: "https://airtable-mcp.example.com/source",
+    });
+    expect(duplicates.count).toBe(1);
+    expect(duplicates.matches[0].reasons).toContain("source_url");
+  });
+
+  it("does not flag unrelated docsUrl or sourceUrl values (#5590)", () => {
+    const entry = indexedEntry({
+      slug: "airtable-connector",
+      title: "Airtable Connector",
+      documentationUrl: undefined,
+      repoUrl: undefined,
+      docsUrl: "https://airtable-mcp.example.com/docs",
+      sourceUrl: "https://airtable-mcp.example.com/source",
+    });
+    expect(
+      searchDuplicateEntries([entry], {
+        docsUrl: "https://unrelated.example.com/docs",
+      }).count,
+    ).toBe(0);
+    expect(
+      searchDuplicateEntries([entry], {
+        sourceUrl: "https://unrelated.example.com/source",
+      }).count,
+    ).toBe(0);
+  });
+
   it("matches slug and title duplicates within a category", () => {
     expect(
       searchDuplicateEntries([indexedEntry()], {


### PR DESCRIPTION
## Summary

- Add `entry.docsUrl` and `entry.sourceUrl` to `collectEntrySourceUrls` in `packages/mcp/src/submissions-lib.js`, so `submission.duplicates` compares the same URL fields `collectSubmissionCandidateUrls` already accepts from submitters.
- Add regressions for a docsUrl-only and a sourceUrl-only match, plus a negative control proving unrelated URLs on those fields still do not match.

Closes #5590

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: `collectEntrySourceUrls` in `packages/mcp/src/submissions-lib.js` and its focused unit tests in `tests/mcp-submissions-lib.test.ts`. The affected MCP tool is `submission.duplicates`; no route, component, or endpoint changed.
- Root cause: the two halves of the duplicate comparison read different field lists. `collectSubmissionCandidateUrls` accepts `sourceUrl`, `githubUrl`, `docsUrl`, `downloadUrl`, `websiteUrl`, and the `sourceUrls` array from the submitter, but `collectEntrySourceUrls` built the entry-side set from `documentationUrl`, `repoUrl`, `githubUrl`, `websiteUrl`, `downloadUrl`, `url`, `canonicalUrl`, `llmsUrl`, `apiUrl` — omitting `docsUrl` and `sourceUrl`. A submitter offering a URL on either field therefore had nothing to match against.
- Why these are not already covered by `documentationUrl`/`repoUrl`: I verified they are independent top-level entry fields, not aliases. `packages/registry/src/content-builder-lib.js:295-296` sets `docsUrl: data.docsUrl ...` and `sourceUrl: data.sourceUrl ...` directly from frontmatter, so an entry can carry a `docsUrl` with no `documentationUrl` at all.
- Corroborating the asymmetry: the sibling list used for trust/source-status, `ENTRY_SOURCE_URL_FIELDS` in `packages/mcp/src/search-ranking-lib.js`, already includes both `docsUrl` and `sourceUrl`. This change brings duplicate detection in line with the list the rest of the package already treats as the entry's source URLs.
- Before/after: an indexed entry carrying only `docsUrl: "https://airtable-mcp.example.com/docs"` (no `documentationUrl`/`repoUrl`) previously returned `count: 0` for a submission offering that exact `docsUrl`. It now returns `count: 1` with `source_url` in `matches[0].reasons`. Same before/after for `sourceUrl`.
- Regression strength: both positive tests were confirmed red before the source change (`AssertionError: expected +0 to be 1`) and green after. Each fixture clears `documentationUrl`/`repoUrl` and varies slug and title, so the only available path to a match is the field under test — a slug/title match cannot mask the result. The third test is a negative control that passes both before and after, pinning that the wider comparison set did not make matching indiscriminate.
- Backward compatibility: strictly additive, no break. The change only adds two fields to the entry-side comparison set; nothing is removed or reordered, `collectSubmissionCandidateUrls` is untouched, normalization still runs through `normalizeSubmissionUrlForMatch`, and the `reasons` payload and return shape are unchanged. Entries without `docsUrl`/`sourceUrl` behave exactly as before. The only behavior change is that genuine duplicates on these two fields are now detected, which is the reported bug.
- Out of scope, as the issue specifies: `collectSubmissionCandidateUrls` (already correct) and every other duplicate-detection heuristic (slug, title, brand domain).
- No visual impact: no UI, markup, or styling changed. Accessibility: not applicable, no interactive UI changed.

## Validation

- [x] `pnpm test:mcp` — 72 passed.
- [x] `pnpm exec vitest run tests/mcp-submissions-lib.test.ts` — 42 passed.
- [x] `pnpm exec vitest run tests/mcp-http-route.test.ts tests/non-ui-branch-matrix.test.ts tests/submission-api.test.ts` — 88 passed, covering the MCP tool surface and submission API consumers.
- [x] `pnpm exec prettier --check` on both changed files — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed; no generated artifacts committed.

## Notes

- Linked issue: #5590.
- Scope is limited to the entry-side URL field list and its focused regressions.
