### PR TITLE
fix(web): add BreadcrumbList and ItemList JSON-LD to /brief (#5680)

### DIFF
--- a/apps/web/src/lib/brief-jsonld-lib.ts
+++ b/apps/web/src/lib/brief-jsonld-lib.ts
@@ -1,0 +1,28 @@
+// Pure builder for the Weekly Brief archive page's schema.org ItemList of
+// Articles, split out of the route head() so mapping can be unit-tested
+// without rendering the route (mirrors changelog-jsonld-lib.ts).
+
+type BriefIssueLike = {
+  title: string;
+  date: string;
+  summary: string;
+};
+
+/** schema.org ItemList JSON-LD of Articles for the Weekly Brief archive. */
+export function briefItemListJsonLd(issues: BriefIssueLike[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "HeyClaude Weekly Brief archive",
+    itemListElement: issues.map((issue, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      item: {
+        "@type": "Article",
+        headline: issue.title,
+        datePublished: issue.date,
+        description: issue.summary,
+      },
+    })),
+  };
+}

--- a/apps/web/src/routes/brief.tsx
+++ b/apps/web/src/routes/brief.tsx
@@ -20,6 +20,9 @@ import {
   type BriefHubSectionId,
 } from "@/lib/brief-entry-cta-events";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { briefItemListJsonLd } from "@/lib/brief-jsonld-lib";
 
 type PublishedBriefSummary = { number: number; periodThrough: string; title: string };
 
@@ -57,6 +60,13 @@ export const Route = createFileRoute("/brief")({
       { property: "og:url", content: absoluteUrl("/brief") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/brief") }],
+    scripts: [
+      breadcrumbScript([{ name: "Weekly Brief", path: "/brief" }]),
+      {
+        type: "application/ld+json",
+        children: stringifyJsonLd(briefItemListJsonLd(BRIEF_ISSUES)),
+      },
+    ],
   }),
   component: BriefPage,
 });

--- a/tests/brief-jsonld-lib.test.ts
+++ b/tests/brief-jsonld-lib.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { briefItemListJsonLd } from "../apps/web/src/lib/brief-jsonld-lib";
+import { repoRoot } from "./helpers/registry-fixtures";
+
+describe("briefItemListJsonLd (#5680)", () => {
+  it("builds an ItemList named for the Weekly Brief archive", () => {
+    const ld = briefItemListJsonLd([]);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("HeyClaude Weekly Brief archive");
+    expect(ld.itemListElement).toEqual([]);
+  });
+
+  it("maps issues to positioned Articles", () => {
+    const ld = briefItemListJsonLd([
+      {
+        title: "Issue one",
+        date: "2026-01-01",
+        summary: "first summary",
+      },
+      {
+        title: "Issue two",
+        date: "2026-01-08",
+        summary: "second summary",
+      },
+    ]);
+    expect(ld.itemListElement.map((i) => i.position)).toEqual([1, 2]);
+    expect(ld.itemListElement[0].item).toMatchObject({
+      "@type": "Article",
+      headline: "Issue one",
+      datePublished: "2026-01-01",
+      description: "first summary",
+    });
+  });
+});
+
+describe("/brief archive JSON-LD scripts (#5680)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/brief.tsx"),
+    "utf8",
+  );
+
+  it("emits BreadcrumbList and ItemList scripts from head()", () => {
+    expect(source).toContain("breadcrumbScript([");
+    expect(source).toContain('{ name: "Weekly Brief", path: "/brief" }');
+    expect(source).toContain("briefItemListJsonLd(BRIEF_ISSUES)");
+    expect(source).toContain('type: "application/ld+json"');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5680
- `/brief` rendered breadcrumbs and a dated archive list but emitted no JSON-LD, unlike `/changelog` and `/brief/$number`.
- Add `breadcrumbScript` plus `briefItemListJsonLd(BRIEF_ISSUES)` (mirrors `changelog-jsonld-lib`).

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/brief-jsonld-lib.test.ts`
- [ ] Confirm `/brief` head includes BreadcrumbList + ItemList scripts