### PR TITLE
fix(web): use FilterChip radiogroup on trending category filters

### DIFF
--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/badges";
 import { TrendingPodium } from "@/components/trending-podium";
 import { ShareMenu } from "@/components/share-menu";
+import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CATEGORIES } from "@/types/registry";
 import { formatCompact } from "@/lib/format";
@@ -402,48 +403,39 @@ function TrendingPage() {
         </div>
 
         <div className="relative mt-3 -mx-1">
-          <div className="flex gap-1.5 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            <button
-              type="button"
-              onClick={() => {
-                trackCategoryFilter("", true, allRows.length);
-                set({ category: "" });
-              }}
-              aria-pressed={!sp.category}
-              className={cn(
-                "shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-200 ease-out motion-safe:active:scale-[0.97]",
-                !sp.category
-                  ? "border-ink bg-ink text-background"
-                  : "border-border bg-surface text-ink-muted hover:text-ink",
-              )}
-            >
-              All · {allRows.length}
-            </button>
-            {CATEGORIES.map((category) => {
-              const count = countsByCategory[category.id] ?? 0;
-              const active = sp.category === category.id;
-              return (
-                <button
-                  key={category.id}
-                  type="button"
-                  disabled={count === 0 && !active}
-                  onClick={() => {
-                    trackCategoryFilter(category.id, !active, count);
-                    set({ category: active ? "" : category.id });
-                  }}
-                  aria-pressed={active}
-                  className={cn(
-                    "shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors duration-200 ease-out motion-safe:active:scale-[0.97]",
-                    active
-                      ? "border-ink bg-ink text-background"
-                      : "border-border bg-surface text-ink-muted hover:text-ink",
-                    count === 0 && !active && "opacity-40",
-                  )}
-                >
-                  {category.label} <span className="text-ink-subtle">· {count}</span>
-                </button>
-              );
-            })}
+          <div className="overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[role=radiogroup]]:w-max [&_[role=radiogroup]]:flex-nowrap [&_[role=radiogroup]]:gap-1.5">
+            <FilterChipGroup label="Filter by category" multi={false}>
+              <FilterChip
+                role="radio"
+                active={!sp.category}
+                onClick={() => {
+                  trackCategoryFilter("", true, allRows.length);
+                  set({ category: "" });
+                }}
+                count={allRows.length}
+              >
+                All
+              </FilterChip>
+              {CATEGORIES.map((category) => {
+                const count = countsByCategory[category.id] ?? 0;
+                const active = sp.category === category.id;
+                return (
+                  <FilterChip
+                    key={category.id}
+                    role="radio"
+                    active={active}
+                    disabled={count === 0 && !active}
+                    count={count}
+                    onClick={() => {
+                      trackCategoryFilter(category.id, !active, count);
+                      set({ category: active ? "" : category.id });
+                    }}
+                  >
+                    {category.label}
+                  </FilterChip>
+                );
+              })}
+            </FilterChipGroup>
           </div>
           <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent" />
         </div>

--- a/tests/toggle-aria-pressed.test.ts
+++ b/tests/toggle-aria-pressed.test.ts
@@ -34,10 +34,9 @@ describe("two-state toggle aria-pressed exposure (#5476)", () => {
     expect(source).toContain("aria-pressed={type === t}");
   });
 
-  it("matches the reference toggle pattern used by trending and advertise", () => {
-    // Reference implementations named by the issue — guard against the pattern
-    // drifting away while the three fixed controls still depend on it.
-    expect(routeSource("trending.tsx")).toContain("aria-pressed={active}");
+  it("advertise tier tiles expose aria-pressed for the selected plan", () => {
+    // Trending category filters moved to FilterChip radiogroup (#5636); advertise
+    // still uses the two-state aria-pressed toggle pattern from #5476.
     expect(routeSource("advertise.tsx")).toContain(
       "aria-pressed={planId === p.id}",
     );

--- a/tests/trending-category-filter-a11y.test.ts
+++ b/tests/trending-category-filter-a11y.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// /trending category chips were plain aria-pressed buttons; /browse already uses
+// FilterChipGroup/FilterChip radiogroup for the same control — pin the parity (#5636).
+describe("/trending category filter radiogroup (#5636)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/trending.tsx"),
+    "utf8",
+  );
+
+  it("imports FilterChipGroup and FilterChip", () => {
+    expect(source).toContain(
+      'import { FilterChip, FilterChipGroup } from "@/components/filter-chip";',
+    );
+  });
+
+  it("renders category filters as a single-select radiogroup", () => {
+    expect(source).toContain(
+      'FilterChipGroup label="Filter by category" multi={false}',
+    );
+    expect(source).toContain('role="radio"');
+    expect(source).not.toContain("aria-pressed={!sp.category}");
+    expect(source).not.toContain("aria-pressed={active}");
+  });
+
+  it("preserves category filter analytics tracking", () => {
+    expect(source).toContain("trackCategoryFilter(");
+    expect(source).toContain('set({ category: active ? "" : category.id })');
+  });
+});


### PR DESCRIPTION
## Summary

- Replace `/trending` category filter plain `aria-pressed` buttons with `FilterChipGroup` / `FilterChip` `role="radio"` components (same pattern as `/browse`).
- Update `tests/toggle-aria-pressed.test.ts` — trending intentionally left the `aria-pressed` reference set per #5636; only `advertise.tsx` remains pinned there.
- Add `tests/trending-category-filter-a11y.test.ts` regression coverage.

Closes #5636

## Note

Replacement for #5666 (auto-closed: `toggle-aria-pressed.test.ts` still expected `trending.tsx` to use `aria-pressed={active}`).

## Validation

- [x] `vitest run tests/trending-category-filter-a11y.test.ts tests/toggle-aria-pressed.test.ts`
- [x] `prettier --check`
- [ ] CI / coverage