### PR TITLE
fix(registry): unify isLikelyAffiliateUrl across submission paths

### DIFF
--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -251,6 +251,44 @@ export function stripTrackingParams(value) {
 }
 
 /**
+ * Detect whether a URL is likely affiliate/referral tracked.
+ *
+ * Combines the registry-canonical query-param check (`isAffiliateParam` /
+ * `AFFILIATE_PARAMS` plus every `utm_*`) with the path-based checks that
+ * submission-risk previously kept locally (`/referral/`, `/affiliate/`,
+ * `/partner(s)/`, bare terminal `/ref`/`/refer`). One implementation gates
+ * both field validation and install-snippet risk review (#5637).
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isLikelyAffiliateUrl(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return false;
+
+  try {
+    const url = new URL(text);
+
+    if ([...url.searchParams.keys()].some(isAffiliateParam)) {
+      return true;
+    }
+
+    // Explicit affiliate path segments anywhere in the path.
+    if (/\/(referral|affiliate|partners?)(?:\/|$)/i.test(url.pathname)) {
+      return true;
+    }
+    // Bare `/ref` or `/refer` ONLY as the terminal path segment (affiliate
+    // shortlinks like example.com/ref). A `ref` segment with more after it is
+    // almost always a docs "reference" section (e.g. go.dev/ref/mod), not an
+    // affiliate link, so it is not flagged here — genuine affiliate links use a
+    // `ref=` query param (handled above) instead.
+    return /^\/(ref|refer)\/?$/i.test(url.pathname);
+  } catch {
+    return /\b(affiliate|referral|ref=|via=)\b/i.test(text);
+  }
+}
+
+/**
  * Canonical form for comparing submitted source URLs against registry entries.
  *
  * @param {unknown} value

--- a/packages/registry/src/source-url.d.ts
+++ b/packages/registry/src/source-url.d.ts
@@ -8,5 +8,6 @@ export function isPublicGitHubHostUrl(value: unknown): boolean;
 export function isAffiliateParam(name: unknown): boolean;
 export function isTrackingParam(name: unknown): boolean;
 export function hasAffiliateParam(value: unknown): boolean;
+export function isLikelyAffiliateUrl(value: unknown): boolean;
 export function stripTrackingParams(value: unknown): string;
 export function canonicalizeSourceUrl(value: unknown): string;

--- a/packages/registry/src/source-url.js
+++ b/packages/registry/src/source-url.js
@@ -9,6 +9,7 @@ export {
   hasAffiliateParam,
   hasEmbeddedUrlUserinfo,
   isAffiliateParam,
+  isLikelyAffiliateUrl,
   isPublicGitHubHostUrl,
   isPublicGitHubProfileUrl,
   isPublicHttpUrl,

--- a/packages/registry/src/submission-lib.js
+++ b/packages/registry/src/submission-lib.js
@@ -11,7 +11,7 @@
 import categorySpec from "./category-spec.json" with { type: "json" };
 import { normalizeBrandDomain } from "./brand-assets.js";
 import {
-  hasAffiliateParam,
+  isLikelyAffiliateUrl,
   isPublicGitHubProfileUrl,
   isPublicHttpsUrl,
   publicUrlHostname,
@@ -620,9 +620,7 @@ export function looksLikeSubmissionPrDraft(draft = {}) {
   return hasSubmissionShape;
 }
 
-export function isLikelyAffiliateUrl(value) {
-  return hasAffiliateParam(normalizeValue(value));
-}
+export { isLikelyAffiliateUrl } from "./source-url.js";
 
 function isHttpsUrl(value) {
   return isPublicHttpsUrl(normalizeValue(value));

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -10,7 +10,7 @@ import {
   hasPipeToShellInstall,
 } from "./command-safety-lib.js";
 import {
-  AFFILIATE_PARAMS,
+  isLikelyAffiliateUrl,
   isPublicGitHubProfileUrl,
   isPublicHttpUrl,
   isPublicHttpsUrl,
@@ -948,38 +948,6 @@ const FULL_COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
 
 const LOCAL_SCRIPT_REFERENCE_PATTERN =
   /(?:^|[\s`;&|])(?:(?:bash|sh|zsh|pwsh|powershell)\s+)?(?:\.{1,2}\/|[\w.-]+\/)?[\w./-]*(?:install|setup|start|bootstrap|init)[\w.-]*\.(?:sh|bash|zsh|ps1)\b/im;
-
-function isLikelyAffiliateUrl(value) {
-  const raw = normalizeText(value);
-  if (!raw) return false;
-
-  try {
-    const url = new URL(raw);
-
-    for (const key of url.searchParams.keys()) {
-      const normalizedKey = key.toLowerCase();
-      if (
-        AFFILIATE_PARAMS.has(normalizedKey) ||
-        normalizedKey.startsWith("utm_aff")
-      ) {
-        return true;
-      }
-    }
-
-    // Explicit affiliate path segments anywhere in the path.
-    if (/\/(referral|affiliate|partners?)(?:\/|$)/i.test(url.pathname)) {
-      return true;
-    }
-    // Bare `/ref` or `/refer` ONLY as the terminal path segment (affiliate
-    // shortlinks like example.com/ref). A `ref` segment with more after it is
-    // almost always a docs "reference" section (e.g. go.dev/ref/mod), not an
-    // affiliate link, so it is not flagged here - genuine affiliate links use a
-    // `ref=` query param (handled above) instead.
-    return /^\/(ref|refer)\/?$/i.test(url.pathname);
-  } catch {
-    return /\b(affiliate|referral|ref=|via=)\b/i.test(raw);
-  }
-}
 
 function githubSourceRef(value) {
   const raw = normalizeText(value);

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -5,6 +5,7 @@ import {
   hasAffiliateParam,
   hasEmbeddedUrlUserinfo,
   isAffiliateParam,
+  isLikelyAffiliateUrl,
   isPublicGitHubHostUrl,
   isPublicGitHubProfileUrl,
   isPublicHttpUrl,
@@ -782,5 +783,24 @@ describe("URL helpers handle nullish, empty, and unparseable input", () => {
     expect(publicHttpUrlHref(null)).toBe("");
     expect(publicHttpUrlHref("")).toBe("");
     expect(publicHttpUrlHref("   ")).toBe("");
+  });
+});
+
+describe("isLikelyAffiliateUrl shared helper (#5637)", () => {
+  it("flags query params via isAffiliateParam", () => {
+    expect(isLikelyAffiliateUrl("https://example.com/?ref=creator")).toBe(true);
+    expect(isLikelyAffiliateUrl("https://example.com/?utm_source=x")).toBe(
+      true,
+    );
+  });
+
+  it("flags affiliate path segments used by install-snippet risk review", () => {
+    expect(isLikelyAffiliateUrl("https://example.com/partners/xyz")).toBe(true);
+    expect(isLikelyAffiliateUrl("https://example.com/ref")).toBe(true);
+  });
+
+  it("does not flag docs reference paths", () => {
+    expect(isLikelyAffiliateUrl("https://go.dev/ref/mod")).toBe(false);
+    expect(isLikelyAffiliateUrl("https://example.com/docs")).toBe(false);
   });
 });

--- a/tests/submission-lib.test.ts
+++ b/tests/submission-lib.test.ts
@@ -346,6 +346,13 @@ describe("isLikelyAffiliateUrl", () => {
     ["https://example.com?page=2", false],
     ["  https://example.com?utm_campaign=x  ", true],
     ["http://example.com?ref=x", true],
+    // Path-based checks previously only in submission-risk (#5637)
+    ["https://example.com/partners/xyz", true],
+    ["https://example.com/affiliate/go", true],
+    ["https://example.com/referral/x", true],
+    ["https://example.com/ref", true],
+    ["https://example.com/refer/", true],
+    ["https://go.dev/ref/mod", false],
   ])("isLikelyAffiliateUrl(%j) -> %j", (input, expected) => {
     expect(isLikelyAffiliateUrl(input)).toBe(expected);
   });
@@ -787,6 +794,19 @@ describe("validateSubmission mcp", () => {
     });
     expect(result.errors).toContain(
       "Contributor submissions cannot include affiliate/referral URLs: docs_url",
+    );
+  });
+
+  it("rejects website_url with /partners/ path (#5637)", () => {
+    const result = validateSubmission({
+      title: "Add MCP Server: Demo",
+      body: buildValidBody({
+        ...validMcpFields,
+        website_url: "https://example.com/partners/xyz",
+      }),
+    });
+    expect(result.errors).toContain(
+      "Contributor submissions cannot include affiliate/referral URLs: website_url",
     );
   });
 


### PR DESCRIPTION
## Summary
- Moved a single `isLikelyAffiliateUrl` into `source-url-lib` combining:
  - query-param detection via `isAffiliateParam` (canonical `AFFILIATE_PARAMS` + all `utm_*`)
  - path checks from submission-risk (`/referral/`, `/affiliate/`, `/partner(s)/`, terminal `/ref`/`/refer`)
- `submission-lib` re-exports it; `submission-risk` deletes its local copy and imports the shared helper.
- Field validation now rejects `website_url` / `github_url` / `docs_url` / `download_url` with `/partners/…` paths, matching install-snippet behavior.

### Invariants
- Still passes: plain docs URLs, `go.dev/ref/mod`-style reference paths, empty/optional fields.
- Now fails field validation: `/partners/xyz`, `/affiliate/…`, bare `/ref`, plus existing query-param cases.
- Install-snippet affiliate flags unchanged in behavior.

Closes #5637

## Test plan
- [x] `pnpm exec vitest run tests/submission-lib.test.ts tests/source-url-lib.test.ts tests/submission-risk-invariants.test.ts tests/submission-pr-first.test.ts tests/submission-builders.test.ts` (738 passed)
- [ ] `pnpm build`