### PR TITLE
fix(web): add radiogroup a11y to command-center tab switcher

### DIFF
--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent } from "react";
 import {
   ArrowUpRight,
   BookOpen,
@@ -154,6 +155,27 @@ export function EntryDetailCommandCenter({
     absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
     siteConfig.githubUrl,
   );
+  const availableTabs = (["install", "config", "full"] as const).filter((id) =>
+    liveVariants.some((variant) => variant.id === id && variant.value),
+  );
+  const onTabKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!availableTabs.length) return;
+    const index = availableTabs.indexOf(tab);
+    if (index === -1) return;
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      onTabChange(availableTabs[(index + 1) % availableTabs.length]!);
+    } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      onTabChange(availableTabs[(index - 1 + availableTabs.length) % availableTabs.length]!);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      onTabChange(availableTabs[0]!);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      onTabChange(availableTabs[availableTabs.length - 1]!);
+    }
+  };
 
   return (
     <aside
@@ -274,19 +296,27 @@ export function EntryDetailCommandCenter({
               />
             </div>
           )}
-          <div className="flex gap-1">
+          <div
+            role="radiogroup"
+            aria-label="Choose payload view"
+            onKeyDown={onTabKeyDown}
+            className="flex gap-1"
+          >
             {(["install", "config", "full"] as const).map((t) => {
               const payload = liveVariants.find((v) => v.id === t)?.value;
               if (!payload) return null;
+              const isActive = tab === t;
               return (
                 <button
                   key={t}
                   type="button"
+                  role="radio"
+                  aria-checked={isActive}
+                  tabIndex={isActive ? 0 : -1}
                   onClick={() => onTabChange(t)}
-                  aria-pressed={tab === t}
                   className={cn(
                     "rounded-t-md px-2.5 py-1.5 text-xs font-medium capitalize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
-                    tab === t ? "bg-background text-ink" : "text-ink-muted hover:text-ink",
+                    isActive ? "bg-background text-ink" : "text-ink-muted hover:text-ink",
                   )}
                 >
                   {t}

--- a/tests/entry-detail-command-center-tab-a11y.test.ts
+++ b/tests/entry-detail-command-center-tab-a11y.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// Entry detail command-center tab switcher used aria-pressed toggles; copy-segmented
+// already implements radiogroup + arrow-key navigation for the same UI (#5635).
+describe("entry detail command-center tab radiogroup (#5635)", () => {
+  const source = fs.readFileSync(
+    path.join(
+      repoRoot,
+      "apps/web/src/components/entry-detail-command-center.tsx",
+    ),
+    "utf8",
+  );
+
+  it("uses a radiogroup for install/config/full tabs", () => {
+    expect(source).toContain('role="radiogroup"');
+    expect(source).toContain('aria-label="Choose payload view"');
+    expect(source).toContain('role="radio"');
+    expect(source).toContain("aria-checked={isActive}");
+    expect(source).toContain("tabIndex={isActive ? 0 : -1}");
+    expect(source).not.toContain("aria-pressed={tab === t}");
+  });
+
+  it("supports arrow-key navigation between available tabs", () => {
+    expect(source).toContain("onKeyDown={onTabKeyDown}");
+    expect(source).toContain('event.key === "ArrowRight"');
+    expect(source).toContain('event.key === "ArrowLeft"');
+    expect(source).toContain('event.key === "Home"');
+    expect(source).toContain('event.key === "End"');
+  });
+});


### PR DESCRIPTION
## Summary

- Give the entry detail command-center install/config/full switcher a proper `radiogroup` / `radio` pattern with roving `tabIndex` and arrow/Home/End keyboard navigation.
- Mirrors `copy-segmented.tsx` for the same single-select payload view control (without changing copy behavior).
- Add source-level regression coverage in `tests/entry-detail-command-center-tab-a11y.test.ts`.

Closes #5635

## Quality evidence

Before: three disconnected `aria-pressed` toggle buttons.
After: `role="radiogroup"` container, `role="radio"` + `aria-checked` options, arrow-key navigation between available tabs.

## Scope

- [x] `entry-detail-command-center.tsx` + focused test
- [x] Duplicate gate: no other open PR for #5635

## Validation

- [x] `vitest run tests/entry-detail-command-center-tab-a11y.test.ts`
- [x] `prettier --check`
- [ ] CI