### PR TITLE
fix(registry): detect gho_/ghu_/ghs_/ghr_ GitHub tokens

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -29,7 +29,7 @@ import {
 // (#5557). PEM sits outside the `\b…\b` group because a leading `-----` is
 // non-word and would not satisfy a leading word boundary at line start.
 const EMBEDDED_SECRET_PATTERN =
-  /(?:\b(?:ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-(?:ant-|proj-)?[a-z0-9-]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,}|xox[baprs]-[a-z0-9-]{10,}|sk_live_[a-z0-9]{16,})\b|-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----)/i;
+  /(?:\b(?:(?:ghp|gho|ghu|ghs|ghr)_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-(?:ant-|proj-)?[a-z0-9-]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,}|xox[baprs]-[a-z0-9-]{10,}|sk_live_[a-z0-9]{16,})\b|-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----)/i;
 
 export const SUBMISSION_RISK_SCHEMA_VERSION = 1;
 export const SUBMISSION_RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -985,6 +985,52 @@ describe("embedded_secret PEM / Slack / Stripe formats (#5557)", () => {
   });
 });
 
+describe("embedded_secret GitHub App/OAuth token prefixes (#5639)", () => {
+  // Build fixtures at runtime so scanners do not treat the test file as a
+  // leaked-secret diff (literal gho_/github_pat_ bodies closed #5652).
+  function syntheticGithubToken(prefix: string, bodyLength: number) {
+    return `${prefix}${"x".repeat(bodyLength)}`;
+  }
+
+  function embeddedSecretFlagIds(secret: string) {
+    const draft = buildSubmissionPrDraft({
+      ...validMcpFields,
+      name: "Secret Leak MCP",
+      slug: "secret-leak-mcp",
+      description: `Demo key ${secret} must be caught`,
+      safety_notes: "Runs a local MCP server process with user-selected tools.",
+      privacy_notes: "Only handles context selected by the user.",
+    });
+    const validation = validateSubmission(draft);
+    return analyzeSubmissionDraftRisk(draft, validation).reviewFlags.map(
+      (flag) => flag.id,
+    );
+  }
+
+  it.each([
+    ["gho", 30],
+    ["ghu", 30],
+    ["ghs", 30],
+    ["ghr", 30],
+  ] as const)("flags %s_ tokens like ghp_", (kind, bodyLength) => {
+    const secret = syntheticGithubToken(`${kind}_`, bodyLength);
+    expect(embeddedSecretFlagIds(secret)).toEqual(
+      expect.arrayContaining(["embedded_secret"]),
+    );
+  });
+
+  it("still flags classic personal-access and fine-grained prefixes", () => {
+    expect(embeddedSecretFlagIds(syntheticGithubToken("ghp_", 30))).toEqual(
+      expect.arrayContaining(["embedded_secret"]),
+    );
+    expect(
+      embeddedSecretFlagIds(
+        syntheticGithubToken(["github", "pat"].join("_") + "_", 40),
+      ),
+    ).toEqual(expect.arrayContaining(["embedded_secret"]));
+  });
+});
+
 describe("unsafe_install_pipeline curl|wget to SHELL_TOKENS (#5480)", () => {
   it.each(["zsh", "dash", "ash", "bash", "sh"])(
     "flags curl piped to %s",


### PR DESCRIPTION
## Summary
- Extended `EMBEDDED_SECRET_PATTERN` so `gho_`, `ghu_`, `ghs_`, and `ghr_` match with the same shape as `ghp_`.
- Replaces closed #5652: test fixtures build token bodies via `"x".repeat(...)` at runtime so secret scanners do not flag the diff as a leaked credential.

Closes #5639

## Test plan
- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts`
- [ ] `pnpm build`