### PR TITLE
fix(mcp): sync TRACKING_QUERY_KEYS with registry AFFILIATE_PARAMS

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -84,6 +84,8 @@ function isHttpsUrl(value) {
   return isPublicHttpsUrl(normalizeText(value));
 }
 
+// Keep in sync with packages/registry/src/source-url-lib.js AFFILIATE_PARAMS so
+// submission.validate/review/prepare match the private submission gate.
 const TRACKING_QUERY_KEYS = new Set([
   "aff",
   "affiliate",
@@ -92,8 +94,11 @@ const TRACKING_QUERY_KEYS = new Set([
   "coupon",
   "irclickid",
   "partner",
+  "partner_id",
+  "ref",
   "referral",
   "referral_code",
+  "tag",
   "via",
 ]);
 

--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -217,6 +217,23 @@ describe("submissions-lib spec validation", () => {
     ).toContain("Guide submissions require guide_content.");
   });
 
+  it.each([
+    ["ref", "https://example.com/tool?ref=xyz123"],
+    ["tag", "https://example.com/tool?tag=partner"],
+    ["partner_id", "https://example.com/tool?partner_id=42"],
+  ])(
+    "flags docs_url with registry-canonical affiliate param %s (#5645)",
+    (_param, docs_url) => {
+      const result = validateSubmissionDraftFromSpec(submissionSpec, {
+        fields: { ...validMcpFields, docs_url },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain(
+        "Contributor submissions cannot include affiliate/referral URLs",
+      );
+    },
+  );
+
   it("rejects affiliate URLs and invalid capability-pack metadata", () => {
     const affiliateResult = validateSubmissionDraftFromSpec(submissionSpec, {
       fields: {


### PR DESCRIPTION
## Summary

- Sync `packages/mcp/src/submissions-lib.js` `TRACKING_QUERY_KEYS` with the registry package's canonical `AFFILIATE_PARAMS` by adding `partner_id`, `ref`, and `tag`.
- `submission.validate` / `submission.review` / `submission.prepare` now flag URLs like `?ref=`, `?tag=`, and `?partner_id=` the same way the private submission gate does.
- Add focused regression coverage in `tests/mcp-submissions-lib.test.ts` for each of the three newly caught params (alone, without `utm_*`).

Closes #5645

## Quality evidence

Newly caught params (match `packages/registry/src/source-url-lib.js` `AFFILIATE_PARAMS`):

| Param | Example URL now flagged |
|-------|-------------------------|
| `ref` | `https://example.com/tool?ref=xyz123` |
| `tag` | `https://example.com/tool?tag=partner` |
| `partner_id` | `https://example.com/tool?partner_id=42` |

Existing tracking keys (`aff`, `utm_*`, `via`, etc.) are unchanged.

## Scope

- [x] `packages/mcp/src/submissions-lib.js` + focused tests only
- [x] Duplicate gate: no other open PR for #5645

## Validation

- [x] `git diff --check`
- [ ] CI (`pnpm build` / `pnpm test:mcp` / coverage suite)