### PR TITLE
fix(mcp): recognize antigravity in platform alias maps

### DIFF
--- a/packages/mcp/src/registry-normalize-lib.js
+++ b/packages/mcp/src/registry-normalize-lib.js
@@ -28,6 +28,7 @@ const platformAliases = new Map([
   ["agents", "cli"],
   ["agents-context", "cli"],
   ["agents-md", "cli"],
+  ["antigravity", "antigravity"],
 ]);
 
 export function normalizeText(value) {

--- a/packages/mcp/src/search-ranking-lib.js
+++ b/packages/mcp/src/search-ranking-lib.js
@@ -53,6 +53,7 @@ const PLATFORM_ALIASES = new Map([
   ["agents", "cli"],
   ["agents-context", "cli"],
   ["agents-md", "cli"],
+  ["antigravity", "antigravity"],
 ]);
 
 const QUERY_INTENT_PROFILES = [

--- a/tests/mcp-registry-normalize-lib.test.ts
+++ b/tests/mcp-registry-normalize-lib.test.ts
@@ -35,8 +35,8 @@ describe("registry-normalize-lib platform aliases", () => {
     expect(normalizePlatform("   ")).toBe("");
   });
 
-  it("returns empty string for unrecognized platforms instead of leaking raw input", () => {
-    expect(normalizePlatform("Antigravity")).toBe("");
+  it("resolves antigravity and rejects unrecognized platforms (#5685)", () => {
+    expect(normalizePlatform("Antigravity")).toBe("antigravity");
     expect(normalizePlatform("Cluade Code")).toBe("");
   });
 });

--- a/tests/mcp-search-ranking-lib.test.ts
+++ b/tests/mcp-search-ranking-lib.test.ts
@@ -63,6 +63,7 @@ describe("search-ranking-lib platform and haystack helpers", () => {
   it("normalizes platform aliases", () => {
     expect(normalizeRegistryPlatform("claude")).toBe("claude-code");
     expect(normalizeRegistryPlatform("cursor-rules")).toBe("cursor");
+    expect(normalizeRegistryPlatform("antigravity")).toBe("antigravity");
     expect(normalizeRegistryPlatform("unknown-platform")).toBe("");
     expect(normalizeRegistryPlatform("Cluade Code")).toBe("");
   });


### PR DESCRIPTION
## Summary
- Added `[\"antigravity\", \"antigravity\"]` to both MCP platform alias maps (`registry-normalize-lib` and `search-ranking-lib`).
- `normalizePlatform(\"Antigravity\")` / `normalizeRegistryPlatform(\"antigravity\")` now resolve to `\"antigravity\"` instead of `\"\"`.
- Before: `entry.compare` / `entry.safety` / `entry.coverage` / `install.guidance` with `platform: \"antigravity\"` could not match an existing `platformCompatibility` row. After: alias match finds the native-mcp row.

Closes #5685

## Test plan
- [x] `pnpm exec vitest run tests/mcp-registry-normalize-lib.test.ts tests/mcp-search-ranking-lib.test.ts`
- [ ] `pnpm test:mcp`