### PR TITLE
fix(mcp): flag affiliate path segments in submissions (#5687)

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -115,10 +115,17 @@ function isLikelyAffiliateUrl(value) {
     for (const key of url.searchParams.keys()) {
       if (isTrackingQueryKey(key)) return true;
     }
+    // Path-based checks mirror packages/registry/src/source-url-lib.js's
+    // hasAffiliatePath (#5637 / #5687). Keep in sync with that canonical
+    // detector so MCP submission.validate agrees with the private gate.
+    const pathname = url.pathname;
+    if (/\/(referral|affiliate|partners?)(?:\/|$)/i.test(pathname)) {
+      return true;
+    }
+    return /^\/(ref|refer)\/?$/i.test(pathname);
   } catch {
-    return false;
+    return /\b(affiliate|referral|ref=|via=)\b/i.test(trimmed);
   }
-  return false;
 }
 
 function isPublicContact(value) {

--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -234,6 +234,35 @@ describe("submissions-lib spec validation", () => {
     },
   );
 
+  it.each([
+    ["partners", "https://example.com/partners/xyz"],
+    ["referral", "https://example.com/referral/abc"],
+    ["affiliate", "https://example.com/affiliate/link"],
+    ["bare /ref", "https://example.com/ref"],
+    ["bare /refer", "https://example.com/refer"],
+  ])(
+    "flags docs_url with affiliate path segment %s (#5687)",
+    (_label, docs_url) => {
+      const result = validateSubmissionDraftFromSpec(submissionSpec, {
+        fields: { ...validMcpFields, docs_url },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.join("\n")).toContain(
+        "Contributor submissions cannot include affiliate/referral URLs",
+      );
+    },
+  );
+
+  it("does not flag docs reference paths as affiliate (#5687)", () => {
+    const result = validateSubmissionDraftFromSpec(submissionSpec, {
+      fields: {
+        ...validMcpFields,
+        docs_url: "https://go.dev/ref/mod",
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
   it("rejects affiliate URLs and invalid capability-pack metadata", () => {
     const affiliateResult = validateSubmissionDraftFromSpec(submissionSpec, {
       fields: {


### PR DESCRIPTION
## Summary
- Closes #5687
- MCP's local `isLikelyAffiliateUrl` only checked query params, so path-based affiliate URLs (`/partners/`, `/referral/`, `/affiliate/`, bare `/ref`/`/refer`) passed `submission.validate` while the registry gate (post-#5637) flagged them.
- Mirror `hasAffiliatePath` so MCP preflight matches the private gate. Docs paths like `go.dev/ref/mod` stay clean.

## Test plan
- [x] `pnpm exec vitest run tests/mcp-submissions-lib.test.ts` (51 passed)
- [ ] Path URLs `/partners/xyz`, `/ref` flag as affiliate
- [ ] Query-param detection unchanged; `/ref/spec` not flagged