### PR TITLE
fix(web): uncap tag and platform-category ItemList JSON-LD

### DIFF
--- a/apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts
@@ -1,12 +1,14 @@
 // Pure builder for a platform+category ("for/<platform>/<category>") page's
 // schema.org ItemList JSON-LD, split out of the route head(). The ListItem
-// mapping and the item cap are delegated to the shared entry ItemList builder.
+// mapping is delegated to the shared entry ItemList builder; the page renders
+// every matching entry, so no cap is applied (same escape hatch as comparison
+// pages / #5593).
 
 import { entryItemListJsonLd, type ItemListEntryRef } from "@/lib/entry-itemlist-jsonld-lib";
 
 /**
  * schema.org ItemList JSON-LD for a platform+category's resources.
- * numberOfItems reflects the full set; itemListElement is capped at 30 entries.
+ * numberOfItems and itemListElement both reflect the full set rendered on the page.
  */
 export function platformCategoryItemListJsonLd(
   platformLabel: string,
@@ -20,5 +22,6 @@ export function platformCategoryItemListJsonLd(
     description,
     entries,
     absoluteUrl,
+    Infinity,
   );
 }

--- a/apps/web/src/lib/tag-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/tag-itemlist-jsonld-lib.ts
@@ -1,12 +1,13 @@
 // Pure builder for a tag page's schema.org ItemList JSON-LD, split out of the
-// route head() so the name/count and the first-30 slice cap can be unit-tested.
-// The ListItem mapping is delegated to the shared entry ItemList builder.
+// route head() so the name/count can be unit-tested. The ListItem mapping is
+// delegated to the shared entry ItemList builder; the page renders every tagged
+// entry, so no cap is applied (same escape hatch as comparison pages / #5593).
 
 import { entryItemListJsonLd, type ItemListEntryRef } from "@/lib/entry-itemlist-jsonld-lib";
 
 /**
- * schema.org ItemList JSON-LD for a tag's resources. numberOfItems reflects the
- * full set; itemListElement is capped at the first 30 entries.
+ * schema.org ItemList JSON-LD for a tag's resources. numberOfItems and
+ * itemListElement both reflect the full set rendered on the page.
  */
 export function tagItemListJsonLd(
   tagName: string,
@@ -19,5 +20,6 @@ export function tagItemListJsonLd(
     description,
     entries,
     absoluteUrl,
+    Infinity,
   );
 }

--- a/tests/platform-category-itemlist-jsonld-lib.test.ts
+++ b/tests/platform-category-itemlist-jsonld-lib.test.ts
@@ -43,7 +43,7 @@ describe("platformCategoryItemListJsonLd", () => {
     expect(ld.itemListElement[1].position).toBe(2);
   });
 
-  it("reports the full count but caps list items at 30", () => {
+  it("lists every entry (no 30-item cap) while numberOfItems matches (#5632)", () => {
     const ld = platformCategoryItemListJsonLd(
       "Cursor",
       "MCP",
@@ -52,6 +52,11 @@ describe("platformCategoryItemListJsonLd", () => {
       abs,
     );
     expect(ld.numberOfItems).toBe(31);
-    expect(ld.itemListElement).toHaveLength(30);
+    expect(ld.itemListElement).toHaveLength(31);
+    expect(ld.itemListElement[30]).toMatchObject({
+      position: 31,
+      name: "Entry 31",
+      url: "https://heyclau.de/entry/mcp/e31",
+    });
   });
 });

--- a/tests/tag-itemlist-jsonld-lib.test.ts
+++ b/tests/tag-itemlist-jsonld-lib.test.ts
@@ -31,9 +31,14 @@ describe("tagItemListJsonLd", () => {
     expect(ld.itemListElement[1].position).toBe(2);
   });
 
-  it("reports the full count but caps list items at 30", () => {
+  it("lists every entry (no 30-item cap) while numberOfItems matches (#5632)", () => {
     const ld = tagItemListJsonLd("cli", "d", makeEntries(31), abs);
     expect(ld.numberOfItems).toBe(31);
-    expect(ld.itemListElement).toHaveLength(30);
+    expect(ld.itemListElement).toHaveLength(31);
+    expect(ld.itemListElement[30]).toMatchObject({
+      position: 31,
+      name: "Entry 31",
+      url: "https://heyclau.de/entry/agents/e31",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Pass `Infinity` into the shared `entryItemListJsonLd` builder from `tagItemListJsonLd` and `platformCategoryItemListJsonLd`.
- `/tags/$tag` and `/for/$platform/$category` ItemList JSON-LD now lists every entry the page renders (same pattern as comparison pages and the `/tools` fix in #5593).
- Update unit tests that previously asserted the 30-item cap.

Closes #5632

## Quality evidence

Before: `numberOfItems` could be 99/159 while `itemListElement.length` stayed at 30.
After: both match the full rendered entry set (verified with 31-entry fixtures in both lib tests).

No visual/UI change — structured data only.

## Scope

- [x] `tag-itemlist-jsonld-lib.ts` + `platform-category-itemlist-jsonld-lib.ts` + tests
- [x] Duplicate gate: no other open PR for #5632

## Validation

- [x] Targeted vitest for both lib tests
- [x] `git diff --check`
- [ ] CI