### PR TITLE
fix(mcp): declare recommendForTask in registry.d.ts

### DIFF
--- a/packages/mcp/src/registry.d.ts
+++ b/packages/mcp/src/registry.d.ts
@@ -41,6 +41,11 @@ export function planWorkflowToolbox(
   options?: RegistryArtifactLoaders,
 ): Promise<RegistryToolResult>;
 
+export function recommendForTask(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
 export function getServerInfo(
   args?: Record<string, unknown>,
   options?: RegistryArtifactLoaders,


### PR DESCRIPTION
## Summary

- `recommendForTask` is a live runtime export backing the `registry.recommend` MCP tool — defined in `packages/mcp/src/registry-tool-orchestration-lib.js` and re-exported from `packages/mcp/src/registry.js` alongside its 34 sibling tool functions — but `registry.d.ts` never declared it, so TypeScript consumers of `@heyclaude/mcp` lose type information for exactly this one tool (a `TS2305` missing-export error under `nodenext` resolution).
- Added the sibling-shaped declaration (`args?: Record<string, unknown>, options?: RegistryArtifactLoaders) => Promise<RegistryToolResult>` — identical to `searchRegistry`/`planWorkflowToolbox`/etc.) positioned right after `planWorkflowToolbox`, matching the live tool order (`registry.plan` → `registry.recommend` → `registry.info`). The file already declared `RecommendForTaskInputSchema`; the function declaration now matches.
- 1 file, +5/−0. No runtime change; no other declaration touched (issue's out-of-scope honored).

Closes #5644

## Quality Evidence

- **Invariant added**: every function `registry.js` re-exports now has a `registry.d.ts` declaration — `recommendForTask` was the single missing one of the 35.
- **RED → GREEN proof (typed consumer)**: `tsc --noEmit --strict --module nodenext --moduleResolution nodenext` over `import { recommendForTask } from ".../registry.js"` fails pre-fix with `error TS2305: Module '.../registry.js' has no exported member 'recommendForTask'` and exits 0 post-fix with the declared `Promise<RegistryToolResult>` type flowing through.
- **Signature matches runtime**: `registry-tool-orchestration-lib.js` defines `export async function recommendForTask(args = {}, options = {})` reading `args.task/category/platform/limit` and artifact loaders from `options` — exactly the loose-args + `RegistryArtifactLoaders` shape every sibling declaration uses.
- No visual impact — `.d.ts`-only diff, zero rendered output, zero executable lines (codecov N/A, same as merged #5495).

## Validation

- [x] `pnpm build` — pass (issue's listed set; type-check step clean)
- [x] `pnpm test:mcp` — 2 files / 72 tests pass (issue's listed set)
- [x] `git diff --check` — clean (issue's listed set)
- [x] `pnpm type-check` — clean
- [x] `pnpm validate:mcp-package` — `Validated packed @heyclaude/mcp@0.14.3`
- [x] `pnpm test` — full suite, 774 files / 39944 tests pass
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check packages/mcp/src/registry.d.ts` — clean
