### PR TITLE
fix(mcp): count commandSyntax in entryInstallComplexity

### DIFF
--- a/packages/mcp/src/registry-asset-lib.js
+++ b/packages/mcp/src/registry-asset-lib.js
@@ -83,7 +83,7 @@ export function categoryPrimaryAsset(entry) {
 
 export function entryInstallComplexity(entry) {
   const pieces = [
-    entry.installCommand,
+    entry.installCommand || entry.commandSyntax,
     entry.configSnippet,
     entry.downloadUrl,
     entry.prerequisites,

--- a/tests/mcp-registry-asset-lib.test.ts
+++ b/tests/mcp-registry-asset-lib.test.ts
@@ -80,6 +80,15 @@ describe("registry-asset-lib install complexity", () => {
       }),
     ).toBe("higher");
   });
+
+  it("counts commandSyntax when installCommand is absent (#5686)", () => {
+    expect(
+      entryInstallComplexity({
+        category: "commands",
+        commandSyntax: "/review-pr --full",
+      }),
+    ).toBe("low");
+  });
 });
 
 describe("registry-asset-lib categoryPrimaryAsset fallbacks", () => {

--- a/tests/mcp-registry-compare-lib.test.ts
+++ b/tests/mcp-registry-compare-lib.test.ts
@@ -8555,3 +8555,30 @@ describe("registry-compare-lib buildCompareEntriesResponse", () => {
     expect(response.entries).toHaveLength(1);
   });
 });
+
+describe("entry.compare installComplexity commandSyntax fallback (#5686)", () => {
+  it("reports low for commands entries that only set commandSyntax", () => {
+    const row = buildCompareEntryRow(
+      makeEntry({
+        category: "commands",
+        slug: "review-pr",
+        installCommand: "",
+        commandSyntax: "/review-pr --full",
+        configSnippet: "",
+        downloadUrl: "",
+        prerequisites: "",
+      }),
+      "",
+      {
+        normalizePlatform,
+        buildSkillPlatformCompatibility,
+        entryInstallComplexity,
+        categoryPrimaryAsset,
+        sourceSummary,
+        entryTrustSummary,
+        entryCanonicalUrl,
+      },
+    );
+    expect(row.installComplexity).toBe("low");
+  });
+});


### PR DESCRIPTION
## Summary
- `entryInstallComplexity` now uses `installCommand || commandSyntax` for its first install signal piece.
- Before: commands entry with only `commandSyntax` → `installComplexity: \"unknown\"` in `entry.compare`.
- After: same entry → `\"low\"`, matching `entry.asset` / `install.guidance` / `registry.plan`.

Closes #5686

## Test plan
- [x] `pnpm exec vitest run tests/mcp-registry-asset-lib.test.ts tests/mcp-registry-compare-lib.test.ts` (592 passed)
- [ ] `pnpm test:mcp`