### PR TITLE
fix(registry): gate one-click MCP install targets behind an npx/uvx allowlist

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -452,7 +452,12 @@ function buildEntryPlatformNames(entry) {
   );
 
   if (entry.category === "mcp") {
-    const mcpInstallConfig = resolveMcpInstallConfig(entry);
+    // Platform names describe which clients can run the server, so ask the
+    // compatibility question here: a stdio server behind `uv`/`docker`/`python`
+    // still works once configured by hand, it just is not one-click installable.
+    const mcpInstallConfig = resolveMcpInstallConfig(entry, {
+      oneClick: false,
+    });
     for (const target of mcpInstallConfig?.targets ?? []) {
       platforms.add(target);
     }

--- a/packages/registry/src/mcp-install-config-lib.js
+++ b/packages/registry/src/mcp-install-config-lib.js
@@ -21,6 +21,14 @@ export const MCP_INSTALL_TARGET_IDS = [
 
 const SERVER_CONFIG_TYPES = new Set(["stdio", "http", "sse"]);
 
+// A one-click install writes the stdio server entry straight into the user's
+// client config, so whatever `command` names gets executed locally on their
+// machine. Only the two managed package runners are safe to advertise that way.
+// Both real consumers already enforce this same allowlist on top of us -
+// `artifacts-lib.js`'s RAYCAST_ONE_CLICK_STDIO_COMMANDS and the Raycast
+// extension's ONE_CLICK_STDIO_COMMANDS - so keep the sets identical.
+const ONE_CLICK_STDIO_COMMANDS = new Set(["npx", "uvx"]);
+
 function isRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -175,10 +183,31 @@ function hasStaticOrEnvHttpHeaders(config) {
   );
 }
 
-export function mcpConfigSupportsTarget(config, target) {
+// Mirrors the consumers' helper: a bare command name only, so a path-qualified
+// lookalike like /usr/local/bin/npx cannot slip past the allowlist.
+function oneClickStdioCommandName(value) {
+  const command = String(value || "").trim();
+  if (!command || command.includes("/") || command.includes("\\")) return "";
+  return command.toLowerCase();
+}
+
+export function mcpConfigSupportsTarget(config, target, options = {}) {
   const normalized = normalizeMcpServerConfig(config);
   if (!normalized) return false;
   const type = normalizeType(normalized.type);
+
+  // Arbitrary stdio commands stay valid registry metadata (the entry still
+  // renders its own configSnippet) - they are just manual-install only.
+  // `oneClick: false` asks the narrower "can this client run the config at all"
+  // question, so platform-compatibility facets still count a server that works
+  // fine once configured by hand.
+  if (
+    options.oneClick !== false &&
+    type === "stdio" &&
+    !ONE_CLICK_STDIO_COMMANDS.has(oneClickStdioCommandName(normalized.command))
+  ) {
+    return false;
+  }
 
   if (target === "codex") {
     if (type === "sse") return false;
@@ -190,9 +219,9 @@ export function mcpConfigSupportsTarget(config, target) {
   return MCP_INSTALL_TARGET_IDS.includes(target);
 }
 
-export function mcpInstallTargetsForConfig(config) {
+export function mcpInstallTargetsForConfig(config, options = {}) {
   return MCP_INSTALL_TARGET_IDS.filter((target) =>
-    mcpConfigSupportsTarget(config, target),
+    mcpConfigSupportsTarget(config, target, options),
   );
 }
 
@@ -205,7 +234,7 @@ export function formatMcpConfigSnippet(name, config) {
   )}\n`;
 }
 
-export function resolveMcpInstallConfig(entry) {
+export function resolveMcpInstallConfig(entry, options = {}) {
   if (!entry || entry.category !== "mcp") return null;
   const snippet = String(entry.configSnippet || "").trim();
   if (!snippet) return null;
@@ -213,7 +242,7 @@ export function resolveMcpInstallConfig(entry) {
     const extracted = extractMcpServerConfig(snippet);
     if (!extracted) return null;
     const name = extracted.name || entry.slug || "heyclaude-mcp";
-    const targets = mcpInstallTargetsForConfig(extracted.config);
+    const targets = mcpInstallTargetsForConfig(extracted.config, options);
     if (!targets.length) return null;
     return {
       name,

--- a/packages/registry/src/mcp-install-config.d.ts
+++ b/packages/registry/src/mcp-install-config.d.ts
@@ -23,13 +23,35 @@ export declare function extractMcpServerConfig(
   value: unknown,
 ): { name?: string; config: McpServerConfig } | null;
 
+export type McpInstallTargetOptions = {
+  /**
+   * Whether to require one-click install safety. Defaults to `true`, which
+   * limits stdio configs to a bare `npx`/`uvx` command. Pass `false` to ask
+   * only whether the client can run the config at all (platform compatibility).
+   */
+  oneClick?: boolean;
+};
+
+/**
+ * One-click install support for `config` on `target`.
+ *
+ * A stdio config only qualifies when its `command` is a bare `npx` or `uvx`;
+ * any other local binary or shell command is manual-install only, even though
+ * `normalizeMcpServerConfig` still accepts it as valid registry metadata.
+ */
 export declare function mcpConfigSupportsTarget(
   config: unknown,
   target: McpInstallTargetId,
+  options?: McpInstallTargetOptions,
 ): boolean;
 
+/**
+ * The one-click install targets `config` supports - empty for a stdio config
+ * whose `command` is outside the `npx`/`uvx` allowlist.
+ */
 export declare function mcpInstallTargetsForConfig(
   config: unknown,
+  options?: McpInstallTargetOptions,
 ): McpInstallTargetId[];
 
 export declare function formatMcpConfigSnippet(
@@ -39,4 +61,5 @@ export declare function formatMcpConfigSnippet(
 
 export declare function resolveMcpInstallConfig(
   entry: Record<string, unknown>,
+  options?: McpInstallTargetOptions,
 ): ResolvedMcpInstallConfig | null;

--- a/tests/mcp-install-config-lib.test.ts
+++ b/tests/mcp-install-config-lib.test.ts
@@ -445,27 +445,97 @@ describe("resolveMcpInstallConfig", () => {
     ).toBeNull();
   });
 
-  it("keeps arbitrary stdio commands valid for registry metadata", () => {
-    const resolved = resolveMcpInstallConfig({
-      category: "mcp",
-      slug: "shell-one-liner",
-      configSnippet: JSON.stringify({
-        mcpServers: {
-          shell: {
-            command: "bash",
-            args: ["-lc", "touch /tmp/heyclaude-owned"],
-          },
-        },
+  it("keeps arbitrary stdio commands valid metadata but out of one-click install", () => {
+    const shellConfig = {
+      command: "bash",
+      args: ["-lc", "touch /tmp/heyclaude-owned"],
+    };
+
+    // Still valid registry metadata - the entry renders its own configSnippet.
+    expect(normalizeMcpServerConfig(shellConfig)).toMatchObject({
+      type: "stdio",
+      command: "bash",
+      args: ["-lc", "touch /tmp/heyclaude-owned"],
+    });
+
+    // But it is never advertised as one-click installable.
+    expect(mcpInstallTargetsForConfig(shellConfig)).toEqual([]);
+    expect(
+      resolveMcpInstallConfig({
+        category: "mcp",
+        slug: "shell-one-liner",
+        configSnippet: JSON.stringify({ mcpServers: { shell: shellConfig } }),
       }),
-    });
-    expect(resolved).toMatchObject({
-      targets: ALL_TARGETS,
-      config: {
-        type: "stdio",
-        command: "bash",
-        args: ["-lc", "touch /tmp/heyclaude-owned"],
-      },
-    });
+    ).toBeNull();
+  });
+
+  it("allows only bare npx/uvx stdio commands for one-click install", () => {
+    for (const command of ["npx", "uvx", "NPX", " uvx "]) {
+      expect(mcpInstallTargetsForConfig({ command })).toEqual(ALL_TARGETS);
+    }
+
+    for (const command of [
+      "node",
+      "docker",
+      "python3",
+      "sh",
+      "npx-evil",
+      // Path-qualified lookalikes must not slip past the allowlist.
+      "/usr/local/bin/npx",
+      "./npx",
+      "C:\\tools\\uvx.exe",
+    ]) {
+      expect(mcpInstallTargetsForConfig({ command })).toEqual([]);
+      for (const target of ALL_TARGETS) {
+        expect(mcpConfigSupportsTarget({ command }, target)).toBe(false);
+      }
+    }
+  });
+
+  it("leaves remote install targets unaffected by the stdio allowlist", () => {
+    expect(
+      mcpInstallTargetsForConfig({
+        type: "http",
+        url: "https://example.com/mcp",
+      }),
+    ).toEqual(ALL_TARGETS);
+  });
+
+  it("keeps compatibility answers available via oneClick: false", () => {
+    const shellConfig = { command: "docker", args: ["run", "example/mcp"] };
+
+    expect(mcpInstallTargetsForConfig(shellConfig)).toEqual([]);
+    expect(
+      mcpInstallTargetsForConfig(shellConfig, { oneClick: false }),
+    ).toEqual(ALL_TARGETS);
+    expect(
+      mcpConfigSupportsTarget(shellConfig, "cursor", { oneClick: false }),
+    ).toBe(true);
+
+    // The opt-out only relaxes the stdio allowlist - it never revives a config
+    // that fails normalization, nor codex's transport limits.
+    expect(
+      mcpInstallTargetsForConfig(
+        { type: "sse", url: "https://example.com/sse" },
+        { oneClick: false },
+      ),
+    ).not.toContain("codex");
+    expect(
+      mcpConfigSupportsTarget({ command: "" }, "cursor", { oneClick: false }),
+    ).toBe(false);
+
+    expect(
+      resolveMcpInstallConfig(
+        {
+          category: "mcp",
+          slug: "docker-server",
+          configSnippet: JSON.stringify({
+            mcpServers: { example: shellConfig },
+          }),
+        },
+        { oneClick: false },
+      ),
+    ).toMatchObject({ targets: ALL_TARGETS, config: { command: "docker" } });
   });
 
   it("allows loopback http urls in install metadata", () => {

--- a/tests/mcp-install-config.test.ts
+++ b/tests/mcp-install-config.test.ts
@@ -61,7 +61,7 @@ describe("MCP install config helpers", () => {
     });
   });
 
-  it("keeps arbitrary stdio commands valid for registry metadata", () => {
+  it("keeps arbitrary stdio commands valid metadata but out of one-click install", () => {
     expect(
       normalizeMcpServerConfig({
         command: "python3",
@@ -73,15 +73,27 @@ describe("MCP install config helpers", () => {
       args: ["-c", 'print("owned")'],
     });
 
+    expect(
+      resolveMcpInstallConfig({
+        category: "mcp",
+        slug: "shell-one-liner",
+        configSnippet: JSON.stringify({
+          mcpServers: {
+            shell: {
+              command: "bash",
+              args: ["-lc", "touch /tmp/heyclaude-owned"],
+            },
+          },
+        }),
+      }),
+    ).toBeNull();
+
     const resolved = resolveMcpInstallConfig({
       category: "mcp",
-      slug: "shell-one-liner",
+      slug: "npx-server",
       configSnippet: JSON.stringify({
         mcpServers: {
-          shell: {
-            command: "bash",
-            args: ["-lc", "touch /tmp/heyclaude-owned"],
-          },
+          example: { command: "npx", args: ["-y", "@example/mcp"] },
         },
       }),
     });
@@ -89,8 +101,8 @@ describe("MCP install config helpers", () => {
       targets: ["claude-code", "codex", "cursor", "antigravity"],
       config: {
         type: "stdio",
-        command: "bash",
-        args: ["-lc", "touch /tmp/heyclaude-owned"],
+        command: "npx",
+        args: ["-y", "@example/mcp"],
       },
     });
   });

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -2147,9 +2147,10 @@ describe("non-UI branch matrix", () => {
     expect(
       normalizeMcpServerConfig({ command: "node", args: ["server.js"] }),
     ).toMatchObject({ type: "stdio", command: "node" });
+    // Valid metadata, but outside the npx/uvx one-click allowlist.
     expect(
       mcpInstallTargetsForConfig({ command: "node", args: ["server.js"] }),
-    ).toEqual(["claude-code", "codex", "cursor", "antigravity"]);
+    ).toEqual([]);
 
     const remoteWithHeaders = {
       type: "http",


### PR DESCRIPTION
> Supersedes #5705, which LoopOver auto-closed because it was opened as a draft.
> The draft was only used to get a real PR-context CI run before requesting review;
> this PR is the same change, rebased onto `main` (754f721c) and ready to review.
> Every check was green on #5705, including `codecov/patch` at 100% of the diff.

## Root cause

`mcpConfigSupportsTarget` / `mcpInstallTargetsForConfig` accepted **any** non-empty stdio
`command`, so the registry package's canonical, typed "which install targets does this MCP
config support" API advertised one-click install for a config that runs an arbitrary local
binary or shell command.

A one-click install writes the stdio server entry straight into the user's client config,
so that `command` is what gets executed locally on their machine.

Both real consumers had already independently reimplemented the same npx/uvx allowlist on
top of the canonical function:

- `packages/registry/src/artifacts-lib.js` — `RAYCAST_ONE_CLICK_STDIO_COMMANDS`
- `integrations/raycast/src/mcp-installer.ts` — `ONE_CLICK_STDIO_COMMANDS`

They papered over the gap locally, so anything trusting the shared primitive directly
inherited it. That is not hypothetical: `buildEntryPlatformNames` in `artifacts-lib.js`
calls `resolveMcpInstallConfig(entry)` with no allowlist of its own.

## Fix approach

1. Apply the allowlist in the canonical function (`mcp-install-config-lib.js`), reusing the
   consumers' exact bare-command-name check so a path-qualified lookalike such as
   `/usr/local/bin/npx` or `C:\tools\uvx.exe` cannot slip past.
2. `normalizeMcpServerConfig` is deliberately **unchanged** — an arbitrary stdio command is
   still valid registry metadata and still renders its own `configSnippet`. It is only
   never advertised as one-click installable.
3. Added an optional `{ oneClick: false }` escape hatch (the "equivalent parameter/flag"
   the issue allows) threaded through `mcpInstallTargetsForConfig` / `resolveMcpInstallConfig`,
   and used it at the one call site that asks a *compatibility* question rather than an
   install-safety one — `buildEntryPlatformNames`. Platform names describe which clients can
   run a server; a stdio server behind `uv`/`docker`/`python` genuinely works on Claude
   Code / Codex / Cursor once configured by hand.

Default is secure: callers that pass nothing get the allowlist. The signature stays
backward compatible (optional third/second argument), so no existing caller changes.

## Exact before/after — stdio config with a non-npx/uvx command

```js
const config = { command: "bash", args: ["-lc", "touch /tmp/heyclaude-owned"] };
```

| Call | Before | After |
|---|---|---|
| `normalizeMcpServerConfig(config)` | `{ type: "stdio", command: "bash", … }` | `{ type: "stdio", command: "bash", … }` (unchanged) |
| `mcpInstallTargetsForConfig(config)` | `["claude-code","codex","cursor","antigravity"]` | `[]` |
| `mcpConfigSupportsTarget(config, "cursor")` | `true` | `false` |
| `resolveMcpInstallConfig({ category:"mcp", configSnippet })` | resolved w/ 4 targets | `null` (manual-install only) |
| `mcpInstallTargetsForConfig(config, { oneClick: false })` | n/a | `["claude-code","codex","cursor","antigravity"]` |

`npx`/`uvx` configs are completely unaffected, as are all non-stdio (HTTP/SSE) paths and
Codex's existing transport rules.

## Impact

- **Generated artifacts are byte-identical to `main`.** Verified by generating
  `apps/web/public/data/raycast/**` before and after and diffing: no change. The Raycast
  feed was already locally gated, and `buildEntryPlatformNames` keeps its compatibility
  semantics via `oneClick: false`.
- Without step 3 this change would have silently emptied `trustSignals.platforms` for **70
  live MCP entries** (`uv`, `docker`, `python`, `java`, `php`, absolute-path commands),
  which feeds `inferPlatforms` and the platform browse facets. That regression is avoided,
  not accepted.
- Both existing consumers still pass their own tests unchanged (`tests/artifacts-lib.test.ts`
  291 passed; Raycast one-click tests untouched).

## Quality evidence

- **No visual impact** — no UI/route/component code touched.
- Tests: updated the three specs that encoded the old contract
  (`mcp-install-config-lib`, `mcp-install-config`, `non-ui-branch-matrix`) and added focused
  coverage for the allowlist, path-qualified bypass attempts, case/whitespace handling, the
  `oneClick: false` opt-out, and that the opt-out does **not** revive configs failing
  normalization or Codex's transport limits.
- Validation run: `pnpm test` (full suite), `pnpm validate:packages`, `pnpm scan:packages`,
  `pnpm validate:raycast-feed`, `pnpm generate:registry` + artifact diff, `git diff --check`,
  prettier clean on all changed files.

## Risk / tradeoffs

- Behavior change is intentional and narrow: a non-npx/uvx stdio config becomes
  manual-install only. That is the point of the issue, and it matches what both consumers
  already enforced.
- `resolveMcpInstallConfig` returns `null` (rather than a config with empty `targets`) for
  such entries, because the existing `if (!targets.length) return null` already means
  "manual-only" — consistent with the non-JSON-snippet path.
- The `packages/mcp/` mirror of this module still carries the original gap. It is outside
  this issue's stated scope and has no cross-package parity test, so it is left for a
  follow-up rather than widened into this PR.

Closes #5682
