### PR TITLE
fix(web): dedupe browse theme tags by slug within an entry

### DIFF
--- a/apps/web/src/lib/browse-theme-distribution-lib.ts
+++ b/apps/web/src/lib/browse-theme-distribution-lib.ts
@@ -41,11 +41,11 @@ function normalizeTags(entry: Entry): string[] {
     if (tag.length === 0) {
       continue;
     }
-    const key = tag.toLowerCase();
-    if (seen.has(key)) {
+    const slug = tagSlug(tag);
+    if (seen.has(slug)) {
       continue;
     }
-    seen.add(key);
+    seen.add(slug);
     tags.push(tag);
   }
   return tags;

--- a/tests/browse-theme-distribution-lib.test.ts
+++ b/tests/browse-theme-distribution-lib.test.ts
@@ -63,6 +63,21 @@ describe("browseThemeDistributionState", () => {
     expect(memory?.count).toBe(2);
   });
 
+  it("de-duplicates raw tags that slug to the same theme (#5634)", () => {
+    const state = browseThemeDistributionState([
+      entry("a", ["Model Context Protocol", "model-context-protocol"]),
+      entry("b", ["memory"]),
+      entry("c", ["rag"]),
+    ]);
+    const mcp = state.topThemes.find(
+      (t) => t.slug === "model-context-protocol",
+    );
+    expect(mcp?.count).toBe(1);
+    expect(
+      state.topThemes.find((t) => t.tag === "Model Context Protocol")?.count,
+    ).toBe(1);
+  });
+
   it("classifies a dominant theme as focused", () => {
     const state = browseThemeDistributionState([
       entry("a", ["memory", "rag"]),


### PR DESCRIPTION
## Summary

- Dedupe browse theme tags by `tagSlug` inside `normalizeTags` so alternate spellings that collapse to the same slug (e.g. `Model Context Protocol` + `model-context-protocol`) only count once per entry.
- Aligns browse theme distribution counting with `tags-lib` slug semantics and the function's own per-entry dedupe doc comment.
- Add regression test in `tests/browse-theme-distribution-lib.test.ts`.

Closes #5634

## Quality evidence

Before: one entry with `["Model Context Protocol", "model-context-protocol"]` incremented `model-context-protocol` count **twice**.
After: count is **1** (first raw tag wins for display).

No visual/UI change — insight panel math only.

## Scope

- [x] `browse-theme-distribution-lib.ts` + focused test
- [x] Duplicate gate: no other open PR for #5634

## Validation

- [x] `vitest run tests/browse-theme-distribution-lib.test.ts`
- [x] `prettier --check` on touched files
- [ ] CI