### PR TITLE
fix(web): add og:url to compare index page (#5679)

### DIFF
--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -113,6 +113,7 @@ export const Route = createFileRoute("/compare/")({
         property: "og:description",
         content: "Side-by-side comparison of Claude workflow resources.",
       },
+      { property: "og:url", content: absoluteUrl("/compare") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/compare") }],
     scripts: [

--- a/tests/compare-index-og-url.test.ts
+++ b/tests/compare-index-og-url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+describe("/compare index og:url (#5679)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/compare.index.tsx"),
+    "utf8",
+  );
+
+  it("emits og:url pointing at the compare canonical path", () => {
+    expect(source).toContain(
+      '{ property: "og:url", content: absoluteUrl("/compare") }',
+    );
+    expect(source).toContain(
+      '{ rel: "canonical", href: absoluteUrl("/compare") }',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5679
- `/compare` was the only hub index missing `og:url`; every sibling sets it explicitly.
- Add `{ property: \"og:url\", content: absoluteUrl(\"/compare\") }` next to the existing title/description meta.

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/compare-index-og-url.test.ts`
- [ ] Confirm `/compare` head includes `og:url` matching the canonical