### PR TITLE
fix(registry): require HTTPS reviewable sources for trust sourceStatus

### DIFF
--- a/packages/registry/src/artifacts-lib.js
+++ b/packages/registry/src/artifacts-lib.js
@@ -27,6 +27,7 @@ import {
   buildRegistryRelationGraph,
   relationLookupFromGraph,
 } from "./relationships.js";
+import { isPublicHttpsUrl } from "./source-url-lib.js";
 
 export const ENTRY_SCHEMA_VERSION = 1;
 export const RAYCAST_SCHEMA_VERSION = 2;
@@ -507,6 +508,25 @@ function sourceUrlsForEntry(entry) {
     .filter((value, index, list) => list.indexOf(value) === index);
 }
 
+// Trust "source available" must reflect reviewable provenance, not marketing
+// sites or mutable package downloads, and never cleartext http:// URLs.
+function reviewableSourceUrlsForEntry(entry) {
+  return [
+    entry.documentationUrl,
+    entry.docsUrl,
+    entry.repoUrl,
+    externalGithubUrl(entry),
+    entry.repositoryUrl,
+    entry.sourceUrl,
+    ...(Array.isArray(entry.sourceUrls) ? entry.sourceUrls : []),
+    ...(Array.isArray(entry.retrievalSources) ? entry.retrievalSources : []),
+  ]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean)
+    .filter((value, index, list) => list.indexOf(value) === index)
+    .filter((value) => isPublicHttpsUrl(value));
+}
+
 function lastVerifiedForEntry(entry) {
   return (
     entry.verifiedAt ||
@@ -531,6 +551,7 @@ export function buildEntryTrustSignals(entry) {
   const packageChecksum =
     entry.downloadSha256 || entry.skillPackage?.sha256 || "";
   const sourceUrls = sourceUrlsForEntry(entry);
+  const reviewableSourceUrls = reviewableSourceUrlsForEntry(entry);
   const hasSafetyNotes = noteList(entry.safetyNotes).length > 0;
   const hasPrivacyNotes = noteList(entry.privacyNotes).length > 0;
 
@@ -542,7 +563,7 @@ export function buildEntryTrustSignals(entry) {
     checksumPresent: Boolean(packageChecksum),
     sourceUrlCount: sourceUrls.length,
     sourceUrls,
-    sourceStatus: sourceUrls.length ? "available" : "missing",
+    sourceStatus: reviewableSourceUrls.length ? "available" : "missing",
     lastVerifiedAt: lastVerifiedForEntry(entry),
     adapterGenerated,
     hasSafetyNotes,

--- a/tests/artifacts-trust-source-status.test.ts
+++ b/tests/artifacts-trust-source-status.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEntryTrustSignals } from "../packages/registry/src/artifacts-lib.js";
+
+describe("buildEntryTrustSignals sourceStatus", () => {
+  it("does not treat marketing websiteUrl alone as available source provenance", () => {
+    expect(
+      buildEntryTrustSignals({
+        websiteUrl: "https://example.com/marketing",
+        downloadUrl: "https://registry.npmjs.org/example/-/example-1.0.0.tgz",
+      }).sourceStatus,
+    ).toBe("missing");
+  });
+
+  it("rejects cleartext http source URLs for sourceStatus", () => {
+    expect(
+      buildEntryTrustSignals({
+        sourceUrl: "http://example.com/repo",
+        documentationUrl: "http://docs.example.com",
+      }).sourceStatus,
+    ).toBe("missing");
+  });
+
+  it("marks HTTPS reviewable sources as available", () => {
+    const signals = buildEntryTrustSignals({
+      repoUrl: "https://github.com/example/project",
+      websiteUrl: "https://example.com",
+    });
+    expect(signals.sourceStatus).toBe("available");
+    expect(signals.sourceUrls).toEqual(
+      expect.arrayContaining([
+        "https://github.com/example/project",
+        "https://example.com",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
﻿## Summary
- Root cause: `buildEntryTrustSignals` set `sourceStatus: "available"` whenever any URL field was present, including marketing `websiteUrl`, mutable `downloadUrl`/`packageUrl`, and cleartext `http://` sources.
- Fix: compute `sourceStatus` from HTTPS-only reviewable provenance fields (`repoUrl`, `sourceUrl`, docs, etc.), excluding marketing/distribution URLs and non-HTTPS links. `sourceUrls` / `sourceUrlCount` remain unchanged for display.
- Impact: trust filters and reports no longer overclaim source-backed status for entries that only have a website or http link.

## Test plan
- [x] `pnpm exec vitest run tests/artifacts-trust-source-status.test.ts tests/artifacts-lib.test.ts`

## Risks / tradeoffs
- Some entries that previously showed `sourceStatus=available` solely from website/download/http fields will flip to `missing` until they gain an HTTPS reviewable source. Intended accuracy improvement.
