### PR TITLE
fix(mcp): declare createTimeoutFetch in remote-proxy.d.ts

### DIFF
--- a/packages/mcp/src/remote-proxy.d.ts
+++ b/packages/mcp/src/remote-proxy.d.ts
@@ -34,6 +34,8 @@ export function createRemoteMcpProxyServerFromClient(
   timeoutMs: number;
 }>;
 
+export function createTimeoutFetch(timeoutMs: number | string): typeof fetch;
+
 export function runRemoteStdioProxy(
   options?: RemoteProxyOptions,
 ): Promise<void>;


### PR DESCRIPTION
## Summary

- `createTimeoutFetch` is one of the 4 runtime exports of `@heyclaude/mcp/remote-proxy` (defined in `packages/mcp/src/remote-proxy-lib.js`, used internally as the proxy transport's `fetch:` option), but `packages/mcp/src/remote-proxy.d.ts` declared only the other 3 (`createRemoteMcpProxyServer`, `createRemoteMcpProxyServerFromClient`, `runRemoteStdioProxy`) — TypeScript consumers got a missing-export error for it.
- Declared it as `createTimeoutFetch(timeoutMs: number | string): typeof fetch` — the issue's sanctioned signature: the runtime returns an `async (url, init) => Response` wrapper (fetch-compatible: `AbortController` timeout + input-signal chaining + `redirect: "error"`), and the `number | string` union matches the existing `RemoteProxyOptions.timeoutMs` type in the same file. Placed in the runtime barrel's alphabetical position (between `createRemoteMcpProxyServerFromClient` and `runRemoteStdioProxy`).
- 1 file, +2/−0. No runtime change; no other declaration touched.

Closes #5646

## Quality Evidence

- **Invariant added**: all 4 exports of the `remote-proxy.js` barrel now have declarations — `createTimeoutFetch` was the only one missing.
- **RED → GREEN proof (typed consumer)**: `tsc --noEmit --strict --module nodenext --moduleResolution nodenext` over `import { createTimeoutFetch } from ".../remote-proxy.js"; const f: typeof fetch = createTimeoutFetch(5000);` fails pre-fix with `error TS2305: ... has no exported member 'createTimeoutFetch'` and exits 0 post-fix (the `typeof fetch` assignment type-checks, confirming the declared shape is usable exactly where the runtime uses it — `fetch: createTimeoutFetch(timeoutMs)`).
- No visual impact — `.d.ts`-only diff, zero rendered output, zero executable lines (codecov N/A).

## Validation

- [x] `pnpm build` — pass (issue's listed set; type-check step clean)
- [x] `pnpm test:mcp` — 2 files / 72 tests pass (issue's listed set)
- [x] `git diff --check` — clean (issue's listed set)
- [x] `pnpm type-check` — clean
- [x] `pnpm validate:mcp-package` — `Validated packed @heyclaude/mcp@0.14.3`
- [x] `pnpm test` — full suite, 774 files / 39944 tests pass
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check packages/mcp/src/remote-proxy.d.ts` — clean
