### PR TITLE
fix(web): keep command-bar panel controls out of tab order

### DIFF
--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -357,6 +357,9 @@ export function CommandBar({
               <button
                 key={c.id || "all"}
                 type="button"
+                // Combobox keeps focus on the input; these are mouse/pointer
+                // affordances activated via aria-activedescendant + Enter (#5677).
+                tabIndex={-1}
                 onMouseDown={(e) => {
                   e.preventDefault();
                   if (quickCat !== c.id) {
@@ -481,6 +484,7 @@ export function CommandBar({
                 >
                   <button
                     type="button"
+                    tabIndex={-1}
                     onMouseEnter={() => setActive(i)}
                     onMouseDown={(e) => {
                       e.preventDefault();
@@ -506,6 +510,7 @@ export function CommandBar({
           {q.trim() && (
             <button
               type="button"
+              tabIndex={-1}
               onMouseDown={(e) => {
                 e.preventDefault();
                 submit();

--- a/tests/command-bar.test.ts
+++ b/tests/command-bar.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+// ARIA combobox keeps focus on the input; panel buttons are pointer affordances
+// driven via aria-activedescendant + Enter. They must stay out of the tab order
+// so keyboard users are not stranded on onMouseDown-only controls (#5677).
+describe("command-bar keyboard focus model (#5677)", () => {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/components/command-bar.tsx"),
+    "utf8",
+  );
+
+  it("keeps scope pills, action buttons, and footer out of the tab order", () => {
+    const tabIndexNegOne = [...source.matchAll(/tabIndex=\{-1\}/g)];
+    expect(tabIndexNegOne.length).toBeGreaterThanOrEqual(3);
+    expect(source).toMatch(/onMouseDown=\{[\s\S]*?setQuickCat/);
+    expect(source).toMatch(/onMouseDown=\{[\s\S]*?activate\(/);
+    expect(source).toMatch(/onMouseDown=\{[\s\S]*?submit\(/);
+  });
+});


### PR DESCRIPTION
## Summary
- Chose the **roving / combobox** interaction model: focus stays on the search input; panel controls are not Tab stops.
- Added `tabIndex={-1}` to scope pills, action-item buttons, and the \"See all results\" footer button.
- Keyboard activation continues via arrow keys + `aria-activedescendant` + Enter on the input; mouse `onMouseDown` unchanged.

Closes #5677

## Test plan
- [x] `pnpm exec vitest run tests/command-bar.test.ts`
- [ ] Keyboard: open command bar, Tab from input — focus must not land on scope pills/actions/footer; arrows + Enter still activate selection
- [ ] `pnpm build`