### PR TITLE
fix(mcp): bound entry list size in compareEntries and reviewEntrySafety

### DIFF
--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -536,9 +536,15 @@ export async function getCopyableAsset(args = {}, options = {}) {
 }
 
 export async function compareEntries(args = {}, options = {}) {
+  const requested = Array.isArray(args.entries) ? args.entries : [];
+  // Schema validation already enforces 2-5 entries for the public tool path;
+  // this guard keeps the function safe for direct callers too.
+  if (requested.length < 2 || requested.length > 5) {
+    return invalid("Provide between 2 and 5 entries to compare.");
+  }
   const platform = normalizePlatform(args.platform);
   const entries = [];
-  for (const target of args.entries || []) {
+  for (const target of requested) {
     const category = normalizeText(target.category);
     const slug = normalizeText(target.slug);
     const entry = await readEntry(category, slug, options);
@@ -992,9 +998,15 @@ export async function explainEntryTrust(args = {}, options = {}) {
 }
 
 export async function reviewEntrySafety(args = {}, options = {}) {
+  const requested = Array.isArray(args.entries) ? args.entries : [];
+  // Schema validation already enforces 1-5 entries for the public tool path;
+  // this guard keeps the function safe for direct callers too.
+  if (requested.length < 1 || requested.length > 5) {
+    return invalid("Provide between 1 and 5 entries to review.");
+  }
   const platform = normalizePlatform(args.platform);
   const entries = [];
-  for (const target of args.entries || []) {
+  for (const target of requested) {
     const category = normalizeText(target.category);
     const slug = normalizeText(target.slug);
     const entry = await readEntry(category, slug, options);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -9,6 +9,7 @@ import * as registryModule from "../packages/mcp/src/registry.js";
 import * as schemaModule from "../packages/mcp/src/schemas.js";
 import {
   callRegistryTool,
+  compareEntries,
   compareEntryTrust,
   getClientSetup,
   getRegistryPrompt,
@@ -18,6 +19,7 @@ import {
   planWorkflowToolbox,
   READ_ONLY_TOOL_NAMES,
   readRegistryResource,
+  reviewEntrySafety,
   TOOL_DEFINITIONS,
 } from "../packages/mcp/src/registry.js";
 import {
@@ -1596,6 +1598,95 @@ describe("HeyClaude read-only MCP helpers", () => {
       ok: false,
       error: { code: "invalid_request" },
     });
+  });
+
+  // Regression (#5583): both functions are public exports of
+  // `@heyclaude/mcp/registry`, so a direct caller bypasses the Zod schema that
+  // guards only the MCP-protocol dispatch path. Without their own bounds check
+  // they silently returned a degenerate empty result or an unbounded one.
+  it("rejects direct compareEntries calls outside the 2-5 entry window", async () => {
+    const empty = await compareEntries({ entries: [] }, { dataDir });
+    expect(empty).toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
+    });
+
+    const tooFew = await compareEntries(
+      { entries: [{ category: skill.category, slug: skill.slug }] },
+      { dataDir },
+    );
+    expect(tooFew).toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
+    });
+
+    const tooMany = await compareEntries(
+      {
+        entries: Array.from({ length: 6 }, (_, index) => ({
+          category: skill.category,
+          slug: `placeholder-${index}`,
+        })),
+      },
+      { dataDir },
+    );
+    expect(tooMany).toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
+    });
+
+    const missingEntries = await compareEntries({}, { dataDir });
+    expect(missingEntries).toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
+    });
+  });
+
+  it("rejects direct reviewEntrySafety calls outside the 1-5 entry window", async () => {
+    const empty = await reviewEntrySafety({ entries: [] }, { dataDir });
+    expect(empty).toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
+    });
+
+    const tooMany = await reviewEntrySafety(
+      {
+        entries: Array.from({ length: 6 }, (_, index) => ({
+          category: skill.category,
+          slug: `placeholder-${index}`,
+        })),
+      },
+      { dataDir },
+    );
+    expect(tooMany).toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
+    });
+
+    const missingEntries = await reviewEntrySafety({}, { dataDir });
+    expect(missingEntries).toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
+    });
+  });
+
+  it("keeps in-range direct compareEntries and reviewEntrySafety calls working", async () => {
+    // Lower bound of each window: 2 for compare, 1 for safety.
+    const compared = await compareEntries(
+      {
+        entries: [
+          { category: skill.category, slug: skill.slug },
+          { category: otherSkill.category, slug: otherSkill.slug },
+        ],
+      },
+      { dataDir },
+    );
+    expect(compared).toMatchObject({ ok: true, count: 2 });
+
+    const reviewed = await reviewEntrySafety(
+      { entries: [{ category: skill.category, slug: skill.slug }] },
+      { dataDir },
+    );
+    expect(reviewed).toMatchObject({ ok: true, count: 1 });
   });
 
   it("returns not_found when an entry.coverage entry is missing", async () => {


### PR DESCRIPTION
## Summary

- Add the entry-count bounds guard that `compareEntryTrust` (`entry.coverage`) already has to `compareEntries` (`entry.compare`, 2-5) and `reviewEntrySafety` (`entry.safety`, 1-5) in `packages/mcp/src/registry-tool-orchestration-lib.js`.
- Add regressions for the empty, too-few, too-many, and missing-`entries` cases on both functions, plus an in-range control proving valid counts are untouched.
- Update three existing tests that encoded the pre-fix behavior (detail below).

Closes #5583

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed surface: `compareEntries` and `reviewEntrySafety` in `packages/mcp/src/registry-tool-orchestration-lib.js`, plus tests in `tests/mcp-server.test.ts`, `tests/mcp-registry-tool-orchestration-lib-g.test.ts`, and `tests/mcp-registry-tool-orchestration-lib-h.test.ts`. Affected MCP tools: `entry.compare` and `entry.safety`. No route, component, or endpoint changed.
- Invariant added: **entry-count bounds are now enforced for direct callers, not just MCP-protocol callers.** Both functions are public exports of `@heyclaude/mcp/registry`, so calling them directly bypasses the Zod schema that only guards the protocol dispatch path in `callRegistryTool`. That left each function's documented contract unenforced on the path most likely to be used programmatically.
- Before/after: `compareEntries({ entries: [] })` previously returned a degenerate `{ ok: true, count: 0 }` success, and a 6+ entry list ran unbounded. Both now return the standard `invalid(...)` envelope, `{ ok: false, error: { code: "invalid_request" } }`. Same before/after for `reviewEntrySafety` on empty and 6+ inputs.
- Bounds are taken from each tool's own documented contract and verified against the schemas rather than guessed: `CompareEntriesInputSchema` is `.min(2).max(5)` ("2–5 entries to compare") and `ReviewEntrySafetyInputSchema` is `.min(1).max(5)` ("Review 1-5 HeyClaude entries"). The guards mirror those exactly, so the direct-call path can never be **stricter** than the protocol path and no input the MCP schema accepts is newly rejected.
- Implementation matches the existing house pattern verbatim: same `Array.isArray(args.entries) ? args.entries : []` normalization, same `invalid(...)` return shape, and the same explanatory comment style `compareEntryTrust` already carries. The loop now iterates the normalized `requested` array instead of re-deriving `args.entries || []`.

### Existing tests updated (please review this part specifically)

Three pre-existing tests asserted the old behavior and were updated. Two of them asserted the bug itself, so changing them is the point of the fix, not a workaround:

| Test | Was | Now | Why |
|---|---|---|---|
| `-g` `compareEntries` "defaults to an empty entry list" | `expect((await compareEntries({})).ok).toBe(true)` | asserts `invalid_request` | This asserted precisely the degenerate `{ ok: true, count: 0 }` success #5583 reports. Renamed to "rejects an absent entry list". |
| `-h` `reviewEntrySafety` "defaults to an empty entry list" | same shape as above | asserts `invalid_request` | Same reason. |
| `-g` `compareEntries` "reports a missing compare target as not found" | passed **1** entry | passes **2** entries | Incidental: 1 entry now trips the minimum before the lookup runs. Widened so the test still exercises `not_found` rather than silently re-testing the new count guard. Its assertion is unchanged. |

No other call site needed changing — I checked every direct caller in the test suite. `tests/mcp-registry-tool-orchestration-lib-coverage.test.ts` already passes 2 entries, and `tests/non-ui-branch-matrix.test.ts` passes 2 to `compareEntries` and 1 to `reviewEntrySafety`, all in range.

- No behavior change for in-range inputs: the new in-range control exercises the lower bound of each window (2 entries for compare, 1 for safety) against real fixture entries and asserts `{ ok: true, count: 2 }` / `{ ok: true, count: 1 }`. The protocol-path `entry.compare`/`entry.safety` tests are unmodified and still pass.
- Regression strength: the two new bounds tests were confirmed red before the source change (`AssertionError: expected { ok: true, platform: '', …(4) } to match object { ok: false, …(1) }` — the degenerate success itself) and green after. The in-range control passes both before and after, which is what makes it a useful no-regression guard.
- Backward compatibility: the only inputs whose behavior changes are ones already outside the tools' published contract and unreachable through the MCP protocol, where the schema rejected them first. Response shape, `platform` normalization, `notFound` handling for missing entries, and the success payloads are all unchanged.
- Out of scope, as the issue specifies: `compareEntryTrust` (already correct), the public Zod schemas in `schemas-lib.js`, and every other MCP tool.
- No visual impact: no UI, markup, or styling changed. Accessibility: not applicable, no interactive UI changed.

## Validation

- [x] `pnpm exec vitest run` (full suite) — **39845 passed**. The 40 remaining failures across 14 files are pre-existing environment failures on my Windows checkout: I baselined the same 14 files on clean `upstream/main` and got an identical `14 failed / 40 failed tests`, so this branch contributes none of them. None are in the MCP orchestration surface.
- [x] `pnpm test:mcp` — passed.
- [x] `pnpm exec vitest run tests/mcp-registry-tool-orchestration-lib-{f,g,h,i,coverage}.test.ts tests/mcp-server.test.ts tests/non-ui-branch-matrix.test.ts` — 154 passed.
- [x] `pnpm exec prettier --check` on all changed files — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed; no generated artifacts committed.
- [x] Rebased onto latest `upstream/main` (includes #5622/#5623/#5624) and re-validated.

## Notes

- Linked issue: #5583.
- Correction to my first push: the initial revision of this PR failed the `coverage` check because I validated against a hand-picked subset of the orchestration suites and missed `-g`/`-h`, which contained the three tests above. Now fixed, and I have re-run the **full** suite with a clean-baseline comparison rather than a subset.
