### PR TITLE
fix(web): emit ItemList JSON-LD on /for hub page

### DIFF
--- a/apps/web/src/routes/for.index.tsx
+++ b/apps/web/src/routes/for.index.tsx
@@ -9,7 +9,7 @@ import {
   platformIndexSelectAnalyticsEvent,
   platformIndexSelectDestination,
 } from "@/lib/directory-hub-cta-events";
-import { stringifyJsonLd } from "@/lib/json-ld";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 
 const PLATFORMS = Object.keys(PLATFORM_LABEL) as Platform[];
@@ -42,18 +42,20 @@ export const Route = createFileRoute("/for/")({
         { name: "twitter:card", content: "summary_large_image" },
       ],
       links: [{ rel: "canonical", href: url }],
+      // BreadcrumbList + ItemList for every /for/$platform link rendered below —
+      // same platform set /platforms already emits (#5630).
       scripts: [
-        {
-          type: "application/ld+json",
-          children: stringifyJsonLd({
-            "@context": "https://schema.org",
-            "@type": "BreadcrumbList",
-            itemListElement: [
-              { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
-              { "@type": "ListItem", position: 2, name: "Platforms", item: url },
-            ],
-          }),
-        },
+        breadcrumbScript([
+          { name: "Directory", path: "/browse" },
+          { name: "Platforms", path: "/for" },
+        ]),
+        itemListScript(
+          PLATFORMS.map((id) => ({
+            name: PLATFORM_LABEL[id],
+            path: `/for/${id}`,
+          })),
+          { name: "Claude platforms" },
+        ),
       ],
     };
   },

--- a/tests/for-hub-itemlist-jsonld.test.ts
+++ b/tests/for-hub-itemlist-jsonld.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { buildItemListJsonLd } from "@heyclaude/registry/seo";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// /for renders every platform as a /for/$platform link but head() only emitted
+// BreadcrumbList JSON-LD. /platforms already pairs breadcrumb + ItemList for the
+// same destinations — pin the /for head() parity at the source level (#5630).
+describe("/for hub ItemList JSON-LD (#5630)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/for.index.tsx"),
+    "utf8",
+  );
+
+  it("imports breadcrumbScript and itemListScript", () => {
+    expect(source).toContain(
+      'import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";',
+    );
+  });
+
+  it("emits BreadcrumbList and ItemList scripts from head()", () => {
+    expect(source).toContain("scripts: [");
+    expect(source).toContain("breadcrumbScript([");
+    expect(source).toContain('{ name: "Directory", path: "/browse" }');
+    expect(source).toContain('{ name: "Platforms", path: "/for" }');
+    expect(source).toContain("itemListScript(");
+    expect(source).toContain("path: `/for/${id}`");
+    expect(source).toContain('{ name: "Claude platforms" }');
+  });
+
+  it("builds a valid ItemList for sample platform destinations", () => {
+    const itemList = buildItemListJsonLd(
+      [
+        { name: "Claude Code", url: "https://heyclau.de/for/claude-code" },
+        { name: "Cursor", url: "https://heyclau.de/for/cursor" },
+      ],
+      { name: "Claude platforms" },
+    );
+    expect(itemList["@type"]).toBe("ItemList");
+    expect(itemList.name).toBe("Claude platforms");
+    expect(itemList.itemListElement).toHaveLength(2);
+    expect(itemList.itemListElement[0]).toMatchObject({
+      "@type": "ListItem",
+      position: 1,
+      name: "Claude Code",
+      url: "https://heyclau.de/for/claude-code",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Emit `ItemList` JSON-LD on `/for` alongside the existing `BreadcrumbList`, covering every platform link rendered on the page.
- Reuse `breadcrumbScript` / `itemListScript` helpers so structured data matches `/platforms` for the same `/for/$platform` destinations.
- Add source-level regression coverage in `tests/for-hub-itemlist-jsonld.test.ts`.

Closes #5630

## Quality evidence

Structured data now includes both scripts (same pattern as `platforms.tsx`):

- `BreadcrumbList`: Directory → Platforms (`/for`)
- `ItemList` name `Claude platforms`: one `ListItem` per `PLATFORM_LABEL` entry at `/for/{id}`

No visual/UI change — `head()` scripts only.

## Scope

- [x] `apps/web/src/routes/for.index.tsx` + focused test
- [x] Duplicate gate: no other open PR for #5630

## Validation

- [x] `git diff --check`
- [ ] CI