### PR TITLE
fix(web): align entry WebPage dateModified with sitemap freshness (#5675)

### DIFF
--- a/apps/web/src/lib/entry-webpage-jsonld-lib.ts
+++ b/apps/web/src/lib/entry-webpage-jsonld-lib.ts
@@ -3,9 +3,29 @@
 // isBasedOn) can be unit-tested without rendering the route.
 
 import type { Entry } from "@/types/registry";
+import { sitemapEntryLastModified } from "@/lib/sitemap-policy";
+
+type EntryWebPageFreshness = {
+  contentUpdatedAt?: string | null;
+  repoUpdatedAt?: string | null;
+  verifiedAt?: string | null;
+};
 
 /** schema.org WebPage JSON-LD for an entry at the given absolute url. */
-export function entryWebPageJsonLd(entry: Entry, url: string) {
+export function entryWebPageJsonLd(entry: Entry & EntryWebPageFreshness, url: string) {
+  // Prefer content/repo freshness (same priority as sitemap lastmod / #5472),
+  // then reviewedAt, then dateAdded — so dateModified stays at least as fresh
+  // as the sitemap for the same URL (#5675).
+  const dateModified =
+    sitemapEntryLastModified({
+      contentUpdatedAt: entry.contentUpdatedAt,
+      repoUpdatedAt: entry.repoUpdatedAt,
+      verifiedAt: entry.verifiedAt || entry.reviewedAt,
+      dateAdded: entry.dateAdded,
+    })?.toISOString() ??
+    entry.reviewedAt ??
+    entry.dateAdded;
+
   return {
     "@context": "https://schema.org",
     "@type": "WebPage",
@@ -13,7 +33,7 @@ export function entryWebPageJsonLd(entry: Entry, url: string) {
     description: entry.description,
     url,
     datePublished: entry.dateAdded,
-    dateModified: entry.reviewedAt ?? entry.dateAdded,
+    dateModified,
     about: entry.category,
     author: { "@type": "Person", name: entry.author },
     ...(entry.sourceUrl ? { isBasedOn: entry.sourceUrl } : {}),

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { getEntry, related, relatedGroups, relatedGuides } from "@/data/search";
 import { getEntryRedirectTarget } from "@/lib/entry-redirects";
-import { BEST_LISTS, ENTRIES } from "@/data/entries";
+import { BEST_LISTS, ENTRIES, REGISTRY_ENTRIES } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
 import { EntryAuthorAttribution } from "@/components/contributor-attribution";
 import { findContributorForIdentity } from "@/data/contributors";
@@ -234,7 +234,21 @@ export const Route = createFileRoute("/entry/$category/$slug")({
     const e = loaderData.entry;
     const path = `/entry/${params.category}/${params.slug}`;
     const url = absoluteUrl(path);
-    const ld = entryWebPageJsonLd(e, url);
+    // contentUpdatedAt/repoUpdatedAt live on the raw registry snapshot only
+    // (buildEntry drops them); look up the sibling the way sitemap.xml does
+    // so WebPage dateModified matches sitemap lastmod (#5675).
+    const raw = REGISTRY_ENTRIES.find(
+      (entry) => entry.category === e.category && entry.slug === e.slug,
+    );
+    const ld = entryWebPageJsonLd(
+      {
+        ...e,
+        contentUpdatedAt: raw?.contentUpdatedAt,
+        repoUpdatedAt: raw?.repoUpdatedAt,
+        verifiedAt: raw?.verifiedAt,
+      },
+      url,
+    );
     const breadcrumbs = entryBreadcrumbJsonLd(e, url, absoluteUrl);
     const ogUrl = absoluteUrl(`/og/${params.category}/${params.slug}`);
     const ogTitle = `${e.title} — HeyClaude`;

--- a/tests/entry-webpage-jsonld-lib.test.ts
+++ b/tests/entry-webpage-jsonld-lib.test.ts
@@ -26,10 +26,34 @@ describe("entryWebPageJsonLd", () => {
   });
 
   it("falls back dateModified to dateAdded, or uses reviewedAt when present", () => {
-    expect(entryWebPageJsonLd(entry(), URL).dateModified).toBe("2026-01-01");
+    expect(entryWebPageJsonLd(entry(), URL).dateModified).toBe(
+      new Date("2026-01-01").toISOString(),
+    );
     expect(
       entryWebPageJsonLd(entry({ reviewedAt: "2026-02-02" }), URL).dateModified,
-    ).toBe("2026-02-02");
+    ).toBe(new Date("2026-02-02").toISOString());
+  });
+
+  it("prefers contentUpdatedAt/repoUpdatedAt over reviewedAt like the sitemap (#5675)", () => {
+    expect(
+      entryWebPageJsonLd(
+        entry({
+          reviewedAt: "2026-02-02",
+          repoUpdatedAt: "2026-03-15T12:00:00.000Z",
+        }),
+        URL,
+      ).dateModified,
+    ).toBe(new Date("2026-03-15T12:00:00.000Z").toISOString());
+    expect(
+      entryWebPageJsonLd(
+        entry({
+          reviewedAt: "2026-02-02",
+          contentUpdatedAt: "2026-04-01T00:00:00.000Z",
+          repoUpdatedAt: "2026-03-15T12:00:00.000Z",
+        }),
+        URL,
+      ).dateModified,
+    ).toBe(new Date("2026-04-01T00:00:00.000Z").toISOString());
   });
 
   it("includes isBasedOn only when sourceUrl is present", () => {


### PR DESCRIPTION
## Summary
- Closes #5675
- Entry WebPage JSON-LD `dateModified` only saw `reviewedAt`/`dateAdded` because `buildEntry` drops `contentUpdatedAt`/`repoUpdatedAt`.
- Look up the raw registry sibling (same as `sitemap.xml`) and reuse `sitemapEntryLastModified` so page `dateModified` matches sitemap `lastmod`.

## Test plan
- [x] `pnpm exec vitest run tests/entry-webpage-jsonld-lib.test.ts`
- [x] Prettier on touched files
- [ ] Confirm newer `repoUpdatedAt` wins over `reviewedAt`