### PR TITLE
fix(registry): restrict one-click MCP stdio to npx/uvx

### DIFF
--- a/packages/registry/src/mcp-install-config-lib.js
+++ b/packages/registry/src/mcp-install-config-lib.js
@@ -19,6 +19,11 @@ export const MCP_INSTALL_TARGET_IDS = [
   "antigravity",
 ];
 
+// One-click install targets only support package runners that fetch a remote
+// package — not arbitrary local binaries/shells. Matches artifacts-lib and
+// Raycast installer allowlists (#5682).
+export const ONE_CLICK_STDIO_COMMANDS = new Set(["npx", "uvx"]);
+
 const SERVER_CONFIG_TYPES = new Set(["stdio", "http", "sse"]);
 
 function isRecord(value) {
@@ -175,9 +180,22 @@ function hasStaticOrEnvHttpHeaders(config) {
   );
 }
 
+function oneClickStdioCommandName(value) {
+  const command = String(value || "").trim();
+  if (!command || command.includes("/") || command.includes("\\")) return "";
+  return command.toLowerCase();
+}
+
+function isOneClickStdioCommand(config) {
+  const type = normalizeType(config?.type);
+  if (type !== "stdio") return true;
+  return ONE_CLICK_STDIO_COMMANDS.has(oneClickStdioCommandName(config.command));
+}
+
 export function mcpConfigSupportsTarget(config, target) {
   const normalized = normalizeMcpServerConfig(config);
   if (!normalized) return false;
+  if (!isOneClickStdioCommand(normalized)) return false;
   const type = normalizeType(normalized.type);
 
   if (target === "codex") {

--- a/packages/registry/src/mcp-install-config.d.ts
+++ b/packages/registry/src/mcp-install-config.d.ts
@@ -15,6 +15,8 @@ export type ResolvedMcpInstallConfig = {
 
 export declare const MCP_INSTALL_TARGET_IDS: readonly McpInstallTargetId[];
 
+export declare const ONE_CLICK_STDIO_COMMANDS: ReadonlySet<string>;
+
 export declare function normalizeMcpServerConfig(
   value: unknown,
 ): McpServerConfig | null;

--- a/packages/registry/src/mcp-install-config.js
+++ b/packages/registry/src/mcp-install-config.js
@@ -7,6 +7,7 @@
  */
 export {
   MCP_INSTALL_TARGET_IDS,
+  ONE_CLICK_STDIO_COMMANDS,
   normalizeMcpServerConfig,
   extractMcpServerConfig,
   mcpConfigSupportsTarget,

--- a/tests/mcp-install-config-lib.test.ts
+++ b/tests/mcp-install-config-lib.test.ts
@@ -446,26 +446,49 @@ describe("resolveMcpInstallConfig", () => {
   });
 
   it("keeps arbitrary stdio commands valid for registry metadata", () => {
-    const resolved = resolveMcpInstallConfig({
-      category: "mcp",
-      slug: "shell-one-liner",
-      configSnippet: JSON.stringify({
-        mcpServers: {
-          shell: {
-            command: "bash",
-            args: ["-lc", "touch /tmp/heyclaude-owned"],
-          },
-        },
-      }),
-    });
-    expect(resolved).toMatchObject({
-      targets: ALL_TARGETS,
-      config: {
-        type: "stdio",
+    // normalize still accepts bash/etc for listing metadata; one-click install
+    // targets do not advertise support for non-npx/uvx commands (#5682).
+    expect(
+      normalizeMcpServerConfig({
         command: "bash",
         args: ["-lc", "touch /tmp/heyclaude-owned"],
-      },
+      }),
+    ).toMatchObject({
+      type: "stdio",
+      command: "bash",
     });
+    expect(
+      mcpInstallTargetsForConfig({
+        command: "bash",
+        args: ["-lc", "touch /tmp/heyclaude-owned"],
+      }),
+    ).toEqual([]);
+    expect(
+      resolveMcpInstallConfig({
+        category: "mcp",
+        slug: "shell-one-liner",
+        configSnippet: JSON.stringify({
+          mcpServers: {
+            shell: {
+              command: "bash",
+              args: ["-lc", "touch /tmp/heyclaude-owned"],
+            },
+          },
+        }),
+      }),
+    ).toBeNull();
+  });
+
+  it("does not advertise one-click targets for path-based stdio commands (#5682)", () => {
+    expect(
+      mcpConfigSupportsTarget(
+        { command: "/usr/bin/node", args: ["server.js"] },
+        "cursor",
+      ),
+    ).toBe(false);
+    expect(
+      mcpInstallTargetsForConfig({ command: "python", args: ["-m", "mcp"] }),
+    ).toEqual([]);
   });
 
   it("allows loopback http urls in install metadata", () => {


### PR DESCRIPTION
## Summary
- `mcpConfigSupportsTarget` / `mcpInstallTargetsForConfig` now require stdio `command` to be `npx` or `uvx` (no path separators), matching artifacts-lib / Raycast.
- Before: `{ command: \"bash\", ... }` advertised all one-click targets. After: no targets / `resolveMcpInstallConfig` returns `null`.
- `normalizeMcpServerConfig` still accepts arbitrary stdio commands for registry metadata.
- Existing consumer local allowlists left in place (out of scope to remove).

Closes #5682

## Test plan
- [x] `pnpm exec vitest run tests/mcp-install-config-lib.test.ts` (33 passed)
- [ ] `pnpm validate:packages`
- [ ] `pnpm build`