### PR TITLE
fix(registry): align buildSourceProvenance URL fields with MCP

### DIFF
--- a/packages/registry/src/quality-lib.js
+++ b/packages/registry/src/quality-lib.js
@@ -44,13 +44,25 @@ export function normalizeBodyForDuplicateCheck(entry) {
     .trim();
 }
 
+/**
+ * Canonical source-URL fields — keep in sync with
+ * `ENTRY_SOURCE_URL_FIELDS` in `packages/mcp/src/search-ranking-lib.js` so
+ * content-quality / source-health reports agree with MCP trust summaries.
+ */
+export const SOURCE_PROVENANCE_URL_FIELDS = Object.freeze([
+  "documentationUrl",
+  "docsUrl",
+  "repoUrl",
+  "githubUrl",
+  "sourceUrl",
+  "url",
+  "canonicalUrl",
+  "llmsUrl",
+  "apiUrl",
+]);
+
 export function buildSourceProvenance(entry) {
-  const sourceUrls = [
-    entry.documentationUrl,
-    entry.repoUrl,
-    entry.githubUrl,
-    entry.websiteUrl,
-  ]
+  const sourceUrls = SOURCE_PROVENANCE_URL_FIELDS.map((field) => entry[field])
     .map(clean)
     .filter(Boolean);
   const externalSourceUrls = sourceUrls.filter(

--- a/tests/quality-lib.test.ts
+++ b/tests/quality-lib.test.ts
@@ -5,6 +5,7 @@ import {
   SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
   SOURCE_HEALTH_RISK_CATEGORIES,
   SOURCE_FRESHNESS_THRESHOLDS,
+  SOURCE_PROVENANCE_URL_FIELDS,
   clean,
   clampScore,
   generatedAtForEntries,
@@ -24,6 +25,7 @@ import {
   buildSourceHealthReport,
   buildContentPromptReport,
 } from "../packages/registry/src/quality-lib.js";
+import { ENTRY_SOURCE_URL_FIELDS } from "../packages/mcp/src/search-ranking-lib.js";
 
 const REFERENCE = new Date("2026-06-01T00:00:00.000Z");
 
@@ -138,13 +140,34 @@ describe("buildSourceProvenance", () => {
   it("treats first-party directory urls as non-external", () => {
     const provenance = buildSourceProvenance({
       githubUrl: "https://github.com/JSONbored/awesome-claude/blob/main/x.md",
-      websiteUrl: "https://external.example",
+      sourceUrl: "https://external.example",
     });
     expect(provenance.hasExternalSource).toBe(true);
     expect(provenance.externalSourceUrls).toEqual(["https://external.example"]);
     expect(provenance.sourceUrls).toContain(
       "https://github.com/JSONbored/awesome-claude/blob/main/x.md",
     );
+  });
+
+  it("detects docsUrl and sourceUrl as external provenance", () => {
+    expect(
+      buildSourceProvenance({ docsUrl: "https://docs.example/guide" })
+        .hasExternalSource,
+    ).toBe(true);
+    expect(
+      buildSourceProvenance({ sourceUrl: "https://origin.example/src" })
+        .hasExternalSource,
+    ).toBe(true);
+    expect(
+      buildSourceProvenance({ docsUrl: "https://docs.example/guide" })
+        .sourceUrls,
+    ).toEqual(["https://docs.example/guide"]);
+  });
+
+  it("aligns SOURCE_PROVENANCE_URL_FIELDS with MCP ENTRY_SOURCE_URL_FIELDS", () => {
+    expect([...SOURCE_PROVENANCE_URL_FIELDS]).toEqual([
+      ...ENTRY_SOURCE_URL_FIELDS,
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- `buildSourceProvenance` now reads `SOURCE_PROVENANCE_URL_FIELDS`, kept identical to MCP `ENTRY_SOURCE_URL_FIELDS` (`documentationUrl`, `docsUrl`, `repoUrl`, `githubUrl`, `sourceUrl`, `url`, `canonicalUrl`, `llmsUrl`, `apiUrl`).
- Entries with only `docsUrl` or `sourceUrl` are no longer treated as source-free.
- Field-set alignment test locks the two lists together; prior repo/docs/github self-link tiers unchanged.

Closes #5581

## Test plan
- [x] `pnpm test -- quality-lib`
- [ ] `pnpm build`