### PR TITLE
feat(web): honor saved-search signal filter in alert matching

### DIFF
--- a/apps/web/src/lib/saved-search-alerts-lib.ts
+++ b/apps/web/src/lib/saved-search-alerts-lib.ts
@@ -25,6 +25,22 @@ export interface SavedSearchAlertSchedule {
   lastNotifiedAt?: string;
 }
 
+/**
+ * Trust-signal filter values shared with browse (`TRUST_SIGNAL_FILTERS` in
+ * `@/data/search`). Kept local so this pure alerts module does not import the
+ * catalog-backed search module.
+ */
+export const SAVED_SEARCH_ALERT_TRUST_SIGNALS = [
+  "safety-notes",
+  "privacy-notes",
+  "source-backed",
+  "trusted-package",
+  "reviewed",
+  "checksums",
+] as const;
+
+export type SavedSearchAlertTrustSignal = (typeof SAVED_SEARCH_ALERT_TRUST_SIGNALS)[number];
+
 export interface SavedSearchAlertSearch {
   id: string;
   label: string;
@@ -32,6 +48,8 @@ export interface SavedSearchAlertSearch {
   category?: string;
   trust?: string;
   source?: string;
+  /** Browse trust-signal chip (`safety-notes` / `reviewed` / …). */
+  signal?: string;
   platform?: string;
   alerts?: SavedSearchAlertSchedule;
 }
@@ -49,6 +67,28 @@ export interface SavedSearchAlertEntry {
   platforms?: Array<Platform | string>;
   trust?: TrustLevel | string;
   source?: SourceStatus | string;
+  /**
+   * Optional fields used by browse's trust-signal filters. Live detail JSON
+   * loaded by `watch.tsx` carries them via the full `Entry` shape; synthetic
+   * removal fallbacks usually omit them.
+   */
+  safetyNotes?: string;
+  privacyNotes?: string;
+  reviewed?: boolean;
+  reviewedBy?: string;
+  claimed?: boolean;
+  claimStatus?: string;
+  packageVerified?: boolean;
+  downloadTrust?: string | null;
+  downloadSha256?: string;
+  trustSignals?: {
+    hasSafetyNotes?: boolean;
+    hasPrivacyNotes?: boolean;
+    sourceStatus?: string;
+    packageVerified?: boolean;
+    packageTrust?: string | null;
+    checksumPresent?: boolean;
+  };
 }
 
 export interface SavedSearchAlertEvent {
@@ -158,6 +198,47 @@ export function savedSearchQueryMatchesEntry(
   );
 }
 
+function isSavedSearchAlertTrustSignal(value: string): value is SavedSearchAlertTrustSignal {
+  return (SAVED_SEARCH_ALERT_TRUST_SIGNALS as readonly string[]).includes(value);
+}
+
+/**
+ * Mirror of browse `entryMatchesTrustSignal` for the slim alert entry shape.
+ * Unknown signal values never match (same as browse's final `return false`).
+ */
+export function alertEntryMatchesTrustSignal(
+  entry: SavedSearchAlertEntry,
+  signal: string,
+): boolean {
+  if (!isSavedSearchAlertTrustSignal(signal)) return false;
+  if (signal === "safety-notes") {
+    return Boolean(entry.safetyNotes || entry.trustSignals?.hasSafetyNotes);
+  }
+  if (signal === "privacy-notes") {
+    return Boolean(entry.privacyNotes || entry.trustSignals?.hasPrivacyNotes);
+  }
+  if (signal === "source-backed") {
+    return entry.source === "source-backed" || entry.trustSignals?.sourceStatus === "available";
+  }
+  if (signal === "trusted-package") {
+    return Boolean(
+      entry.packageVerified ||
+      entry.downloadTrust === "first-party" ||
+      entry.trustSignals?.packageVerified ||
+      entry.trustSignals?.packageTrust === "first-party",
+    );
+  }
+  if (signal === "reviewed") {
+    return Boolean(
+      entry.reviewed || entry.reviewedBy || entry.claimed || entry.claimStatus === "verified",
+    );
+  }
+  if (signal === "checksums") {
+    return Boolean(entry.downloadSha256 || entry.trustSignals?.checksumPresent);
+  }
+  return false;
+}
+
 export function savedSearchMatchesEntry(
   search: SavedSearchAlertSearch,
   entry: SavedSearchAlertEntry,
@@ -171,6 +252,7 @@ export function savedSearchMatchesEntry(
   ) {
     return false;
   }
+  if (search.signal && !alertEntryMatchesTrustSignal(entry, search.signal)) return false;
   return savedSearchQueryMatchesEntry(entry, search.q);
 }
 
@@ -205,9 +287,50 @@ export function removedEntryFromEvent(event: SavedSearchAlertEvent): SavedSearch
 }
 
 /**
- * Whether a removal synthetic entry can satisfy a search's trust/source/platform
- * filters. Category/query-only searches always can; filtered searches require
- * the event to actually carry the matching field(s). Without this gate,
+ * Whether a synthetic removal entry carries enough evidence to evaluate a
+ * trust-signal filter. Distinct from `alertEntryMatchesTrustSignal` (which
+ * answers "does it pass?"): this only asks whether the fields that browse
+ * would inspect are present at all.
+ */
+function removalEntryHasTrustSignalEvidence(entry: SavedSearchAlertEntry, signal: string): boolean {
+  if (!isSavedSearchAlertTrustSignal(signal)) return false;
+  if (signal === "safety-notes") {
+    return entry.safetyNotes != null || entry.trustSignals?.hasSafetyNotes != null;
+  }
+  if (signal === "privacy-notes") {
+    return entry.privacyNotes != null || entry.trustSignals?.hasPrivacyNotes != null;
+  }
+  if (signal === "source-backed") {
+    return (
+      (entry.source != null && entry.source !== "") || entry.trustSignals?.sourceStatus != null
+    );
+  }
+  if (signal === "trusted-package") {
+    return (
+      entry.packageVerified != null ||
+      entry.downloadTrust != null ||
+      entry.trustSignals?.packageVerified != null ||
+      entry.trustSignals?.packageTrust != null
+    );
+  }
+  if (signal === "reviewed") {
+    return (
+      entry.reviewed != null ||
+      entry.reviewedBy != null ||
+      entry.claimed != null ||
+      entry.claimStatus != null
+    );
+  }
+  if (signal === "checksums") {
+    return entry.downloadSha256 != null || entry.trustSignals?.checksumPresent != null;
+  }
+  return false;
+}
+
+/**
+ * Whether a removal synthetic entry can satisfy a search's trust/source/platform/
+ * signal filters. Category/query-only searches always can; filtered searches
+ * require the event to actually carry the matching field(s). Without this gate,
  * `savedSearchMatchesEntry` would silently reject (entry field undefined ≠
  * filter), contradicting the "match against carried fields" comment.
  */
@@ -218,6 +341,7 @@ export function removalEventSupportsSearchFilters(
   if (search.trust && (entry.trust == null || entry.trust === "")) return false;
   if (search.source && (entry.source == null || entry.source === "")) return false;
   if (search.platform && !(entry.platforms ?? []).length) return false;
+  if (search.signal && !removalEntryHasTrustSignalEvidence(entry, search.signal)) return false;
   return true;
 }
 
@@ -240,10 +364,11 @@ export function buildSavedSearchAlerts(
     // requiring a live fetch:
     // - category / slug / title are always available from the path classifier
     //   and power category- + query-only saved searches (unchanged).
-    // - trust / source / platforms are NOT emitted by `classifyRegistryPath` /
-    //   the GitHub webhook today (path-only push payload). Searches that filter
-    //   on those dimensions are explicitly skipped for synthetic removals unless
-    //   a producer enriched the event — see `removalEventSupportsSearchFilters`.
+    // - trust / source / platforms / signal evidence are NOT emitted by
+    //   `classifyRegistryPath` / the GitHub webhook today (path-only push
+    //   payload). Searches that filter on those dimensions are explicitly
+    //   skipped for synthetic removals unless a producer enriched the event —
+    //   see `removalEventSupportsSearchFilters`.
     // Added/updated events keep needing the live entry.
     const liveEntry = entriesByRef.get(ref);
     const usingRemovalFallback = action === "removed" && !liveEntry;

--- a/apps/web/src/lib/saved-search-alerts.ts
+++ b/apps/web/src/lib/saved-search-alerts.ts
@@ -12,11 +12,14 @@ export type {
   SavedSearchAlertEvent,
   SavedSearchAlertSeverity,
   SavedSearchAlert,
+  SavedSearchAlertTrustSignal,
 } from "@/lib/saved-search-alerts-lib";
 export {
+  SAVED_SEARCH_ALERT_TRUST_SIGNALS,
   savedSearchAlertTargetId,
   activeInAppSavedSearches,
   savedSearchQueryMatchesEntry,
+  alertEntryMatchesTrustSignal,
   savedSearchMatchesEntry,
   removedEntryFromEvent,
   removalEventSupportsSearchFilters,

--- a/tests/saved-search-alerts-lib.test.ts
+++ b/tests/saved-search-alerts-lib.test.ts
@@ -217,6 +217,132 @@ describe("savedSearchMatchesEntry", () => {
     );
   });
 
+  it("honors the signal (trust-signal) filter the same way browse does", () => {
+    // Baseline fixture: source-backed + trusted, but not reviewed / no notes /
+    // no package checksums — so only the source-backed signal should match.
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "source-backed", q: "postgres" }),
+        entry,
+      ),
+    ).toBe(true);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "reviewed", q: "postgres" }),
+        entry,
+      ),
+    ).toBe(false);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "safety-notes", q: "postgres" }),
+        entry,
+      ),
+    ).toBe(false);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "privacy-notes", q: "postgres" }),
+        entry,
+      ),
+    ).toBe(false);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "checksums", q: "postgres" }),
+        entry,
+      ),
+    ).toBe(false);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "trusted-package", q: "postgres" }),
+        entry,
+      ),
+    ).toBe(false);
+
+    // Synthetic entry that satisfies category/trust/source/platform but NOT
+    // the saved search's `signal=reviewed` filter — the bug this issue fixes.
+    const unreviewed: SavedSearchAlertEntry = {
+      ...entry,
+      reviewed: false,
+      claimed: false,
+    };
+    expect(
+      savedSearchMatchesEntry(
+        search({
+          category: "mcp",
+          trust: "trusted",
+          source: "source-backed",
+          platform: "claude-code",
+          signal: "reviewed",
+          q: "postgres",
+        }),
+        unreviewed,
+      ),
+    ).toBe(false);
+
+    const reviewed: SavedSearchAlertEntry = {
+      ...entry,
+      reviewed: true,
+      reviewedBy: "maintainer",
+    };
+    expect(
+      savedSearchMatchesEntry(
+        search({
+          category: "mcp",
+          trust: "trusted",
+          source: "source-backed",
+          platform: "claude-code",
+          signal: "reviewed",
+          q: "postgres",
+        }),
+        reviewed,
+      ),
+    ).toBe(true);
+
+    // Other signal axes via the same browse-compatible evidence fields.
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "safety-notes", q: "postgres" }),
+        { ...entry, safetyNotes: "Runs shell commands." },
+      ),
+    ).toBe(true);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "privacy-notes", q: "postgres" }),
+        { ...entry, trustSignals: { hasPrivacyNotes: true } },
+      ),
+    ).toBe(true);
+    expect(
+      savedSearchMatchesEntry(search({ signal: "checksums", q: "postgres" }), {
+        ...entry,
+        downloadSha256: "abc123",
+      }),
+    ).toBe(true);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "trusted-package", q: "postgres" }),
+        { ...entry, packageVerified: true },
+      ),
+    ).toBe(true);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "source-backed", q: "postgres" }),
+        {
+          ...entry,
+          source: "external",
+          trustSignals: { sourceStatus: "available" },
+        },
+      ),
+    ).toBe(true);
+
+    // Unknown / empty signal values: empty is a no-op; unknown never matches.
+    expect(savedSearchMatchesEntry(search({ signal: undefined }), entry)).toBe(
+      true,
+    );
+    expect(savedSearchMatchesEntry(search({ signal: "" }), entry)).toBe(true);
+    expect(
+      savedSearchMatchesEntry(search({ signal: "not-a-signal" }), entry),
+    ).toBe(false);
+  });
+
   it("passes when optional filters are unset", () => {
     expect(
       savedSearchMatchesEntry(
@@ -225,6 +351,7 @@ describe("savedSearchMatchesEntry", () => {
           platform: undefined,
           trust: undefined,
           source: undefined,
+          signal: undefined,
           q: "postgres",
         }),
         entry,
@@ -261,6 +388,12 @@ describe("savedSearchMatchesEntry", () => {
       false,
     );
     expect(savedSearchMatchesEntry(search({ q: undefined }), entry)).toBe(true);
+    expect(
+      savedSearchMatchesEntry(
+        search({ signal: "source-backed", q: "missing-term" }),
+        entry,
+      ),
+    ).toBe(false);
   });
 });
 
@@ -330,6 +463,30 @@ describe("removedEntryFromEvent / removalEventSupportsSearchFilters", () => {
         search({ platform: "claude-code" }),
         enriched,
       ),
+    ).toBe(true);
+    // Path-only removals cannot evaluate a trust-signal filter.
+    expect(
+      removalEventSupportsSearchFilters(search({ signal: "reviewed" }), bare),
+    ).toBe(false);
+    // Enriched with source still supports source-backed signal evidence.
+    expect(
+      removalEventSupportsSearchFilters(
+        search({ signal: "source-backed" }),
+        enriched,
+      ),
+    ).toBe(true);
+    // reviewed evidence is not carried by removedEntryFromEvent today.
+    expect(
+      removalEventSupportsSearchFilters(
+        search({ signal: "reviewed" }),
+        enriched,
+      ),
+    ).toBe(false);
+    expect(
+      removalEventSupportsSearchFilters(search({ signal: "reviewed" }), {
+        ...enriched,
+        reviewed: true,
+      }),
     ).toBe(true);
   });
 });
@@ -412,10 +569,11 @@ describe("buildSavedSearchAlerts", () => {
     });
   });
 
-  it("does not alert trust/source/platform-filtered searches on path-only removals", () => {
+  it("does not alert trust/source/platform/signal-filtered searches on path-only removals", () => {
     // Webhook/path-classifier removal events only carry category/slug/title.
-    // Searches that filter on trust/source/platform are explicitly skipped for
-    // that synthetic fallback rather than silently failing inside the matcher.
+    // Searches that filter on trust/source/platform/signal are explicitly
+    // skipped for that synthetic fallback rather than silently failing inside
+    // the matcher.
     const removedEvent = {
       id: "evt-removed-filters",
       kind: "entry",
@@ -442,6 +600,13 @@ describe("buildSavedSearchAlerts", () => {
     expect(
       buildSavedSearchAlerts(
         [search({ platform: "claude-code", q: "postgres" })],
+        [removedEvent],
+        new Map(),
+      ),
+    ).toEqual([]);
+    expect(
+      buildSavedSearchAlerts(
+        [search({ signal: "reviewed", q: "postgres" })],
         [removedEvent],
         new Map(),
       ),
@@ -490,12 +655,59 @@ describe("buildSavedSearchAlerts", () => {
         new Map(),
       ),
     ).toHaveLength(1);
+    // source on the event also supplies source-backed signal evidence.
+    expect(
+      buildSavedSearchAlerts(
+        [search({ signal: "source-backed", q: "postgres" })],
+        [enrichedRemoval],
+        new Map(),
+      ),
+    ).toHaveLength(1);
     // Wrong filter value still rejects.
     expect(
       buildSavedSearchAlerts(
         [search({ trust: "blocked", q: "postgres" })],
         [enrichedRemoval],
         new Map(),
+      ),
+    ).toEqual([]);
+  });
+
+  it("alerts on live entries that satisfy a signal filter and skips those that do not", () => {
+    const reviewedEntry: SavedSearchAlertEntry = {
+      ...entry,
+      reviewed: true,
+      reviewedBy: "maintainer",
+    };
+    const entries = new Map([["mcp/postgres-memory", reviewedEntry]]);
+    expect(
+      buildSavedSearchAlerts(
+        [search({ signal: "reviewed", q: "postgres" })],
+        [
+          {
+            kind: "entry",
+            category: "mcp",
+            slug: "postgres-memory",
+            action: "updated",
+            date: "2026-06-18T10:00:00.000Z",
+          },
+        ],
+        entries,
+      ),
+    ).toHaveLength(1);
+    expect(
+      buildSavedSearchAlerts(
+        [search({ signal: "reviewed", q: "postgres" })],
+        [
+          {
+            kind: "entry",
+            category: "mcp",
+            slug: "postgres-memory",
+            action: "updated",
+            date: "2026-06-18T10:00:00.000Z",
+          },
+        ],
+        new Map([["mcp/postgres-memory", entry]]),
       ),
     ).toEqual([]);
   });


### PR DESCRIPTION
## Summary

- Add `signal` to `SavedSearchAlertSearch` and gate `savedSearchMatchesEntry` on browse's trust-signal semantics (`safety-notes` / `privacy-notes` / `source-backed` / `trusted-package` / `reviewed` / `checksums`).
- Extend the slim alert entry shape with the optional evidence fields live `Entry` detail already carries via `watch.tsx`.
- Treat path-only removal fallbacks honestly for `signal` the same way trust/source/platform already are.

Closes #5673

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- **Changed surface:**
  - `apps/web/src/lib/saved-search-alerts-lib.ts` — `signal` on search, `alertEntryMatchesTrustSignal`, matcher + removal-support gates
  - `apps/web/src/lib/saved-search-alerts.ts` — re-exports
  - `tests/saved-search-alerts-lib.test.ts`
- **No visual impact** — pure alert-matching lib logic; no UI/routes/rendering changes.
- **Before → after** (synthetic entry that satisfies category/trust/source/platform but not `signal=reviewed`):

  | Saved search filters | Entry | Before | After |
  |---|---|---|---|
  | `category=mcp`, `trust=trusted`, `source=source-backed`, `platform=claude-code`, `signal=reviewed`, `q=postgres` | same filters match except `reviewed: false` | **matched** (signal ignored) | **no match** |
  | same filters | `reviewed: true` | matched | matched |
  | no `signal` set | baseline fixture | matched | matched (unchanged) |

## Validation

- [x] `pnpm exec vitest run tests/saved-search-alerts-lib.test.ts` — **36 passed**
- [x] `pnpm exec vitest run tests/saved-search-alerts-lib.test.ts tests/saved-search-alerts.test.ts tests/saved-search-hash-lib.test.ts tests/saved-search-signature-lib.test.ts` — **57 passed**
- [x] `pnpm build` — passed
- [x] `pnpm exec prettier --check` on touched files — clean
- [x] `git diff --check` — clean
