### PR TITLE
fix(registry): honor notes list fields in source health

### DIFF
--- a/packages/registry/src/quality-lib.js
+++ b/packages/registry/src/quality-lib.js
@@ -396,8 +396,12 @@ export function buildEntrySourceHealth(entry, referenceDate) {
     referenceDate,
   );
   const pkg = derivePackageTrust(entry);
-  const hasSafetyNotes = hasMeaningfulNotes(entry.safetyNotes);
-  const hasPrivacyNotes = hasMeaningfulNotes(entry.privacyNotes);
+  const hasSafetyNotes = hasMeaningfulNotes(
+    entry.safetyNotesList ?? entry.safetyNotes,
+  );
+  const hasPrivacyNotes = hasMeaningfulNotes(
+    entry.privacyNotesList ?? entry.privacyNotes,
+  );
   const riskBearing = isRiskBearingSourceCategory(entry.category);
 
   const attentionReasons = [];

--- a/tests/quality-lib.test.ts
+++ b/tests/quality-lib.test.ts
@@ -578,6 +578,25 @@ describe("buildEntrySourceHealth", () => {
     expect(health.attentionReasons).toEqual([]);
   });
 
+  it("accepts safetyNotesList/privacyNotesList when string fields are empty (#5638)", () => {
+    const health = buildEntrySourceHealth(
+      entry({
+        category: "mcp",
+        repoUrl: "https://github.com/a/b",
+        dateAdded: "2026-05-01",
+        safetyNotes: [],
+        privacyNotes: [],
+        safetyNotesList: ["review before install"],
+        privacyNotesList: ["no telemetry"],
+      }),
+      REFERENCE,
+    );
+    expect(health.hasSafetyNotes).toBe(true);
+    expect(health.hasPrivacyNotes).toBe(true);
+    expect(health.attentionReasons).not.toContain("missing-safety-notes");
+    expect(health.attentionReasons).not.toContain("missing-privacy-notes");
+  });
+
   it("treats stale freshness as an attention reason", () => {
     const health = buildEntrySourceHealth(
       entry({


### PR DESCRIPTION
## Summary
- `buildEntrySourceHealth` now uses `safetyNotesList ?? safetyNotes` and `privacyNotesList ?? privacyNotes`, matching `llms-lib`.
- Entries with only list fields no longer get `missing-safety-notes` / `missing-privacy-notes`.
- Raw array `safetyNotes` / `privacyNotes` behavior unchanged.

Closes #5638

## Test plan
- [x] `pnpm test -- quality-lib`
- [ ] `pnpm build`