### PR TITLE
fix(web): restrict API Origins to HeyClaude prod workers

### DIFF
--- a/apps/web/src/lib/api-security-lib.ts
+++ b/apps/web/src/lib/api-security-lib.ts
@@ -70,10 +70,15 @@ export const __rateLimitTestHooks = {
   maxBuckets: MAX_RATE_BUCKETS,
 };
 
+// Preview origins must be HeyClaude production Workers Builds hosts only.
+// This Cloudflare account also hosts sibling projects, so a bare
+// `*.zeronode.workers.dev` pattern would trust unrelated worker Origins on
+// mutating browser APIs. Match the same worker-label rule as
+// scripts/lib/preview-url-host.mjs (`heyclaude-prod` or `*-heyclaude-prod`).
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/heyclau\.de$/i,
   /^https:\/\/dev\.heyclau\.de$/i,
-  /^https:\/\/[a-z0-9-]+\.zeronode\.workers\.dev$/i,
+  /^https:\/\/(?:[a-z0-9-]+-)?heyclaude-prod\.zeronode\.workers\.dev$/i,
   /^http:\/\/localhost:\d+$/i,
   /^http:\/\/127\.0\.0\.1:\d+$/i,
 ];

--- a/tests/api-security-allowed-origin.test.ts
+++ b/tests/api-security-allowed-origin.test.ts
@@ -20,7 +20,9 @@ describe("isAllowedOrigin", () => {
       true,
     );
     expect(
-      isAllowedOrigin(requestWithOrigin("https://pr-123.zeronode.workers.dev")),
+      isAllowedOrigin(
+        requestWithOrigin("https://pr-123-heyclaude-prod.zeronode.workers.dev"),
+      ),
     ).toBe(true);
     expect(isAllowedOrigin(requestWithOrigin("http://localhost:3000"))).toBe(
       true,

--- a/tests/api-security-lib.test.ts
+++ b/tests/api-security-lib.test.ts
@@ -63,7 +63,14 @@ describe("isAllowedOrigin", () => {
       true,
     );
     expect(
-      isAllowedOrigin(requestWithOrigin("https://pr-123.zeronode.workers.dev")),
+      isAllowedOrigin(
+        requestWithOrigin("https://heyclaude-prod.zeronode.workers.dev"),
+      ),
+    ).toBe(true);
+    expect(
+      isAllowedOrigin(
+        requestWithOrigin("https://pr-123-heyclaude-prod.zeronode.workers.dev"),
+      ),
     ).toBe(true);
     expect(isAllowedOrigin(requestWithOrigin("http://localhost:3000"))).toBe(
       true,
@@ -81,20 +88,24 @@ describe("isAllowedOrigin", () => {
     ).toBe(false);
   });
 
-  it("rejects preview hosts with invalid subdomain characters", () => {
-    expect(
-      isAllowedOrigin(requestWithOrigin("https://pr_123.zeronode.workers.dev")),
-    ).toBe(false);
-    expect(
-      isAllowedOrigin(
-        requestWithOrigin("https://pr..123.zeronode.workers.dev"),
-      ),
-    ).toBe(false);
+  it("rejects sibling and lookalike zeronode worker origins", () => {
+    for (const origin of [
+      "https://evil.zeronode.workers.dev",
+      "https://pr-123.zeronode.workers.dev",
+      "https://heyclaude-prod-next.zeronode.workers.dev",
+      "https://heyclaude-dev.zeronode.workers.dev",
+      "https://pr_123-heyclaude-prod.zeronode.workers.dev",
+      "https://pr..123-heyclaude-prod.zeronode.workers.dev",
+    ]) {
+      expect(isAllowedOrigin(requestWithOrigin(origin)), origin).toBe(false);
+    }
   });
 
-  it("allows uppercase letters in preview worker hostnames", () => {
+  it("allows uppercase letters in HeyClaude preview worker hostnames", () => {
     expect(
-      isAllowedOrigin(requestWithOrigin("https://PR-123.zeronode.workers.dev")),
+      isAllowedOrigin(
+        requestWithOrigin("https://PR-123-HEYCLAUDE-PROD.zeronode.workers.dev"),
+      ),
     ).toBe(true);
   });
 


### PR DESCRIPTION
﻿## Summary
- Root cause: `isAllowedOrigin` trusted any `https://*.zeronode.workers.dev` Origin. This Cloudflare account hosts sibling projects, so an unrelated worker could satisfy origin checks on mutating browser APIs (votes, listing-leads, newsletter, etc.).
- Fix: replace the broad pattern with the same `heyclaude-prod` / `*-heyclaude-prod` worker-label rule already used by `scripts/lib/preview-url-host.mjs`.
- Impact: sibling/evil worker Origins are rejected; legitimate HeyClaude production preview Origins and local/dev hosts remain allowed.

## Test plan
- [x] `pnpm exec vitest run tests/api-security-lib.test.ts tests/api-security-allowed-origin.test.ts tests/web-api-security.test.ts tests/api-router-security.test.ts`

## Notes
- Linked issue or no-issue rationale: No tracked issue exists for this gap and contributors cannot open issues in this repository (CreateIssue permission denied). This is a security hardening PR aligning API Origin checks with the existing `isHeyClaudePreviewHost` contract already documented in `scripts/lib/preview-url-host.mjs` / preview URL validation.
- Risks: Any non-prod worker Origin that previously relied on the broad allowlist (for example `heyclaude-dev.zeronode.workers.dev` or arbitrary preview labels) will now fail origin checks. Intended; align clients with `heyclaude-prod` preview hosts or `dev.heyclau.de` / localhost.
