### PR TITLE
feat(web): emit FAQPage JSON-LD on category hub pages

### DIFF
--- a/apps/web/src/lib/faq-page-jsonld-lib.ts
+++ b/apps/web/src/lib/faq-page-jsonld-lib.ts
@@ -1,0 +1,30 @@
+// Pure builder for schema.org FAQPage JSON-LD from the same { q, a } pairs a
+// page already renders, split out so route head() functions share one tested
+// implementation instead of open-coding the Question/Answer nesting.
+
+export type FaqPair = {
+  q: string;
+  a: string;
+};
+
+/**
+ * schema.org FAQPage JSON-LD. Only pairs with both a question and an answer are
+ * emitted: a Question with an empty acceptedAnswer is invalid structured data,
+ * and rich results must never claim content the page does not actually show.
+ */
+export function faqPageJsonLd(faqs: FaqPair[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs
+      .filter((faq) => faq.q?.trim() && faq.a?.trim())
+      .map((faq) => ({
+        "@type": "Question",
+        name: faq.q,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: faq.a,
+        },
+      })),
+  };
+}

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -32,6 +32,7 @@ import {
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { categoryItemListJsonLd } from "@/lib/category-itemlist-jsonld-lib";
+import { faqPageJsonLd } from "@/lib/faq-page-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, categoryAccent } from "@/lib/og-image";
 import { ogImageMetaTags } from "@/lib/og-meta-lib";
@@ -71,6 +72,9 @@ export const Route = createFileRoute("/$category")({
       { name: "Directory", item: absoluteUrl("/browse") },
       { name: label, item: url },
     ]);
+    // Same faqFor(id, label) data the component renders below, so the schema
+    // and the visible <dl> can never disagree.
+    const faqPage = faqPageJsonLd(faqFor(id, label));
 
     return {
       meta: [
@@ -93,6 +97,7 @@ export const Route = createFileRoute("/$category")({
       scripts: [
         { type: "application/ld+json", children: stringifyJsonLd(itemList) },
         { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+        { type: "application/ld+json", children: stringifyJsonLd(faqPage) },
       ],
     };
   },

--- a/tests/faq-page-jsonld-lib.test.ts
+++ b/tests/faq-page-jsonld-lib.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { faqPageJsonLd } from "../apps/web/src/lib/faq-page-jsonld-lib";
+import { faqFor } from "../apps/web/src/lib/category-faq-lib";
+import { categoryLabels } from "../apps/web/src/lib/site";
+import { CATEGORIES } from "../apps/web/src/types/registry";
+import { repoRoot } from "./helpers/registry-fixtures";
+
+describe("faqPageJsonLd", () => {
+  it("builds a FAQPage with one Question per pair, in order", () => {
+    const ld = faqPageJsonLd([
+      { q: "What is this?", a: "A directory." },
+      { q: "How do I use it?", a: "Open an entry." },
+    ]);
+    expect(ld["@context"]).toBe("https://schema.org");
+    expect(ld["@type"]).toBe("FAQPage");
+    expect(ld.mainEntity).toEqual([
+      {
+        "@type": "Question",
+        name: "What is this?",
+        acceptedAnswer: { "@type": "Answer", text: "A directory." },
+      },
+      {
+        "@type": "Question",
+        name: "How do I use it?",
+        acceptedAnswer: { "@type": "Answer", text: "Open an entry." },
+      },
+    ]);
+  });
+
+  it("returns an empty mainEntity for no pairs", () => {
+    expect(faqPageJsonLd([]).mainEntity).toEqual([]);
+  });
+
+  it("drops pairs missing a question or an answer", () => {
+    // A Question with an empty acceptedAnswer is invalid structured data, so
+    // these are omitted rather than emitted with blank text.
+    const ld = faqPageJsonLd([
+      { q: "Kept?", a: "Yes." },
+      { q: "", a: "Orphan answer." },
+      { q: "Orphan question?", a: "" },
+      { q: "   ", a: "   " },
+    ]);
+    expect(ld.mainEntity).toHaveLength(1);
+    expect(ld.mainEntity[0].name).toBe("Kept?");
+  });
+});
+
+describe("/$category FAQPage JSON-LD (#5594)", () => {
+  const routeSource = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/$category.tsx"),
+    "utf8",
+  );
+
+  it("emits a FAQPage script from the shared builder in head()", () => {
+    expect(routeSource).toContain("faqPageJsonLd");
+    expect(routeSource).toContain('from "@/lib/faq-page-jsonld-lib"');
+    // Built from the same helper the visible <dl> renders, not a second copy.
+    expect(routeSource).toContain("faqPageJsonLd(faqFor(id, label))");
+    // Drift guard: the pre-existing ItemList/BreadcrumbList scripts stay.
+    expect(routeSource).toContain("categoryItemListJsonLd");
+    expect(routeSource).toContain("breadcrumbListJsonLd");
+  });
+
+  it("matches the rendered FAQ block for every category hub", () => {
+    expect(CATEGORIES.length).toBeGreaterThan(0);
+    for (const category of CATEGORIES) {
+      const id = category.id;
+      const label = categoryLabels[id] ?? id;
+      const faqs = faqFor(id, label);
+      const ld = faqPageJsonLd(faqs);
+
+      expect(ld["@type"], id).toBe("FAQPage");
+      // Every rendered question is present, with its exact answer text.
+      expect(ld.mainEntity, id).toHaveLength(faqs.length);
+      expect(
+        ld.mainEntity.map((entity) => entity.name),
+        id,
+      ).toEqual(faqs.map((faq) => faq.q));
+      expect(
+        ld.mainEntity.map((entity) => entity.acceptedAnswer.text),
+        id,
+      ).toEqual(faqs.map((faq) => faq.a));
+      // No empty questions or answers reach the schema.
+      for (const entity of ld.mainEntity) {
+        expect(entity.name.trim(), id).not.toBe("");
+        expect(entity.acceptedAnswer.text.trim(), id).not.toBe("");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `apps/web/src/lib/faq-page-jsonld-lib.ts`, a pure `FAQPage` builder following the repo's existing one-builder-per-schema pattern.
- Wire it into `apps/web/src/routes/$category.tsx`'s `head()` using the same `faqFor(id, label)` call the component already renders.
- Add unit tests for the builder plus a per-category check that the schema matches the rendered FAQ block exactly.

Closes #5594

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] `No visual impact` is included below.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed route: `/$category` (all ~9 category hub pages) — `head()` only. New module: `apps/web/src/lib/faq-page-jsonld-lib.ts`. New tests: `tests/faq-page-jsonld-lib.test.ts`. No component, endpoint, or MCP tool changed.
- Expected behavior: each `/$category` page now emits a third `application/ld+json` script containing a valid `FAQPage` whose `mainEntity` is one `Question`/`acceptedAnswer` pair per rendered FAQ item, making the hubs eligible for FAQ rich results for content they already display.
- Why a new lib rather than inline schema: `apps/web/src/lib/` already holds `breadcrumb-jsonld-lib.ts`, `category-itemlist-jsonld-lib.ts`, `entry-itemlist-jsonld-lib.ts`, and several siblings — one small pure builder per schema type, each with its own focused test. I followed that convention exactly rather than open-coding the `Question`/`Answer` nesting in the route, which also keeps the logic unit-testable (route `.tsx` files are outside the node suite's coverage scope; `lib/**` `.ts` is inside it).
- Drift safety, the main correctness risk: the schema is built from `faqPageJsonLd(faqFor(id, label))` — the *same* helper call whose output the component maps into the visible `<dl>`. There is no second copy of the question set to fall out of sync. The test asserts this per category, comparing `mainEntity` names/answers against `faqFor()` output for every entry in `CATEGORIES`, so a future edit to `faqFor()` cannot silently desync the schema from the page.
- Deliberate behavior detail: pairs missing a question or an answer are filtered out. A `Question` with an empty `acceptedAnswer` is invalid structured data, and emitting blank text would advertise content the page does not show. `faqFor()` always returns three populated pairs today, so this is defensive and changes nothing in practice — it is covered by its own test rather than left implicit.
- Important invariants: the existing `ItemList` (`categoryItemListJsonLd`) and `BreadcrumbList` (`breadcrumbListJsonLd`) scripts are untouched and still emitted, in the same order, with the new script appended third. The test asserts both remain present so this change cannot quietly displace them. Meta tags, canonical, RSS `alternate` link, and OG image are unchanged.
- Backward compatibility: purely additive — one extra JSON-LD script tag. No data shape, API, or route contract changed.
- Out of scope, as the issue specifies: the visible FAQ content and `faqFor()`'s question/answer data are unchanged, the other JSON-LD types on this route stay as-is, and no FAQ sections were added to other route types.
- No visual impact: structured data only. No markup, styling, or layout changed. Accessibility: not applicable, no interactive UI changed.

## Validation

- [x] `pnpm exec vitest run tests/faq-page-jsonld-lib.test.ts tests/category-faq-lib.test.ts tests/seo-jsonld.test.ts` — 25 passed.
- [x] `pnpm --filter web type-check` — passed (`tsc --noEmit`, no errors).
- [x] `pnpm exec vitest run` (**full** suite) — 39854 passed. The 14 remaining failing files are pre-existing environment failures on my Windows checkout; I baselined that same 14-file set on clean `upstream/main` and reproduced them there, so this branch contributes none.
- [x] `pnpm exec prettier --check` on all three changed/added files — passed.
- [x] `pnpm build` — passed.
- [x] `git diff --check` — passed.
- [x] No generated artifacts committed: `pnpm --filter web type-check` regenerates `apps/web/public/data/**` as a side effect, so I re-checked `git status` afterwards — only the three intended files appear.
- [x] Rebased onto latest `upstream/main` (through #5628) and re-ran the focused tests, prettier, and build after rebasing.

## Notes

- Linked issue: #5594.
- Scope is limited to the new builder, its wiring in `head()`, and focused tests.
