### PR TITLE
chore(superagent): add Superagent config with contributor-trust disabled

### DIFF
--- a/.github/superagent.yml
+++ b/.github/superagent.yml
@@ -1,0 +1,24 @@
+# Superagent (https://superagent.sh) GitHub App configuration — PR security scanning + contributor trust
+# scoring. All fields are optional; anything omitted falls back to Superagent's own defaults.
+prScan:
+  enabled: true
+
+# Contributor-trust scoring is DISABLED (2026-07-29), matching JSONbored/loopover and JSONbored/metagraphed.
+#
+# It does not discriminate on these repos: established repeat contributors with dozens of merged PRs were
+# scored "dangerous" (10/100) on volume and velocity alone. The `trustedAuthors` allowlist that used to sit
+# here was meant to fix exactly that and did NOT work -- a listed author was still flagged
+# `action_required` -- so it has been dropped rather than carried along inert and misleading.
+#
+# The verdict also has no consumer any more: LoopOver lists this check under `gate.ignoredCheckRuns`
+# (loopover#9813) on all three gate repos, so a non-passing result no longer gates, pends, or holds
+# anything. Leaving it enabled would only produce a permanently red check on contributor PRs that nothing
+# acts on -- noise that makes good contributors think they have failed something.
+#
+# The SECURITY SCAN above stays enabled and still gates CI normally: that is the protection worth having,
+# and it is a different check from the same app.
+contributorTrust:
+  enabled: false
+
+comments:
+  mode: detailed


### PR DESCRIPTION
Completes the set with JSONbored/loopover#9818 and JSONbored/metagraphed#8684 — all three gate repos now carry the same Superagent configuration.

## Why this repo needs a *new* file

Unlike the other two, awesome-claude had **no `.github/superagent.yml` at all**, so the app was running on Superagent's own defaults — including contributor-trust scoring, with no repo-level way to turn it off.

## What it sets

- **`prScan: enabled`** — the Superagent Security Scan keeps gating CI. That's the protection worth having.
- **`contributorTrust: enabled: false`** — it doesn't discriminate on these repos: established repeat contributors with dozens of merged PRs were scored "dangerous" (10/100) on volume and velocity alone.

`trustedAuthors` is deliberately **not** carried over. The other two repos had it, it was added to solve exactly this problem, and it provably does not work — a listed author (`shin-core`) was still flagged `action_required` on loopover#9816. An allowlist that doesn't allow is worse than none: it looks handled while every affected PR still stalls. Better omitted than kept inert and misleading.

## Layering

LoopOver already lists this check under `gate.ignoredCheckRuns` (loopover#9813) on all three gate repos, so a non-passing result no longer gates, pends, or holds anything regardless. This removes the noise at the source; the ignore stays as defence-in-depth.