### PR TITLE
fix(web): emit ItemList JSON-LD on /tags hub page

### DIFF
--- a/apps/web/src/routes/tags.index.tsx
+++ b/apps/web/src/routes/tags.index.tsx
@@ -4,8 +4,6 @@ import { Search } from "lucide-react";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { CategoryPill } from "@/components/badges";
-import { stringifyJsonLd } from "@/lib/json-ld";
-import { absoluteUrl } from "@/lib/seo";
 import { getIndexableTagGroups } from "@/lib/tags";
 import { toTagView, type TagView } from "@/lib/tag-view-lib";
 import { trackEvent } from "@/lib/analytics";
@@ -20,6 +18,8 @@ import {
   tagsIndexTagSelectDestination,
   type TagsIndexTagVariant,
 } from "@/lib/tags-index-cta-events";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/tags/")({
@@ -28,6 +28,8 @@ export const Route = createFileRoute("/tags/")({
     const title = "Browse Claude resources by tag — HeyClaude";
     const description =
       "Topic index for the HeyClaude directory: browse Claude Code MCP servers, agents, skills, hooks, commands, and rules by tag.";
+    // Same indexable tags the page renders (featured strip + All topics grid).
+    const tags = getIndexableTagGroups().map(toTagView);
     return {
       meta: [
         { title },
@@ -38,18 +40,19 @@ export const Route = createFileRoute("/tags/")({
         { name: "twitter:card", content: "summary_large_image" },
       ],
       links: [{ rel: "canonical", href: url }],
+      // BreadcrumbList + ItemList for every /tags/$tag link rendered below (#5631).
       scripts: [
-        {
-          type: "application/ld+json",
-          children: stringifyJsonLd({
-            "@context": "https://schema.org",
-            "@type": "BreadcrumbList",
-            itemListElement: [
-              { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
-              { "@type": "ListItem", position: 2, name: "Tags", item: url },
-            ],
-          }),
-        },
+        breadcrumbScript([
+          { name: "Directory", path: "/browse" },
+          { name: "Tags", path: "/tags" },
+        ]),
+        itemListScript(
+          tags.map((tag) => ({
+            name: tag.name,
+            path: `/tags/${tag.slug}`,
+          })),
+          { name: "Claude resource tags" },
+        ),
       ],
     };
   },

--- a/tests/tags-hub-itemlist-jsonld.test.ts
+++ b/tests/tags-hub-itemlist-jsonld.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { buildItemListJsonLd } from "@heyclaude/registry/seo";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// /tags renders every indexable tag as a /tags/$tag link but head() only emitted
+// BreadcrumbList JSON-LD. Sibling hub routes (/best, /compare, /integrations, …)
+// already pair breadcrumb + ItemList — pin the /tags head() parity (#5631).
+describe("/tags hub ItemList JSON-LD (#5631)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/tags.index.tsx"),
+    "utf8",
+  );
+
+  it("imports breadcrumbScript and itemListScript", () => {
+    expect(source).toContain(
+      'import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";',
+    );
+  });
+
+  it("emits BreadcrumbList and ItemList scripts from head()", () => {
+    expect(source).toContain("scripts: [");
+    expect(source).toContain("breadcrumbScript([");
+    expect(source).toContain('{ name: "Directory", path: "/browse" }');
+    expect(source).toContain('{ name: "Tags", path: "/tags" }');
+    expect(source).toContain("itemListScript(");
+    expect(source).toContain("getIndexableTagGroups()");
+    expect(source).toContain("path: `/tags/${tag.slug}`");
+    expect(source).toContain('{ name: "Claude resource tags" }');
+  });
+
+  it("builds a valid ItemList for sample tag destinations", () => {
+    const itemList = buildItemListJsonLd(
+      [
+        { name: "MCP", url: "https://heyclau.de/tags/mcp" },
+        { name: "Claude Code", url: "https://heyclau.de/tags/claude-code" },
+      ],
+      { name: "Claude resource tags" },
+    );
+    expect(itemList["@type"]).toBe("ItemList");
+    expect(itemList.name).toBe("Claude resource tags");
+    expect(itemList.itemListElement).toHaveLength(2);
+    expect(itemList.itemListElement[0]).toMatchObject({
+      "@type": "ListItem",
+      position: 1,
+      name: "MCP",
+      url: "https://heyclau.de/tags/mcp",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Emit `ItemList` JSON-LD on `/tags` alongside the existing `BreadcrumbList`, covering every indexable tag link rendered on the page.
- Reuse `breadcrumbScript` / `itemListScript` helpers, matching sibling hubs (`/best`, `/compare`, `/integrations`, …).
- Add source-level regression coverage in `tests/tags-hub-itemlist-jsonld.test.ts`.

Closes #5631

## Quality evidence

Structured data now includes both scripts:

- `BreadcrumbList`: Directory → Tags (`/tags`)
- `ItemList` name `Claude resource tags`: one `ListItem` per `getIndexableTagGroups()` entry at `/tags/{slug}` (same set the featured strip + All topics grid render)

No visual/UI change — `head()` scripts only.

## Scope

- [x] `apps/web/src/routes/tags.index.tsx` + focused test
- [x] Duplicate gate: no other open PR for #5631

## Validation

- [x] `git diff --check`
- [ ] CI