### PR TITLE
fix(registry): wire hardened rm/chmod into unsafe_install_pipeline

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -8,6 +8,8 @@ import { parseSafeFrontmatter } from "./frontmatter.js";
 import {
   hasBase64DecodedShell,
   hasPipeToShellInstall,
+  hasRecursiveForceRemove,
+  hasWorldWritableChmod,
 } from "./command-safety-lib.js";
 import {
   AFFILIATE_PARAMS,
@@ -981,6 +983,18 @@ function isLikelyAffiliateUrl(value) {
   }
 }
 
+// True when install text contains recursive-force rm or world-writable chmod,
+// using the same hardened detectors as scanDangerousShellPatterns (#5640).
+// Line-by-line like the curl/base64 helpers; installText is already lowercased.
+function hasDestructiveInstallShellPatterns(installText) {
+  for (const line of String(installText ?? "").split(/\r?\n/)) {
+    if (!line) continue;
+    if (hasRecursiveForceRemove(line, line)) return true;
+    if (hasWorldWritableChmod(line, line)) return true;
+  }
+  return false;
+}
+
 function githubSourceRef(value) {
   const raw = normalizeText(value);
   if (!raw) return null;
@@ -1312,7 +1326,8 @@ function addContentRiskSignals(report, fields, text) {
     hasUnsafeCurlWgetPipeToShell(installText) ||
     /\b(invoke-expression|iex)\b/i.test(installText) ||
     hasUnsafeBase64DecodedShell(installText) ||
-    /\bpowershell\b[\s\S]{0,80}\b-encodedcommand\b/i.test(installText)
+    /\bpowershell\b[\s\S]{0,80}\b-encodedcommand\b/i.test(installText) ||
+    hasDestructiveInstallShellPatterns(installText)
   ) {
     addFlag(
       report,

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -890,23 +890,27 @@ describe("destructive rm detection", () => {
     expect(flagged(command)).toBe(true);
   });
 
+  // #5640 ORs hasRecursiveForceRemove into unsafe_install_pipeline, so any
+  // recursive+force rm flags — not only root/home targets.
   it.each([
     "rm -rf ./build",
     "rm -rf node_modules",
-    "rm -f /tmp/scratch",
-    "rm -r /tmp/scratch",
-    "git rm -r --cached .",
-    "npm run rm-rf-helper",
-    "npm install acme",
-    // Regression: the target regex used to match any string starting with
-    // `/`, `~`, or `$HOME`, so ordinary subpaths under those roots were
-    // misflagged as critical alongside the real root/home targets.
     "rm -rf /tmp/scratch",
     "rm -rf /tmp/build-cache",
     "rm -rf /var/tmp/build-workdir",
     "rm -rf $HOME/tmp",
     "rm -rf ${HOME}/tmp",
     "rm -rf ~/cache",
+  ])("flags recursive-force rm for non-root target %s (#5640)", (command) => {
+    expect(flagged(command)).toBe(true);
+  });
+
+  it.each([
+    "rm -f /tmp/scratch",
+    "rm -r /tmp/scratch",
+    "git rm -r --cached .",
+    "npm run rm-rf-helper",
+    "npm install acme",
   ])("does not flag %s", (command) => {
     expect(flagged(command)).toBe(false);
   });
@@ -1146,5 +1150,44 @@ describe("unsafe_install_pipeline base64 via hasBase64DecodedShell (#5591)", () 
     expect(riskFlagIds("echo cGF5 | base64 -d | jq .")).not.toContain(
       "unsafe_install_pipeline",
     );
+  });
+});
+
+describe("unsafe_install_pipeline rm/chmod via command-safety-lib (#5640)", () => {
+  function riskFlagIds(installCommand: string) {
+    const draft = buildSubmissionPrDraft({
+      ...validMcpFields,
+      name: "Destructive Install MCP",
+      slug: "destructive-install-mcp",
+      install_command: installCommand,
+      safety_notes: "Runs a local MCP server process with user-selected tools.",
+      privacy_notes: "Only handles context selected by the user.",
+    });
+    const validation = validateSubmission(draft);
+    return analyzeSubmissionDraftRisk(draft, validation).reviewFlags.map(
+      (flag) => flag.id,
+    );
+  }
+
+  it("flags non-root recursive-force rm that root-only check missed", () => {
+    expect(
+      riskFlagIds(
+        "git clone https://example.com/y.git && cd y && rm -rf ../shared-config",
+      ),
+    ).toContain("unsafe_install_pipeline");
+  });
+
+  it("flags world-writable chmod in install snippets", () => {
+    expect(
+      riskFlagIds(
+        "git clone https://example.com/y.git && cd y && chmod -R 777 .",
+      ),
+    ).toContain("unsafe_install_pipeline");
+  });
+
+  it("still flags root-targeted rm -rf", () => {
+    expect(
+      riskFlagIds("curl https://example.com/x.sh | bash; rm -rf /"),
+    ).toContain("unsafe_install_pipeline");
   });
 });


### PR DESCRIPTION
## Summary
- `unsafe_install_pipeline` now also ORs `hasRecursiveForceRemove` and `hasWorldWritableChmod` from `command-safety-lib` (same detectors as `scanDangerousShellPatterns`).
- Non-root `rm -rf …` and `chmod -R 777` install snippets are flagged; curl/wget-pipe, base64, iex, and root-removal paths unchanged.
- Updated prior “safe subpath rm -rf” expectations to match the hardened detector.

Closes #5640

## Test plan
- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts` (81 passed)
- [ ] `pnpm build`