### PR TITLE
fix(web): use FilterChip radiogroup on trending category filters

### DIFF
--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/badges";
 import { TrendingPodium } from "@/components/trending-podium";
 import { ShareMenu } from "@/components/share-menu";
+import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CATEGORIES } from "@/types/registry";
 import { formatCompact } from "@/lib/format";
@@ -402,48 +403,39 @@ function TrendingPage() {
         </div>
 
         <div className="relative mt-3 -mx-1">
-          <div className="flex gap-1.5 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            <button
-              type="button"
-              onClick={() => {
-                trackCategoryFilter("", true, allRows.length);
-                set({ category: "" });
-              }}
-              aria-pressed={!sp.category}
-              className={cn(
-                "shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-200 ease-out motion-safe:active:scale-[0.97]",
-                !sp.category
-                  ? "border-ink bg-ink text-background"
-                  : "border-border bg-surface text-ink-muted hover:text-ink",
-              )}
-            >
-              All · {allRows.length}
-            </button>
-            {CATEGORIES.map((category) => {
-              const count = countsByCategory[category.id] ?? 0;
-              const active = sp.category === category.id;
-              return (
-                <button
-                  key={category.id}
-                  type="button"
-                  disabled={count === 0 && !active}
-                  onClick={() => {
-                    trackCategoryFilter(category.id, !active, count);
-                    set({ category: active ? "" : category.id });
-                  }}
-                  aria-pressed={active}
-                  className={cn(
-                    "shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-200 ease-out motion-safe:active:scale-[0.97]",
-                    active
-                      ? "border-ink bg-ink text-background"
-                      : "border-border bg-surface text-ink-muted hover:text-ink",
-                    count === 0 && !active && "opacity-40",
-                  )}
-                >
-                  {category.label} <span className="text-ink-subtle">· {count}</span>
-                </button>
-              );
-            })}
+          <div className="overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[role=radiogroup]]:w-max [&_[role=radiogroup]]:flex-nowrap [&_[role=radiogroup]]:gap-1.5">
+            <FilterChipGroup label="Filter by category" multi={false}>
+              <FilterChip
+                role="radio"
+                active={!sp.category}
+                onClick={() => {
+                  trackCategoryFilter("", true, allRows.length);
+                  set({ category: "" });
+                }}
+                count={allRows.length}
+              >
+                All
+              </FilterChip>
+              {CATEGORIES.map((category) => {
+                const count = countsByCategory[category.id] ?? 0;
+                const active = sp.category === category.id;
+                return (
+                  <FilterChip
+                    key={category.id}
+                    role="radio"
+                    active={active}
+                    disabled={count === 0 && !active}
+                    count={count}
+                    onClick={() => {
+                      trackCategoryFilter(category.id, !active, count);
+                      set({ category: active ? "" : category.id });
+                    }}
+                  >
+                    {category.label}
+                  </FilterChip>
+                );
+              })}
+            </FilterChipGroup>
           </div>
           <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent" />
         </div>

--- a/tests/trending-category-filter-a11y.test.ts
+++ b/tests/trending-category-filter-a11y.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// /trending category chips were plain aria-pressed buttons; /browse already uses
+// FilterChipGroup/FilterChip radiogroup for the same control — pin the parity (#5636).
+describe("/trending category filter radiogroup (#5636)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/trending.tsx"),
+    "utf8",
+  );
+
+  it("imports FilterChipGroup and FilterChip", () => {
+    expect(source).toContain(
+      'import { FilterChip, FilterChipGroup } from "@/components/filter-chip";',
+    );
+  });
+
+  it("renders category filters as a single-select radiogroup", () => {
+    expect(source).toContain(
+      'FilterChipGroup label="Filter by category" multi={false}',
+    );
+    expect(source).toContain('role="radio"');
+    expect(source).not.toContain("aria-pressed={!sp.category}");
+    expect(source).not.toContain("aria-pressed={active}");
+  });
+
+  it("preserves category filter analytics tracking", () => {
+    expect(source).toContain("trackCategoryFilter(");
+    expect(source).toContain('set({ category: active ? "" : category.id })');
+  });
+});


### PR DESCRIPTION
## Summary

- Replace `/trending` category filter plain `aria-pressed` buttons with `FilterChipGroup` / `FilterChip` `role="radio"` components.
- Matches `/browse`'s accessible single-select category filter pattern while preserving analytics tracking and horizontal scroll layout.
- Add source-level regression coverage in `tests/trending-category-filter-a11y.test.ts`.

Closes #5636

## Quality evidence

Screen readers now hear **radio group, Filter by category** instead of disconnected toggle buttons. Category counts still render via `FilterChip` `count` prop; filter analytics calls unchanged.

## Scope

- [x] `apps/web/src/routes/trending.tsx` + focused test
- [x] Duplicate gate: no other open PR for #5636

## Validation

- [x] `vitest run tests/trending-category-filter-a11y.test.ts`
- [x] `prettier --check`
- [ ] CI