### PR TITLE
fix(registry): declare all 17 content-builder exports in content-builder.d.ts

### DIFF
--- a/packages/registry/src/content-builder.d.ts
+++ b/packages/registry/src/content-builder.d.ts
@@ -1,4 +1,4 @@
-import type { ContentEntry } from "./index.js";
+import type { ContentEntry, SkillPlatformCompatibility } from "./index.js";
 
 export const DEFAULT_DIRECTORY_REPO_URL: string;
 export function buildGitHubUrl(filePath: string, repoRoot: string): string;
@@ -10,12 +10,43 @@ export function parseGitHubRepo(repoUrl?: string | null): {
 } | null;
 export function normalizeDownloadUrl(downloadUrl?: string | null): string;
 export function normalizeDateAdded(value: unknown): string | undefined;
+export function normalizeTextField(value: unknown): string | undefined;
+export function normalizeStringList(value: unknown): string[] | undefined;
+export function normalizeDateTimeField(value: unknown): string | undefined;
+export function normalizePositiveInteger(value: unknown): number | undefined;
+export function normalizeClaimStatus(
+  value: unknown,
+): "unclaimed" | "pending" | "verified" | undefined;
+export function buildProvenanceFields(data?: Record<string, unknown>): {
+  submittedBy: string | undefined;
+  submittedByUrl: string | undefined;
+  submittedAt: string | undefined;
+  sourceSubmissionNumber: number | undefined;
+  sourceSubmissionUrl: string | undefined;
+  importPrNumber: number | undefined;
+  importPrUrl: string | undefined;
+  reviewedBy: string | undefined;
+  reviewedAt: string | undefined;
+  claimStatus: "unclaimed" | "pending" | "verified" | undefined;
+  claimedBy: string | undefined;
+  claimedByUrl: string | undefined;
+  claimedAt: string | undefined;
+};
 export function isFirstPartyPackage(data?: Record<string, unknown>): boolean;
 export function isLocalDownloadUrl(downloadUrl?: string | null): boolean;
 export function localDownloadSourcePath(
   downloadUrl: string,
   contentRoot: string,
 ): string | null;
+export function buildDefaultSkillPlatformCompatibility(
+  data: Record<string, unknown>,
+  inferred: Record<string, unknown>,
+): SkillPlatformCompatibility[];
+export function normalizePlatformCompatibility(
+  value: unknown,
+  data: Record<string, unknown>,
+  inferred: Record<string, unknown>,
+): SkillPlatformCompatibility[];
 export function buildContentEntryFromMdx(params: {
   category: string;
   fileName: string;


### PR DESCRIPTION
## Summary

- `packages/registry/src/content-builder.js` re-exports **17** named symbols from `content-builder-lib.js`, but `content-builder.d.ts` declared only **9** — TypeScript consumers of `@heyclaude/registry/content-builder` got missing-export errors (or no checking) for the other 8 live runtime exports.
- Declared the missing 8, in the runtime barrel's order, mirroring each function's actual semantics:
  - `normalizeTextField(value: unknown): string | undefined`
  - `normalizeStringList(value: unknown): string[] | undefined`
  - `normalizeDateTimeField(value: unknown): string | undefined`
  - `normalizePositiveInteger(value: unknown): number | undefined`
  - `normalizeClaimStatus(value: unknown): "unclaimed" | "pending" | "verified" | undefined` (the exact literal set the runtime allowlists)
  - `buildProvenanceFields(data?: Record<string, unknown>)` → the 13 normalized provenance fields, each typed to its normalizer's return
  - `buildDefaultSkillPlatformCompatibility(data, inferred): SkillPlatformCompatibility[]`
  - `normalizePlatformCompatibility(value, data, inferred): SkillPlatformCompatibility[]`
- The two compatibility builders reuse the existing `SkillPlatformCompatibility` type from `index.d.ts`, which matches the runtime row shape exactly (`platform`/`supportLevel`/`installPath`/`adapterPath?`/`verifiedAt?`) — no new type invented.
- 1 file, +32/−1 (the −1/+1 is widening the existing type-only import to also pull `SkillPlatformCompatibility`). No runtime change; no new exports added (out-of-scope honored).

Closes #5642

## Quality Evidence

- **Invariant added**: `content-builder.d.ts` now declares a type for every symbol `content-builder.js` re-exports — 17/17 (was 9/17).
- **RED → GREEN proof (typed consumer)**: `tsc --noEmit --strict --module nodenext --moduleResolution nodenext` over an import of all 8 missing symbols fails pre-fix with `error TS2305` per symbol (`'has no exported member 'normalizeTextField'`, `'normalizeStringList'`, …) and exits 0 post-fix with each annotated return type checking against the declared shapes.
- No visual impact — `.d.ts`-only diff, zero rendered output, zero executable lines (codecov N/A).

## Validation

- [x] `pnpm build` — pass (issue's listed set; type-check step clean)
- [x] `git diff --check` — clean (issue's listed set)
- [x] `pnpm type-check` — clean
- [x] `pnpm validate:content:strict` — pass (this path triggers the content lane in CI; verified green locally)
- [x] `pnpm validate:packages` — pass
- [x] `pnpm test` — full suite, 774 files / 39944 tests pass
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check packages/registry/src/content-builder.d.ts` — clean
