### PR TITLE
fix(web): include signal in hashSearch so signal-only searches get distinct alert segments

### DIFF
--- a/apps/web/src/lib/saved-search-hash-lib.ts
+++ b/apps/web/src/lib/saved-search-hash-lib.ts
@@ -15,13 +15,19 @@ function escapeField(value: string | undefined): string {
 
 /**
  * Stable base36 hash of a saved search's identifying fields (query plus the
- * category / trust / source / platform filters). Used to key saved-search alert
- * segments: equal searches hash equally, and differing searches hash
- * differently because each field is delimiter-escaped before joining.
- * Deterministic — no ordering or clock dependence.
+ * category / trust / source / platform / signal filters). Used to key
+ * saved-search alert segments: equal searches hash equally, and differing
+ * searches hash differently because each field is delimiter-escaped before
+ * joining. Deterministic — no ordering or clock dependence.
+ *
+ * `signal` is appended only when set, so two searches differing solely by
+ * trust-signal filter hash differently while searches with no signal keep their
+ * existing hash (no alert-segment churn / migration).
  */
 export function hashSearch(s: SavedSearch): string {
-  const raw = [s.q, s.category, s.trust, s.source, s.platform].map(escapeField).join("|");
+  const fields = [s.q, s.category, s.trust, s.source, s.platform];
+  if (s.signal) fields.push(s.signal);
+  const raw = fields.map(escapeField).join("|");
   let h = 0;
   for (let i = 0; i < raw.length; i++) h = (h * 31 + raw.charCodeAt(i)) | 0;
   return Math.abs(h).toString(36);

--- a/tests/saved-search-hash-lib.test.ts
+++ b/tests/saved-search-hash-lib.test.ts
@@ -41,6 +41,27 @@ describe("hashSearch", () => {
       ),
     );
   });
+
+  it("distinguishes two searches that differ only by signal", () => {
+    const base = { q: "mcp", category: "mcp", trust: "trusted" };
+    expect(hashSearch(search({ ...base, signal: "reviewed" }))).not.toBe(
+      hashSearch(search({ ...base, signal: "checksums" })),
+    );
+  });
+
+  it("differs when a signal filter is added to a signal-less search", () => {
+    expect(hashSearch(search({ q: "x" }))).not.toBe(
+      hashSearch(search({ q: "x", signal: "checksums" })),
+    );
+  });
+
+  it("leaves the hash unchanged for searches with no signal set", () => {
+    // Appending signal is conditional, so an absent signal keeps the existing
+    // alert-segment key (matches the "7l9kg2" fixture below).
+    expect(hashSearch(search({ q: "x", trust: "trusted" }))).toBe(
+      hashSearch(search({ q: "x", trust: "trusted", signal: undefined })),
+    );
+  });
 });
 
 describe("hashSearch delimiter escaping", () => {


### PR DESCRIPTION
Closes #5674

## Root cause

`apps/web/src/lib/saved-search-hash-lib.ts` hashed `[s.q, s.category, s.trust, s.source, s.platform]` but **omitted `signal`** — unlike the three sibling serializers (`saved-search-feed-url-lib.ts`, `saved-search-nav-lib.ts`, `saved-search-query-lib.ts`) that already treat it as first-class. Two saved searches identical except for their trust-signal filter (e.g. same query/category, one `reviewed` vs one `checksums`) therefore hashed identically and merged onto the same `saved-search:<hash>` alert segment, cross-contaminating alert emails between two searches the user deliberately kept distinct.

This is a distinct root cause from #5273 (delimiter escaping in the same function) — escaping can't help a field that is never part of the hashed input.

## Fix

Append `s.signal` to the hashed field list **only when it is set**:

```ts
const fields = [s.q, s.category, s.trust, s.source, s.platform];
if (s.signal) fields.push(s.signal);
const raw = fields.map(escapeField).join("|");
```

- Two searches differing solely by `signal` → different hashes.
- Searches with **no** `signal` → byte-identical input to before, so their hash (and existing alert-segment key) is unchanged.

## Hash-stability note (per acceptance criteria)

Existing hashes for searches with no `signal` set are **unaffected** — appending is conditional, so absent/undefined `signal` produces the same input string as today. The existing `"7l9kg2"` stability fixture still passes, and I added an explicit test that `signal: undefined` hashes identically to omitting it.

## Acceptance criteria

- ✅ Two searches identical except for `signal` produce different hashes (new test).
- ✅ No churn for signal-less searches (`"7l9kg2"` fixture unchanged + explicit undefined-signal test).
- ✅ `Closes #5674`.

## Quality evidence

**No visual impact** — pure hashing-logic fix in a `.ts` lib.

## Validation

- `pnpm exec vitest run tests/saved-search-hash-lib.test.ts` → 12/12 pass
- `pnpm build` → succeeds
- `git diff --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)