### PR TITLE
fix(registry): require HTTPS for canonical content provenance URLs

### DIFF
--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -9,7 +9,7 @@
  * re-exports everything below so existing imports stay unchanged.
  */
 import categorySpec from "./category-spec.json" with { type: "json" };
-import { isPublicHttpUrl, isPublicHttpsUrl } from "./source-url-lib.js";
+import { isPublicHttpsUrl } from "./source-url-lib.js";
 import {
   BRAND_ASSET_SOURCES,
   isAllowedBrandAssetUrl,
@@ -816,27 +816,22 @@ export function validateEntry(category, data, inferred = {}) {
   for (const field of [
     "authorProfileUrl",
     "repoUrl",
-    // skills: https-only below — matches retrievalSources auto-derived from it
-    ...(category === "skills" ? [] : ["documentationUrl"]),
+    "documentationUrl",
     "sourceUrl",
     "docsUrl",
     "packageUrl",
     "repositoryUrl",
     "websiteUrl",
   ]) {
-    if (!isPublicHttpUrl(merged[field])) {
-      semanticErrors.push(`${field} must use http or https`);
+    if (!isPublicHttpsUrl(merged[field])) {
+      semanticErrors.push(`${field} must use https`);
     }
-  }
-
-  if (category === "skills" && !isPublicHttpsUrl(merged.documentationUrl)) {
-    semanticErrors.push("documentationUrl must use https");
   }
 
   if (Array.isArray(merged.sourceUrls)) {
     for (const sourceUrl of merged.sourceUrls) {
-      if (!isPublicHttpUrl(sourceUrl)) {
-        semanticErrors.push("sourceUrls must use http or https");
+      if (!isPublicHttpsUrl(sourceUrl)) {
+        semanticErrors.push("sourceUrls must use https");
         break;
       }
     }

--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -1171,7 +1171,7 @@ describe("validateEntry brand color and source URL checks", () => {
         ...base,
         sourceUrls: ["https://ok.dev", "not-a-url"],
       }).semanticErrors,
-    ).toContain("sourceUrls must use http or https");
+    ).toContain("sourceUrls must use https");
   });
 });
 
@@ -1233,19 +1233,14 @@ describe("validateEntry category-specific recommended/semantic rules", () => {
     expect(result.semanticErrors).toContain("documentationUrl must use https");
   });
 
-  it("still allows http documentationUrl on non-skills categories", () => {
+  it("rejects http documentationUrl on non-skills categories", () => {
     const result = validateEntry("agents", {
       slug: "a",
       title: "A",
       description: "D",
       documentationUrl: "http://docs.example/agent",
     });
-    expect(result.semanticErrors).not.toContain(
-      "documentationUrl must use https",
-    );
-    expect(result.semanticErrors).not.toContain(
-      "documentationUrl must use http or https",
-    );
+    expect(result.semanticErrors).toContain("documentationUrl must use https");
   });
 
   it("requires verifiedAt on a capability-pack skill", () => {

--- a/tests/content-schema.test.ts
+++ b/tests/content-schema.test.ts
@@ -244,7 +244,7 @@ describe("inferStructuredFields", () => {
         "brandLogoUrl must be HTTPS and served by Brandfetch, HeyClaude, or a local asset path",
         "brandVerifiedAt must be ISO date format YYYY-MM-DD",
         "brandColors must be hex colors such as #796eff",
-        "repoUrl must use http or https",
+        "repoUrl must use https",
         "submittedByUrl must use https",
         "submittedAt must be an ISO date or datetime",
         "sourceSubmissionNumber must be a positive integer",
@@ -357,8 +357,8 @@ describe("inferStructuredFields", () => {
 
     expect(result.semanticErrors).toEqual(
       expect.arrayContaining([
-        "authorProfileUrl must use http or https",
-        "repoUrl must use http or https",
+        "authorProfileUrl must use https",
+        "repoUrl must use https",
       ]),
     );
   });

--- a/tests/content-validation.test.ts
+++ b/tests/content-validation.test.ts
@@ -76,13 +76,13 @@ describe("content validation", () => {
     expect(result.semanticErrors).toEqual(
       expect.arrayContaining([
         "slug must contain only lowercase letters, numbers, and single hyphens",
-        "documentationUrl must use http or https",
-        "sourceUrls must use http or https",
+        "documentationUrl must use https",
+        "sourceUrls must use https",
       ]),
     );
   });
 
-  it("allows normal content slugs and http or https contributor URLs", () => {
+  it("allows normal content slugs and https contributor URLs", () => {
     const result = validateEntry("agents", {
       title: "Safe Agent",
       slug: "safe-agent",
@@ -90,7 +90,7 @@ describe("content validation", () => {
       description: "Fixture for content validation security checks.",
       author: "tester",
       dateAdded: "2026-06-11",
-      documentationUrl: "http://example.com/docs",
+      documentationUrl: "https://example.com/docs",
       repoUrl: "https://github.com/example/safe-agent",
       sourceUrls: ["https://example.com/source"],
     });
@@ -98,8 +98,8 @@ describe("content validation", () => {
     expect(result.semanticErrors).not.toEqual(
       expect.arrayContaining([
         "slug must use lowercase letters, numbers, and hyphens only",
-        "documentationUrl must use http or https",
-        "sourceUrls must use http or https",
+        "documentationUrl must use https",
+        "sourceUrls must use https",
       ]),
     );
   });

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -722,7 +722,7 @@ describe("non-UI branch matrix", () => {
         "brandLogoUrl must be HTTPS and served by Brandfetch, HeyClaude, or a local asset path",
         "brandVerifiedAt must be ISO date format YYYY-MM-DD",
         "brandColors must be hex colors such as #796eff",
-        "repoUrl must use http or https",
+        "repoUrl must use https",
         "submittedByUrl must use https",
         "submittedAt must be an ISO date or datetime",
         "sourceSubmissionNumber must be a positive integer",


### PR DESCRIPTION
## Summary
- Root cause: `validateEntry` accepted cleartext `http://` for canonical provenance fields (`repoUrl`, `sourceUrl`, `documentationUrl`, `docsUrl`, `packageUrl`, `repositoryUrl`, `websiteUrl`, `authorProfileUrl`, `sourceUrls`) via `isPublicHttpUrl`, while submissions, skills `documentationUrl`, and claim URLs already require HTTPS.
- Fix: switch those checks to `isPublicHttpsUrl` and unify skills/non-skills documentationUrl under the same HTTPS rule.
- Impact: content PRs can no longer land MITM-able cleartext provenance links that users click and trust surfaces present as sources.

## Test plan
- [x] `pnpm exec vitest run tests/content-schema-lib.test.ts tests/content-schema.test.ts tests/non-ui-branch-matrix.test.ts`
- Note: `tests/content-validation.test.ts` hook-bash cases fail locally on Windows (`spawnSync bash ENOENT`); validateEntry-focused cases in that file pass. CI Linux runners cover bash syntax checks.

## Notes
- Linked issue or no-issue rationale: No tracked issue exists for this incomplete HTTPS migration after #5620 (skills-only), and contributors cannot open issues here (`CreateIssue` permission denied). This closes the remaining cleartext gap for all category provenance fields.
- Risks: Existing entries with `http://` provenance would fail schema validation; current content frontmatter does not use cleartext on these fields.
