### PR TITLE
fix(web): exclude self-referential githubUrl from sourceUrl

### DIFF
--- a/apps/web/src/lib/entry-normalize-lib.ts
+++ b/apps/web/src/lib/entry-normalize-lib.ts
@@ -455,7 +455,15 @@ export function buildEntryFromRegistry(entry: RegistryEntry, attribution: EntryA
     fullCopy: copyPayload,
     usageSnippet: entry.usageSnippet,
     copySnippet: entry.copySnippet,
-    sourceUrl: entry.repoUrl ?? entry.githubUrl ?? entry.documentationUrl ?? entry.websiteUrl,
+    // Match inferSource: the always-present directory githubUrl is not real
+    // external provenance and must not satisfy Boolean(entry.sourceUrl) gates.
+    sourceUrl:
+      entry.repoUrl ??
+      (entry.githubUrl && !String(entry.githubUrl).includes("github.com/JSONbored/awesome-claude")
+        ? entry.githubUrl
+        : undefined) ??
+      entry.documentationUrl ??
+      entry.websiteUrl,
     docsUrl: entry.documentationUrl,
     repoUrl: entry.repoUrl ?? undefined,
     websiteUrl: entry.websiteUrl,

--- a/tests/entry-normalize-lib.test.ts
+++ b/tests/entry-normalize-lib.test.ts
@@ -684,4 +684,26 @@ describe("buildEntryFromRegistry", () => {
     );
     expect(withDocs.sourceUrl).toBe("https://docs.example.com/guide");
   });
+
+  it("does not set sourceUrl from a self-referential directory githubUrl (#5671)", () => {
+    const entry = buildEntryFromRegistry(
+      baseEntry({
+        githubUrl:
+          "https://github.com/JSONbored/awesome-claude/blob/main/content/skills/fixture-skill.mdx",
+      }),
+      attribution(),
+    );
+    expect(entry.sourceUrl).toBeUndefined();
+    expect(entry.source).toBe("unverified");
+  });
+
+  it("still uses a real external githubUrl for sourceUrl (#5671)", () => {
+    const entry = buildEntryFromRegistry(
+      baseEntry({
+        githubUrl: "https://github.com/example/real-repo",
+      }),
+      attribution(),
+    );
+    expect(entry.sourceUrl).toBe("https://github.com/example/real-repo");
+  });
 });


### PR DESCRIPTION
## Summary
- `buildEntryFromRegistry` now skips self-referential `github.com/JSONbored/awesome-claude` `githubUrl` values when resolving `sourceUrl`, matching `inferSource`.
- Before: unverified entry with only directory `githubUrl` → `sourceUrl` = that self-link (`Boolean(sourceUrl)` always true).
- After: same entry → `sourceUrl` undefined / `source: \"unverified\"`.
- External `githubUrl` / `repoUrl` / docs / website fallbacks unchanged.
- Spot-check: `Boolean(entry.sourceUrl)` gates in browse/compare/detail decision surfaces and trust `Repository` / command-center `Source repository` links now correctly treat self-link-only entries as missing source.

Closes #5671

## Test plan
- [x] `pnpm exec vitest run tests/entry-normalize-lib.test.ts`
- [ ] `pnpm build`