### PR TITLE
fix(web): share one empty-feed lastBuilt fallback so feed health matches the body

### DIFF
--- a/apps/web/src/lib/feed-items-lib.ts
+++ b/apps/web/src/lib/feed-items-lib.ts
@@ -2,6 +2,8 @@
 // request origin and derive the feed's last-built timestamp. Split out so the
 // link handling and empty-feed fallback can be unit-tested without the route.
 
+import { EMPTY_FEED_LAST_BUILT } from "@/lib/feeds-lib";
+
 /** Prefix each relative item link with the base origin; absolute links pass through. */
 export function absolutizeFeedLinks<T extends { link: string }>(items: T[], base: string): T[] {
   return items.map((item) =>
@@ -9,8 +11,9 @@ export function absolutizeFeedLinks<T extends { link: string }>(items: T[], base
   );
 }
 
-/** The newest item's pubDate, or the epoch ISO string for an empty feed. */
+/** The newest item's pubDate, or the shared empty-feed fallback (so the health
+ *  `lastBuilt` agrees with the RSS/Atom body's `lastBuildDate`) for an empty feed. */
 export function feedLastBuilt(items: Array<{ pubDate: string }>): string {
-  if (items.length === 0) return new Date(0).toISOString();
+  if (items.length === 0) return EMPTY_FEED_LAST_BUILT;
   return items.reduce((acc, item) => (item.pubDate > acc ? item.pubDate : acc), items[0].pubDate);
 }

--- a/apps/web/src/lib/feeds-lib.ts
+++ b/apps/web/src/lib/feeds-lib.ts
@@ -53,11 +53,18 @@ export function rfc822(iso: string): string {
 }
 
 /**
+ * Shared fallback `lastBuildDate`/`lastBuilt` for an empty feed. One constant so
+ * the RSS/Atom body, `feedLastBuilt`, and the reported `FeedHealth.lastBuilt`
+ * all agree for a feed with no items (instead of independently hardcoded epochs).
+ */
+export const EMPTY_FEED_LAST_BUILT = "2025-01-01T00:00:00.000Z";
+
+/**
  * The newest `pubDate` across items, used as a deterministic build timestamp.
  * Falls back to a fixed epoch-ish date when the feed has no items so the body
  * (and therefore its ETag) stays stable.
  */
-export function latestPubDate(items: FeedItem[], fallback = "2025-01-01T00:00:00.000Z"): string {
+export function latestPubDate(items: FeedItem[], fallback = EMPTY_FEED_LAST_BUILT): string {
   if (items.length === 0) return fallback;
   return items.reduce((acc, i) => (i.pubDate > acc ? i.pubDate : acc), items[0].pubDate);
 }

--- a/apps/web/src/lib/feeds.ts
+++ b/apps/web/src/lib/feeds.ts
@@ -21,6 +21,7 @@ import {
   buildRss,
   categoryItems,
   changelogStreamItems,
+  EMPTY_FEED_LAST_BUILT,
   type FeedItem,
   latestPubDate,
   SITE_NAME,
@@ -130,7 +131,7 @@ async function healthFor(
     url,
     itemCount: items.length,
     latestItemAt: latest,
-    lastBuilt: latest ?? new Date(0).toISOString(),
+    lastBuilt: latest ?? EMPTY_FEED_LAST_BUILT,
     etag: await etagFor(body),
     isCurrent: isFeedCurrent(latest, Date.now()),
   };

--- a/tests/feed-items-lib.test.ts
+++ b/tests/feed-items-lib.test.ts
@@ -4,6 +4,12 @@ import {
   absolutizeFeedLinks,
   feedLastBuilt,
 } from "../apps/web/src/lib/feed-items-lib";
+import {
+  buildRss,
+  EMPTY_FEED_LAST_BUILT,
+  latestPubDate,
+  rfc822,
+} from "../apps/web/src/lib/feeds-lib";
 
 describe("absolutizeFeedLinks", () => {
   it("prefixes relative links with the base and preserves other fields", () => {
@@ -44,7 +50,23 @@ describe("feedLastBuilt", () => {
     ).toBe("2026-02-02");
   });
 
-  it("falls back to the epoch ISO string for an empty feed", () => {
-    expect(feedLastBuilt([])).toBe(new Date(0).toISOString());
+  it("falls back to the shared empty-feed timestamp for an empty feed", () => {
+    expect(feedLastBuilt([])).toBe(EMPTY_FEED_LAST_BUILT);
+  });
+
+  it("agrees with the empty feed's own <lastBuildDate> and latestPubDate fallback", () => {
+    // Regression for #5676: the route-level feedLastBuilt fallback and the RSS
+    // body's internal latestPubDate default must be the same instant, so the
+    // reported FeedHealth.lastBuilt matches the <lastBuildDate> in the body.
+    const built = feedLastBuilt([]);
+    expect(built).toBe(latestPubDate([]));
+    const body = buildRss({
+      title: "Empty",
+      description: "Empty feed",
+      link: "https://heyclau.de",
+      selfLink: "https://heyclau.de/feeds/changelog-policy.xml",
+      items: [],
+    });
+    expect(body).toContain(`<lastBuildDate>${rfc822(built)}</lastBuildDate>`);
   });
 });


### PR DESCRIPTION
Closes #5676

## Root cause

For an empty feed, three "newest-pubDate-or-fallback" helpers used **different** hardcoded fallbacks:

- `feeds-lib.ts` `latestPubDate` → `"2025-01-01T00:00:00.000Z"` (this is what `buildRss`/`buildAtom` embed as `<lastBuildDate>` when no explicit `lastBuilt` is passed).
- `feed-items-lib.ts` `feedLastBuilt` → `new Date(0)` (1970).
- `feeds.ts` `healthFor` → `new Date(0)` (1970).

So `/feeds/changelog-policy.xml` and `/feeds/changelog-security.xml` (whose `changelogStreamItems` return `[]` today) reported `FeedHealth.lastBuilt = 1970-01-01` while the RSS body's own `<lastBuildDate>` said `2025-01-01` — a live, observable disagreement.

## Fix

Introduce one shared constant and use it everywhere the empty-feed fallback is needed:

```ts
export const EMPTY_FEED_LAST_BUILT = "2025-01-01T00:00:00.000Z";
```

- `latestPubDate(items, fallback = EMPTY_FEED_LAST_BUILT)` (same value as before → no change to existing body output).
- `feedLastBuilt([])` → `EMPTY_FEED_LAST_BUILT` (was 1970).
- `healthFor` → `latest ?? EMPTY_FEED_LAST_BUILT` (was 1970).

Now an empty feed's reported `lastBuilt` always equals the `<lastBuildDate>` in the body it describes.

## Acceptance criteria

- ✅ For an empty feed, `FeedHealth.lastBuilt` matches the RSS body's `<lastBuildDate>` (new test asserts `feedLastBuilt([]) === latestPubDate([])` and that the empty-feed body embeds that instant).
- ✅ Non-empty feeds unaffected — the newest `pubDate` still wins; only the empty-feed fallback changed, and `latestPubDate`'s value is unchanged.
- ✅ `Closes #5676`.

## Quality evidence

**No visual impact** — feed-metadata-only fix in `.ts` libs. `apps/web/src/data/changelog.ts` (the `stream` content) is left untouched per the issue's out-of-scope note.

## Validation

- `pnpm exec vitest run tests/feed-items-lib.test.ts tests/feeds-lib.test.ts tests/feeds.test.ts` → 60/60 pass
- `pnpm type-check` clean; `pnpm build` succeeds; `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)