### PR TITLE
fix(web): emit BreadcrumbList JSON-LD on /brief/$number

### DIFF
--- a/apps/web/src/routes/brief.$number.tsx
+++ b/apps/web/src/routes/brief.$number.tsx
@@ -10,6 +10,7 @@ import {
   briefIssueHubDestination,
 } from "@/lib/brief-entry-cta-events";
 import { parseBriefNumber } from "@/lib/brief-number-parse-lib";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 
 const loadBriefIssue = createServerFn({ method: "GET" })
@@ -57,6 +58,12 @@ export const Route = createFileRoute("/brief/$number")({
         { property: "og:type", content: "article" },
       ],
       links: [{ rel: "canonical", href: url }],
+      scripts: [
+        breadcrumbScript([
+          { name: "Weekly Brief", path: "/brief" },
+          { name: `Issue #${loaderData.number}`, path: `/brief/${loaderData.number}` },
+        ]),
+      ],
     };
   },
   component: BriefIssuePage,

--- a/tests/brief-breadcrumb-jsonld.test.ts
+++ b/tests/brief-breadcrumb-jsonld.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { buildBreadcrumbJsonLd } from "@heyclaude/registry/seo";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// /brief/$number renders a visible Breadcrumbs trail (Weekly Brief / Issue #N)
+// but head() emitted no JSON-LD at all, unlike every sibling detail route that
+// pairs its breadcrumb UI with BreadcrumbList structured data. Routes are not
+// importable in the node suite, so pin the corrected head() at the source
+// level, the same way state-report-dataset-distribution.test.ts pins #5455.
+describe("/brief/$number BreadcrumbList JSON-LD (#5633)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/brief.$number.tsx"),
+    "utf8",
+  );
+
+  it("emits a breadcrumbScript from head()", () => {
+    expect(source).toContain(
+      'import { breadcrumbScript } from "@/lib/seo-jsonld";',
+    );
+    expect(source).toContain("scripts: [");
+    expect(source).toContain('{ name: "Weekly Brief", path: "/brief" }');
+    expect(source).toContain(
+      "{ name: `Issue #${loaderData.number}`, path: `/brief/${loaderData.number}` }",
+    );
+  });
+
+  it("matches the labels of the visible breadcrumb trail", () => {
+    expect(source).toContain('label: "Weekly Brief"');
+    expect(source).toContain("label: `Issue #${issue.number}`");
+  });
+
+  it("builds a valid BreadcrumbList shape for a sample issue trail", () => {
+    const breadcrumb = buildBreadcrumbJsonLd([
+      { name: "Weekly Brief", url: "https://heyclau.de/brief" },
+      { name: "Issue #7", url: "https://heyclau.de/brief/7" },
+    ]);
+    expect(breadcrumb["@type"]).toBe("BreadcrumbList");
+    expect(breadcrumb.itemListElement).toHaveLength(2);
+    expect(breadcrumb.itemListElement[0]).toMatchObject({
+      "@type": "ListItem",
+      position: 1,
+      name: "Weekly Brief",
+      item: "https://heyclau.de/brief",
+    });
+    expect(breadcrumb.itemListElement[1]).toMatchObject({
+      "@type": "ListItem",
+      position: 2,
+      name: "Issue #7",
+      item: "https://heyclau.de/brief/7",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `/brief/$number` renders a visible `<Breadcrumbs>` trail (Weekly Brief / Issue #N) but its `head()` returned only `meta` and `links` — no `scripts` field at all — making Weekly Brief issue pages the only detail routes with zero structured data, while every sibling detail route (`jobs.$slug`, `tags.$tag`, `contributors.$slug`, `compare.$slug`, `integrations.$slug`, `for.$platform`, `for.$platform.$category`) pairs its breadcrumb UI with `BreadcrumbList` JSON-LD.
- `head()` now emits a `breadcrumbScript` with the same hub + current-issue crumbs the page renders — `{ name: "Weekly Brief", path: "/brief" }` and `` { name: `Issue #${loaderData.number}`, path: `/brief/${loaderData.number}` } `` — following the `jobs.$slug.tsx` convention exactly (hub crumb + current page, no Home crumb, matching every sibling's JSON-LD shape).
- Richer `Article`/`NewsArticle` schema is deliberately **not** added, per the issue's scope note ("if unsure, ship breadcrumbs only"): the periodical nature of briefs (issue numbers, send dates, evolving payload shape) makes that a real design decision worth its own issue rather than a drive-by addition.
- 2 files, +63/−0: the route (+7) and a new regression test.

Closes #5633

## Quality Evidence

- **Rendered JSON-LD for a sample brief page** (issue's evidence requirement) — served from the built worker (`wrangler dev`, local D1 migrated + seeded with an approved issue #1), `/brief/1` after the fix emits, alongside the existing sitewide `Organization`/`WebSite` blocks:

  ```json
  {
    "@context": "https://schema.org",
    "@type": "BreadcrumbList",
    "@id": "https://heyclau.de/brief/1#breadcrumb",
    "itemListElement": [
      {
        "@type": "ListItem",
        "position": 1,
        "name": "Weekly Brief",
        "item": "https://heyclau.de/brief"
      },
      {
        "@type": "ListItem",
        "position": 2,
        "name": "Issue #1",
        "item": "https://heyclau.de/brief/1"
      }
    ]
  }
  ```

  Before the fix the same page emits only 2 ld+json blocks (`Organization`, `WebSite`) — no `BreadcrumbList` (verified on a stock-main build of the same base commit). The two crumbs match the visible trail's labels and targets exactly (`label: "Weekly Brief"` → `/brief`, `` label: `Issue #${issue.number}` ``).
- **Regression test proven RED**: the new `tests/brief-breadcrumb-jsonld.test.ts` pins the corrected `head()` at the source level (same pattern as `tests/state-report-dataset-distribution.test.ts`) and validates the `BreadcrumbList` shape through the same `buildBreadcrumbJsonLd` builder `breadcrumbScript` uses. On pre-fix code the head()-wiring test fails (1/3); all 3 pass after.
- **No change to visible content**: JSON-LD renders zero pixels; the matrices below are visually identical by design. Meta/OG tags, canonical link, and the rendered page are untouched.

### Screenshot evidence

Full viewport × theme matrix for `/brief/1` (local worker, migrated + seeded D1). The change is JSON-LD-only, so before/after pairs are visually identical by design.

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | <img width="360" alt="before desktop light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/before-desktop-light.png"> | <img width="360" alt="after desktop light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/after-desktop-light.png"> |
| Desktop · Dark | <img width="360" alt="before desktop dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/before-desktop-dark.png"> | <img width="360" alt="after desktop dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/after-desktop-dark.png"> |
| Tablet · Light | <img width="360" alt="before tablet light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/before-tablet-light.png"> | <img width="360" alt="after tablet light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/after-tablet-light.png"> |
| Tablet · Dark | <img width="360" alt="before tablet dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/before-tablet-dark.png"> | <img width="360" alt="after tablet dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/after-tablet-dark.png"> |
| Mobile · Light | <img width="360" alt="before mobile light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/before-mobile-light.png"> | <img width="360" alt="after mobile light" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/after-mobile-light.png"> |
| Mobile · Dark | <img width="360" alt="before mobile dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/before-mobile-dark.png"> | <img width="360" alt="after mobile dark" src="https://raw.githubusercontent.com/rsnetworkinginc/awesome-claude/pr-assets-5633-brief-breadcrumb/shots/after-mobile-dark.png"> |

## Validation

- [x] `pnpm build` — pass (issue's listed set)
- [x] `git diff --check` — clean (issue's listed set)
- [x] `pnpm exec vitest run tests/brief-breadcrumb-jsonld.test.ts` — 3/3 pass (1 fails on pre-fix code)
- [x] `pnpm test` — full suite, 775 files / 39947 tests pass
- [x] `pnpm type-check` — clean
- [x] `pnpm validate:clean` / `pnpm validate:tasks` — pass
- [x] `pnpm exec prettier --check` on changed files — clean
