### PR TITLE
fix(registry): reject unsafe downloadUrl schemes in content schema

### DIFF
--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -851,6 +851,23 @@ export function validateEntry(category, data, inferred = {}) {
     }
   }
 
+  // downloadUrl is rendered as a clickable href on entry pages. Only first-party
+  // /downloads/... paths and public HTTPS URLs are safe; reject javascript:,
+  // data:, and cleartext http: schemes before they reach the UI.
+  const downloadUrl = String(merged.downloadUrl || "").trim();
+  if (downloadUrl) {
+    const isHostedDownload =
+      downloadUrl.startsWith("/downloads/") &&
+      !downloadUrl.includes("\\") &&
+      !downloadUrl.includes("..") &&
+      /^\/downloads\/[A-Za-z0-9._/-]+$/.test(downloadUrl);
+    if (!isHostedDownload && !isPublicHttpsUrl(downloadUrl)) {
+      semanticErrors.push(
+        "downloadUrl must be an HTTPS URL or a /downloads/... path",
+      );
+    }
+  }
+
   for (const field of [
     "submittedByUrl",
     "sourceSubmissionUrl",

--- a/tests/content-schema-download-url.test.ts
+++ b/tests/content-schema-download-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { validateEntry } from "../packages/registry/src/content-schema-lib.js";
+
+describe("downloadUrl scheme validation", () => {
+  it("rejects javascript and data download URLs", () => {
+    for (const downloadUrl of [
+      "javascript:alert(1)",
+      "data:text/html,owned",
+      "http://example.com/pkg.zip",
+    ]) {
+      expect(
+        validateEntry("skills", {
+          slug: "s",
+          title: "S",
+          description: "D",
+          downloadUrl,
+        }).semanticErrors,
+      ).toContain("downloadUrl must be an HTTPS URL or a /downloads/... path");
+    }
+  });
+
+  it("allows HTTPS and hosted /downloads paths", () => {
+    expect(
+      validateEntry("skills", {
+        slug: "s",
+        title: "S",
+        description: "D",
+        downloadUrl: "https://example.com/pkg.zip",
+      }).semanticErrors,
+    ).not.toContain(
+      "downloadUrl must be an HTTPS URL or a /downloads/... path",
+    );
+    expect(
+      validateEntry("skills", {
+        slug: "s",
+        title: "S",
+        description: "D",
+        downloadUrl: "/downloads/skills/example.zip",
+      }).semanticErrors,
+    ).not.toContain(
+      "downloadUrl must be an HTTPS URL or a /downloads/... path",
+    );
+  });
+
+  it("rejects path traversal hosted downloads", () => {
+    expect(
+      validateEntry("skills", {
+        slug: "s",
+        title: "S",
+        description: "D",
+        downloadUrl: "/downloads/../etc/passwd",
+      }).semanticErrors,
+    ).toContain("downloadUrl must be an HTTPS URL or a /downloads/... path");
+  });
+});


### PR DESCRIPTION
## Summary
- Root cause: `validateEntry` did not scheme-check `downloadUrl`, so values like `javascript:`, `data:`, or `http://` could pass schema validation and be rendered as `href={entry.downloadUrl}` on entry pages.
- Fix: require `downloadUrl` to be a public HTTPS URL or a first-party `/downloads/...` path (no `..` / backslash traversal).
- Impact: unsafe download links are rejected at content-schema validation before they can ship to the UI.

## Test plan
- [x] `pnpm exec vitest run tests/content-schema-download-url.test.ts`

## Notes
- Linked issue or no-issue rationale: No tracked issue exists for this downloadUrl scheme gap, and contributors cannot open issues here (`CreateIssue` permission denied). This is a security hardening PR for a clickable entry-page field with no prior scheme gate.
- Related open work: #5723 tightens HTTPS for provenance URL fields; this PR specifically covers `downloadUrl`.
- Risks: Entries with cleartext or non-URL downloadUrl values would fail validation; hosted `/downloads/...` and HTTPS package URLs remain valid.
