### PR TITLE
fix(web): emit every tool in the /tools ItemList JSON-LD

### DIFF
--- a/apps/web/src/routes/tools.tsx
+++ b/apps/web/src/routes/tools.tsx
@@ -60,7 +60,10 @@ export const Route = createFileRoute("/tools")({
         { name: "Tools", path: "/tools" },
       ]),
       itemListScript(
-        COMMERCIAL_TOOLS.slice(0, 30).map((t) => ({
+        // Every tool the grid below renders, matching the other index routes
+        // that pass their full array. A truncated ItemList advertised fewer
+        // items to crawlers than the page actually shows (#5593).
+        COMMERCIAL_TOOLS.map((t) => ({
           name: t.name,
           path: `/entry/tools/${t.slug}`,
         })),

--- a/tests/seo-jsonld.test.ts
+++ b/tests/seo-jsonld.test.ts
@@ -18,6 +18,7 @@ import { buildEntryCitationFacts } from "@heyclaude/registry/llms";
 
 import { loadContentEntries, repoRoot } from "./helpers/registry-fixtures";
 import { ENTRIES } from "../apps/web/src/data/entries";
+import { COMMERCIAL_TOOLS } from "../apps/web/src/data/tools";
 
 describe("SEO JSON-LD policy", () => {
   const entries = loadContentEntries();
@@ -465,6 +466,56 @@ describe("entry page JSON-LD unification (#3926)", () => {
       ]) {
         expect(json, `${category} must omit ${banned}`).not.toContain(banned);
       }
+    }
+  });
+});
+
+describe("index route ItemList completeness (#5593)", () => {
+  const routeSource = (file: string) =>
+    fs.readFileSync(path.join(repoRoot, "apps/web/src/routes", file), "utf8");
+
+  it("builds the /tools ItemList from every rendered tool", () => {
+    const source = routeSource("tools.tsx");
+    // Drift guard: the JSON-LD must not re-introduce a cap that the visible
+    // grid does not apply. The grid maps COMMERCIAL_TOOLS directly.
+    expect(source).toContain("itemListScript(");
+    expect(source).not.toMatch(/COMMERCIAL_TOOLS\s*\.\s*slice\s*\(/);
+
+    // The emitted schema covers the whole array, so numberOfItems matches the
+    // number of cards the page renders rather than a truncated prefix.
+    const itemList = buildItemListJsonLd(
+      COMMERCIAL_TOOLS.map((tool) => ({
+        name: tool.name,
+        url: `https://heyclau.de/entry/tools/${tool.slug}`,
+      })),
+      { name: "Claude tools" },
+    );
+    expect(itemList.numberOfItems).toBe(COMMERCIAL_TOOLS.length);
+    expect(itemList.itemListElement).toHaveLength(COMMERCIAL_TOOLS.length);
+    // Guards the specific regression: the old cap stopped at 30.
+    expect(COMMERCIAL_TOOLS.length).toBeGreaterThan(30);
+    expect(itemList.itemListElement.at(-1)?.position).toBe(
+      COMMERCIAL_TOOLS.length,
+    );
+  });
+
+  it("passes the whole collection into itemListScript on sibling index routes", () => {
+    // /tools was the only index route truncating its ItemList. Assert on the
+    // itemListScript argument itself rather than the whole file — several of
+    // these routes legitimately slice elsewhere for UI previews.
+    const cases: Array<[string, string]> = [
+      ["best.index.tsx", "BEST_LISTS"],
+      ["compare.index.tsx", "COMPARISONS"],
+      ["contributors.index.tsx", "CONTRIBUTORS"],
+      ["integrations.index.tsx", "INTEGRATIONS"],
+    ];
+    for (const [file, collection] of cases) {
+      const source = routeSource(file);
+      expect(source, file).toContain("itemListScript(");
+      expect(source, file).toContain(`${collection}.map(`);
+      expect(source, file).not.toMatch(
+        new RegExp(`${collection}\\s*\\.\\s*slice\\s*\\(`),
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary

- Drop the `slice(0, 30)` from the `itemListScript()` call in `apps/web/src/routes/tools.tsx` so the `/tools` `ItemList` JSON-LD covers every tool the page renders.
- Add drift guards in `tests/seo-jsonld.test.ts` for the route itself and for the sibling index routes.

Closes #5593

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed route: `/tools` (`apps/web/src/routes/tools.tsx`), the `itemListScript()` argument inside `head()` only. Plus focused tests in `tests/seo-jsonld.test.ts`.
- Expected behavior: the `/tools` `ItemList` script now emits `numberOfItems` equal to `COMMERCIAL_TOOLS.length` with one `ListItem` per rendered card, instead of stopping at 30. Crawlers see the same set of items the page shows.
- Root cause: `head()` built the schema from `COMMERCIAL_TOOLS.slice(0, 30)` while the grid maps `COMMERCIAL_TOOLS` in full, so structured data under-reported the page contents.
- Convention check, verified rather than assumed: I inspected every index route calling `itemListScript()` — `best.index.tsx`, `compare.index.tsx`, `contributors.index.tsx`, `integrations.index.tsx`, `jobs.index.tsx`, `platforms.tsx`. All six pass their complete arrays. `/tools` was the only truncating one, exactly as the issue states.
- Regression strength: the route guard was confirmed red before the change (`AssertionError: expected 'import { createFileRoute, Link } from…' not to match /COMMERCIAL_TOOLS\s*\.\s*slice\s*\(/`) and green after. It also asserts `COMMERCIAL_TOOLS.length > 30`, so the test would be meaningless-but-passing only if the catalog ever shrank below the old cap — that assertion makes such a case fail loudly instead.
- On the sibling guard: my first version asserted no `.slice(0, N)` anywhere in each sibling route file, which **failed** — `best.index.tsx` and `compare.index.tsx` legitimately slice for a 3-item preview and an 8-result search list. That was my assertion being wrong, not the routes. I narrowed it to the specific collection each route feeds into `itemListScript()` (`BEST_LISTS`, `COMPARISONS`, `CONTRIBUTORS`, `INTEGRATIONS`), which is the property that actually matters and does not fight legitimate UI slicing.
- Important invariants: the visible grid is untouched (it already rendered all tools). `breadcrumbScript`, meta tags, canonical link, and OG/Twitter image are unchanged. `buildItemListJsonLd` already derives `numberOfItems` from `items.length`, so no helper change was needed.
- Backward compatibility: no API or data-shape change. The only difference is a longer, more complete `ItemList` payload in the page head.
- Payload-size note for reviewers: this grows the inlined `/tools` JSON-LD from 30 to all `COMMERCIAL_TOOLS` entries (~205 today), each a small `ListItem` with `position`, `url`, `name`. That is the same shape and order of magnitude the sibling index routes already ship, and completeness is the point of the fix — flagging it explicitly so the tradeoff is a conscious maintainer call rather than a surprise.
- No visual impact: structured data only. No markup, styling, or layout changed, and the rendered grid is identical. Accessibility: not applicable, no interactive UI changed.
- Out of scope, as the issue specifies: the visible tools grid, other routes' JSON-LD usage, and generated content artifacts.

## Validation

- [x] `pnpm exec vitest run tests/seo-jsonld.test.ts` — 17 passed.
- [x] `pnpm --filter web type-check` — passed (`tsc --noEmit`, no errors).
- [x] `pnpm exec vitest run` (**full** suite) — 39849 passed. The 14 remaining failing files are pre-existing environment failures on my Windows checkout; I baselined that same 14-file set on clean `upstream/main` and reproduced them there, so this branch contributes none. `tests/seo-jsonld.test.ts` is not among them.
- [x] `pnpm exec prettier --check` on both changed files — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed.
- [x] No generated artifacts committed: `pnpm --filter web type-check` regenerates `apps/web/public/data/**` as a side effect, so I re-checked `git status` afterwards — only the two intended files are modified.
- [x] Rebased onto latest `upstream/main` (through #5626) immediately before opening.

## Notes

- Linked issue: #5593.
- Scope is limited to the single `itemListScript()` argument and its focused regressions.
