### PR TITLE
feat(web): honor signal filters in saved-search alerts

### DIFF
--- a/apps/web/src/lib/saved-search-alerts-lib.ts
+++ b/apps/web/src/lib/saved-search-alerts-lib.ts
@@ -33,6 +33,7 @@ export interface SavedSearchAlertSearch {
   trust?: string;
   source?: string;
   platform?: string;
+  signal?: string;
   alerts?: SavedSearchAlertSchedule;
 }
 
@@ -49,6 +50,7 @@ export interface SavedSearchAlertEntry {
   platforms?: Array<Platform | string>;
   trust?: TrustLevel | string;
   source?: SourceStatus | string;
+  signal?: string;
 }
 
 export interface SavedSearchAlertEvent {
@@ -69,6 +71,7 @@ export interface SavedSearchAlertEvent {
   trust?: string;
   source?: string;
   platforms?: Array<Platform | string>;
+  signal?: string;
 }
 
 export type SavedSearchAlertSeverity = "info" | "warning" | "blocker";
@@ -165,6 +168,7 @@ export function savedSearchMatchesEntry(
   if (search.category && entry.category !== search.category) return false;
   if (search.trust && entry.trust !== search.trust) return false;
   if (search.source && entry.source !== search.source) return false;
+  if (search.signal && entry.signal !== search.signal) return false;
   if (
     search.platform &&
     !(entry.platforms ?? []).some((platform) => platform === search.platform)
@@ -194,12 +198,14 @@ export function removedEntryFromEvent(event: SavedSearchAlertEvent): SavedSearch
     .filter(Boolean);
   const trust = String(event.trust || "").trim();
   const source = String(event.source || "").trim();
+  const signal = String(event.signal || "").trim();
   return {
     category: event.category ?? "",
     slug: event.slug ?? "",
     title: event.title ?? "",
     ...(trust ? { trust } : {}),
     ...(source ? { source } : {}),
+    ...(signal ? { signal } : {}),
     ...(platforms.length ? { platforms } : {}),
   };
 }
@@ -217,6 +223,7 @@ export function removalEventSupportsSearchFilters(
 ): boolean {
   if (search.trust && (entry.trust == null || entry.trust === "")) return false;
   if (search.source && (entry.source == null || entry.source === "")) return false;
+  if (search.signal && (entry.signal == null || entry.signal === "")) return false;
   if (search.platform && !(entry.platforms ?? []).length) return false;
   return true;
 }

--- a/apps/web/src/lib/saved-search-signature-lib.ts
+++ b/apps/web/src/lib/saved-search-signature-lib.ts
@@ -32,6 +32,7 @@ export function savedSearchSignature(searches: SavedSearchAlertSearch[]): string
         search.trust,
         search.source,
         search.platform,
+        search.signal,
         search.alerts?.enabled ? "1" : "0",
         search.alerts?.channels?.join(",") ?? "",
       ]

--- a/tests/saved-search-alerts-lib.test.ts
+++ b/tests/saved-search-alerts-lib.test.ts
@@ -24,6 +24,7 @@ const entry: SavedSearchAlertEntry = {
   platforms: ["claude-code", "claude-desktop"],
   trust: "trusted",
   source: "source-backed",
+  signal: "reviewed",
 };
 
 function search(
@@ -196,7 +197,7 @@ describe("savedSearchQueryMatchesEntry", () => {
 });
 
 describe("savedSearchMatchesEntry", () => {
-  it("honors category, platform, trust, and source filters", () => {
+  it("honors category, platform, trust, source, and signal filters", () => {
     expect(
       savedSearchMatchesEntry(
         search({ category: "mcp", platform: "claude-code" }),
@@ -215,6 +216,12 @@ describe("savedSearchMatchesEntry", () => {
     expect(savedSearchMatchesEntry(search({ source: "external" }), entry)).toBe(
       false,
     );
+    expect(savedSearchMatchesEntry(search({ signal: "reviewed" }), entry)).toBe(
+      true,
+    );
+    expect(
+      savedSearchMatchesEntry(search({ signal: "safety-notes" }), entry),
+    ).toBe(false);
   });
 
   it("passes when optional filters are unset", () => {
@@ -225,6 +232,7 @@ describe("savedSearchMatchesEntry", () => {
           platform: undefined,
           trust: undefined,
           source: undefined,
+          signal: undefined,
           q: "postgres",
         }),
         entry,
@@ -273,6 +281,7 @@ describe("removedEntryFromEvent / removalEventSupportsSearchFilters", () => {
         title: "X",
         trust: "trusted",
         source: "source-backed",
+        signal: "reviewed",
         platforms: ["claude-code", ""],
       }),
     ).toEqual({
@@ -281,6 +290,7 @@ describe("removedEntryFromEvent / removalEventSupportsSearchFilters", () => {
       title: "X",
       trust: "trusted",
       source: "source-backed",
+      signal: "reviewed",
       platforms: ["claude-code"],
     });
   });
@@ -310,6 +320,7 @@ describe("removedEntryFromEvent / removalEventSupportsSearchFilters", () => {
       title: "X",
       trust: "trusted",
       source: "source-backed",
+      signal: "reviewed",
       platforms: ["claude-code"],
     });
     expect(removalEventSupportsSearchFilters(search(), bare)).toBe(true);
@@ -318,6 +329,15 @@ describe("removedEntryFromEvent / removalEventSupportsSearchFilters", () => {
     ).toBe(false);
     expect(
       removalEventSupportsSearchFilters(search({ trust: "trusted" }), enriched),
+    ).toBe(true);
+    expect(
+      removalEventSupportsSearchFilters(search({ signal: "reviewed" }), bare),
+    ).toBe(false);
+    expect(
+      removalEventSupportsSearchFilters(
+        search({ signal: "reviewed" }),
+        enriched,
+      ),
     ).toBe(true);
     expect(
       removalEventSupportsSearchFilters(

--- a/tests/saved-search-signature-lib.test.ts
+++ b/tests/saved-search-signature-lib.test.ts
@@ -67,6 +67,12 @@ describe("savedSearchSignature delimiter escaping", () => {
       savedSearchSignature([
         search({ id: "1", label: "L", q: "Q", category: "mcp" }),
       ]),
-    ).toBe("1\tL\tQ\tmcp\t\t\t\t0\t");
+    ).toBe("1\tL\tQ\tmcp\t\t\t\t\t0\t");
+  });
+
+  it("changes when the saved search signal filter changes", () => {
+    expect(savedSearchSignature([search({ signal: "reviewed" })])).not.toBe(
+      savedSearchSignature([search({ signal: "safety-notes" })]),
+    );
   });
 });


### PR DESCRIPTION
Closes #5673

## Summary
- add `signal` to saved-search alert search, entry, and removal event matching
- make saved-search alert matching reject entries that do not satisfy a saved trust-signal filter
- include the signal filter in saved-search signatures so alert watchers refresh when it changes

## Quality evidence
- No visual impact; this is a pure alert-matching logic fix.
- Before: a saved search with `signal=reviewed` could match an entry that satisfied category/trust/source/platform/query but lacked the reviewed signal.
- After: `savedSearchMatchesEntry(search({ signal: "reviewed" }), entryWithSignal)` returns true, while `signal="safety-notes"` returns false; synthetic removals also require carried signal metadata before matching signal-filtered searches.

## Validation
- `pnpm exec vitest run tests/saved-search-alerts-lib.test.ts tests/saved-search-signature-lib.test.ts`
- `pnpm build`
- `git diff --check`