### PR TITLE
fix(registry): reject reserved GitHub handles in public contact

### DIFF
--- a/packages/registry/src/source-repo.d.ts
+++ b/packages/registry/src/source-repo.d.ts
@@ -1,3 +1,5 @@
+export const RESERVED_OWNERS: ReadonlySet<string>;
+
 export function parseGitHubRepoUrl(value: unknown): {
   host: string;
   owner: string;

--- a/packages/registry/src/source-repo.js
+++ b/packages/registry/src/source-repo.js
@@ -5,4 +5,4 @@
  * that surface so existing `@heyclaude/registry/source-repo` imports stay
  * unchanged.
  */
-export { parseGitHubRepoUrl } from "./source-repo-lib.js";
+export { parseGitHubRepoUrl, RESERVED_OWNERS } from "./source-repo-lib.js";

--- a/packages/registry/src/submission-lib.js
+++ b/packages/registry/src/submission-lib.js
@@ -10,6 +10,7 @@
  */
 import categorySpec from "./category-spec.json" with { type: "json" };
 import { normalizeBrandDomain } from "./brand-assets.js";
+import { RESERVED_OWNERS } from "./source-repo.js";
 import {
   hasAffiliateParam,
   isLikelyAffiliateUrl,
@@ -723,6 +724,8 @@ function isValidPublicContact(value) {
     handle.length <= 39 &&
     !handle.startsWith("-") &&
     !handle.endsWith("-") &&
+    // Parity with isPublicGitHubProfileUrl / MCP isGitHubHandle (#5562 / #5683).
+    !RESERVED_OWNERS.has(handle.toLowerCase()) &&
     [...handle].every(
       (char) =>
         (char >= "A" && char <= "Z") ||

--- a/tests/submission-lib.test.ts
+++ b/tests/submission-lib.test.ts
@@ -1198,6 +1198,33 @@ describe("validateSubmission shared guardrails", () => {
     );
   });
 
+  it.each(["sponsors", "features", "marketplace", "pricing", "@sponsors"])(
+    "rejects reserved GitHub product-surface contact handle %j (#5683)",
+    (contact_email) => {
+      const result = validateSubmission({
+        title: "Add MCP Server: Demo",
+        body: buildValidBody({ ...validMcpFields, contact_email }),
+      });
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          "Invalid public contact: use a GitHub handle, GitHub profile URL, or email",
+        ]),
+      );
+    },
+  );
+
+  it("still accepts a genuine non-reserved bare GitHub handle", () => {
+    const result = validateSubmission({
+      title: "Add MCP Server: Demo",
+      body: buildValidBody({ ...validMcpFields, contact_email: "@octocat" }),
+    });
+    expect(result.errors).not.toEqual(
+      expect.arrayContaining([
+        "Invalid public contact: use a GitHub handle, GitHub profile URL, or email",
+      ]),
+    );
+  });
+
   it("rejects GitHub profile contact URLs with embedded userinfo", () => {
     const result = validateSubmission({
       title: "Add MCP Server: Demo",


### PR DESCRIPTION
## Summary
- `isValidPublicContact` bare-handle branch now rejects `RESERVED_OWNERS` (e.g. `sponsors`, `features`, `marketplace`, `pricing`), matching MCP `isGitHubHandle` / #5562.
- Re-exported `RESERVED_OWNERS` from `source-repo.js` for the registry package surface.
- Live path: `submission-preflight` → `validateSubmission` → `isValidPublicContact` now rejects the same reserved handles MCP already rejects.

Closes #5683

## Test plan
- [x] `pnpm exec vitest run tests/submission-lib.test.ts` (392 passed)
- [ ] `pnpm validate:packages`
- [ ] `pnpm build`