### PR TITLE
fix(web): announce saved-search alert save to screen readers (#5678)

### DIFF
--- a/apps/web/src/components/saved-search-manager.tsx
+++ b/apps/web/src/components/saved-search-manager.tsx
@@ -460,6 +460,8 @@ export function SavedSearchManager({ open, onOpenChange, trigger }: ManagerProps
                   )}
                   {msg?.id === s.id && (
                     <p
+                      role="status"
+                      aria-live="polite"
                       className={cn(
                         "text-[11px]",
                         msg.ok ? "text-trust-trusted" : "text-trust-blocked",

--- a/tests/saved-search-alerts-a11y.test.ts
+++ b/tests/saved-search-alerts-a11y.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+describe("saved-search alerts save announcement (#5678)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/components/saved-search-manager.tsx"),
+    "utf8",
+  );
+
+  it("announces save-alerts result via a polite live region", () => {
+    expect(source).toContain('role="status"');
+    expect(source).toContain('aria-live="polite"');
+    expect(source).toContain("{msg.text}");
+    expect(source).toContain("Alerts saved · email confirmed.");
+    expect(source).toContain("Saved locally, but:");
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5678
- Save-alerts feedback was a bare `<p>{msg.text}</p>` with no live region, while delete already announces via `toast()`.
- Add `role=\"status\" aria-live=\"polite\"` so success and `Saved locally, but: .` paths are announced. No visual change.

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/saved-search-alerts-a11y.test.ts`
- [ ] Confirm status live region present on save-alerts message