### PR TITLE
fix(mcp): add token-OR query fallback to search/list/updates

### DIFF
--- a/packages/mcp/src/registry-search-delegate-lib.js
+++ b/packages/mcp/src/registry-search-delegate-lib.js
@@ -31,3 +31,19 @@ export function rankSearchEntries(entries, query) {
 export function entryMatchesPlatform(entry, platform) {
   return matchesRegistryPlatform(entry, platform);
 }
+
+/**
+ * AND-match query filter with the same token-OR fallback plan/recommend use:
+ * when strict AND-match returns nothing, match entries where any query token
+ * appears in the normalized search haystack.
+ */
+export function filterEntriesByQuery(entries, query) {
+  let matched = entries.filter((entry) => entryMatchesQuery(entry, query));
+  const queryTokens = searchTokens(query);
+  if (!matched.length && queryTokens.length) {
+    matched = entries.filter((entry) =>
+      queryTokens.some((token) => entrySearchText(entry).includes(token)),
+    );
+  }
+  return matched;
+}

--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -27,6 +27,7 @@ import {
   entryMatchesPlatform,
   entryMatchesQuery,
   entrySearchText,
+  filterEntriesByQuery,
   rankSearchEntries,
   searchTokens,
 } from "./registry-search-delegate-lib.js";
@@ -169,12 +170,14 @@ export async function searchRegistry(args = {}, options = {}) {
     await readJsonArtifact("search-index.json", options),
   );
 
-  const matched = searchIndex
-    .filter((entry) => !category || entry.category === category)
-    .filter((entry) => entryMatchesPlatform(entry, platform))
-    .filter((entry) => entryMatchesTag(entry, tag))
-    .filter((entry) => entryMatchesQuery(entry, query))
-    .filter((entry) => entryMatchesTrustFilters(entry, trustFilters));
+  const matched = filterEntriesByQuery(
+    searchIndex
+      .filter((entry) => !category || entry.category === category)
+      .filter((entry) => entryMatchesPlatform(entry, platform))
+      .filter((entry) => entryMatchesTag(entry, tag))
+      .filter((entry) => entryMatchesTrustFilters(entry, trustFilters)),
+    query,
+  );
   const entries = rankSearchEntries(matched, query)
     .slice(0, limit)
     .map((item) => toSearchResult(item.entry, item));
@@ -347,12 +350,14 @@ export async function listCategoryEntries(args = {}, options = {}) {
     await readJsonArtifact("search-index.json", options),
   );
 
-  const entries = searchIndex
-    .filter((entry) => !category || entry.category === category)
-    .filter((entry) => entryMatchesPlatform(entry, platform))
-    .filter((entry) => entryMatchesTag(entry, tag))
-    .filter((entry) => entryMatchesQuery(entry, query))
-    .filter((entry) => entryMatchesTrustFilters(entry, trustFilters));
+  const entries = filterEntriesByQuery(
+    searchIndex
+      .filter((entry) => !category || entry.category === category)
+      .filter((entry) => entryMatchesPlatform(entry, platform))
+      .filter((entry) => entryMatchesTag(entry, tag))
+      .filter((entry) => entryMatchesTrustFilters(entry, trustFilters)),
+    query,
+  );
   const page = paginateEntries(entries, offset, limit).map(toEntrySummary);
 
   return buildCategoryEntriesPageResponse({
@@ -382,13 +387,15 @@ export async function getRecentUpdates(args = {}, options = {}) {
     await readJsonArtifact("search-index.json", options),
   );
   const sorted = sortEntriesByUpdatedAt(
-    searchIndex
-      .filter((entry) => !category || entry.category === category)
-      .filter((entry) => entryMatchesPlatform(entry, platform))
-      .filter((entry) => entryMatchesTag(entry, tag))
-      .filter((entry) => entryMatchesQuery(entry, query))
-      .filter((entry) => entryMatchesTrustFilters(entry, trustFilters))
-      .filter((entry) => !since || entryUpdatedAt(entry) >= since),
+    filterEntriesByQuery(
+      searchIndex
+        .filter((entry) => !category || entry.category === category)
+        .filter((entry) => entryMatchesPlatform(entry, platform))
+        .filter((entry) => entryMatchesTag(entry, tag))
+        .filter((entry) => entryMatchesTrustFilters(entry, trustFilters))
+        .filter((entry) => !since || entryUpdatedAt(entry) >= since),
+      query,
+    ),
     entryUpdatedAt,
   );
   const entries = mapRecentUpdateEntries(

--- a/tests/registry-search-delegate-lib.test.ts
+++ b/tests/registry-search-delegate-lib.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { filterEntriesByQuery } from "../packages/mcp/src/registry-search-delegate-lib.js";
+import { searchRegistry } from "../packages/mcp/src/registry-tool-orchestration-lib.js";
+
+const entries = [
+  {
+    category: "mcp",
+    slug: "postgres-bridge",
+    title: "Postgres Bridge",
+    description: "PostgreSQL database client for Claude Code",
+    tags: ["database"],
+    platforms: ["claude-code"],
+  },
+  {
+    category: "skills",
+    slug: "spreadsheet-helper",
+    title: "Spreadsheet Helper",
+    description: "CSV export utilities",
+    tags: ["spreadsheet"],
+    platforms: ["claude-code"],
+  },
+];
+
+const artifactOptions = {
+  readJsonArtifact: async () => ({ entries }),
+};
+
+describe("filterEntriesByQuery (#5643)", () => {
+  it("keeps strict AND matches when every token hits", () => {
+    const matched = filterEntriesByQuery(entries, "postgres client");
+    expect(matched.map((entry) => entry.slug)).toEqual(["postgres-bridge"]);
+  });
+
+  it("falls back to token-OR when AND-match returns nothing", () => {
+    const matched = filterEntriesByQuery(entries, "postgres spreadsheet");
+    expect(matched.map((entry) => entry.slug).sort()).toEqual([
+      "postgres-bridge",
+      "spreadsheet-helper",
+    ]);
+  });
+
+  it("returns all entries for an empty query", () => {
+    expect(filterEntriesByQuery(entries, "")).toHaveLength(2);
+  });
+});
+
+describe("searchRegistry query OR fallback (#5643)", () => {
+  it("returns OR-fallback matches for multi-token queries", async () => {
+    const result = await searchRegistry(
+      { query: "postgres spreadsheet" },
+      artifactOptions,
+    );
+    expect(result.ok).toBe(true);
+    expect(
+      result.entries.map((entry: { slug: string }) => entry.slug).sort(),
+    ).toEqual(["postgres-bridge", "spreadsheet-helper"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `filterEntriesByQuery` with the same AND-then-token-OR fallback `registry.plan` / `registry.recommend` already use when strict AND-match returns nothing.
- Wire it into `registry.search`, `registry.list`, and `registry.updates` so multi-token queries like `postgres client` behave consistently across MCP tools.
- Add focused regression coverage in `tests/registry-search-delegate-lib.test.ts`.

Closes #5643

## Quality evidence

| Query | Before | After |
|-------|--------|-------|
| `postgres client` (AND hits) | matches postgres entry | unchanged |
| `postgres spreadsheet` (AND miss) | **0 results** | both entries (OR fallback) |

## Scope

- [x] `registry-search-delegate-lib.js` + `registry-tool-orchestration-lib.js` + test
- [x] Duplicate gate: no other open PR for #5643

## Validation

- [x] `vitest run tests/registry-search-delegate-lib.test.ts`
- [x] `prettier --check` on touched files
- [ ] CI