### PR TITLE
fix(web): treat blank OG description as absent (#5672)

### DIFF
--- a/apps/web/src/lib/og-query-fields-lib.ts
+++ b/apps/web/src/lib/og-query-fields-lib.ts
@@ -22,9 +22,15 @@ export function resolveOgQueryFields(
 ): OgQueryFields {
   // `URLSearchParams.get` returns "" (not null) for present-but-empty params
   // like `?title=`; `??` would keep the blank. Trim so whitespace-only also
-  // falls back to the documented HeyClaude default (#5555).
+  // falls back to the documented HeyClaude default (#5555). Same empty-string
+  // bypass existed for description until #5672 — treat blank description /
+  // subtitle as absent so the chain description -> subtitle -> siteDescription
+  // still works.
   const title = clampOgText(params.get("title")?.trim() || "HeyClaude", OG_TEXT_LIMITS.title);
-  const rawDescription = params.get("description") ?? params.get("subtitle") ?? siteDescription;
+  const rawDescription =
+    params.get("description")?.trim() ||
+    params.get("subtitle")?.trim() ||
+    siteDescription;
   const description = clampOgText(rawDescription, OG_TEXT_LIMITS.description);
   const eyebrow = clampOgText(params.get("eyebrow")?.trim() || "HeyClaude", OG_TEXT_LIMITS.eyebrow);
   const accent = safeAccent(params.get("accent"));

--- a/tests/og-query-fields-lib.test.ts
+++ b/tests/og-query-fields-lib.test.ts
@@ -58,6 +58,25 @@ describe("resolveOgQueryFields", () => {
     ).toBe("Sub");
   });
 
+  // Regression for #5672: present-but-empty (and whitespace-only) description
+  // must fall through to subtitle / siteDescription the way title/eyebrow
+  // already fall through to HeyClaude (#5555).
+  it.each([
+    [{ description: "" }, "site", "site"],
+    [{ description: "   " }, "site", "site"],
+    [{ description: "", subtitle: "Sub" }, "site", "Sub"],
+    [{ description: "\t  ", subtitle: "Sub" }, "site", "Sub"],
+    [{ description: "", subtitle: "" }, "site", "site"],
+    [{ description: "", subtitle: "   " }, "site", "site"],
+  ] as const)(
+    "falls back empty/whitespace description %j through chain to %s",
+    (init, site, expected) => {
+      expect(resolveOgQueryFields(params(init), site).description).toBe(
+        expected,
+      );
+    },
+  );
+
   it("clamps whitespace and falls back to a safe accent for bad hex", () => {
     expect(
       resolveOgQueryFields(params({ title: "  a   b  " }), "s").title,


### PR DESCRIPTION
## Summary
- Closes #5672
- `resolveOgQueryFields` already treated empty `title`/`eyebrow` as absent (#5555), but `description` still used `??`, so a present-but-blank `?description=` skipped the subtitle/siteDescription fallback.
- Switch description (and subtitle) to the same `trim() ||` chain.

## Test plan
- [x] `pnpm exec vitest run tests/og-query-fields-lib.test.ts` (18 passed)
- [ ] Confirm blank `?description=` falls through to subtitle, then site description
- [ ] Confirm non-blank `?description=` still wins