### PR TITLE
fix(mcp): return domain error for unmatched read-only tool dispatch

### DIFF
--- a/packages/mcp/src/registry-tool-orchestration-lib.js
+++ b/packages/mcp/src/registry-tool-orchestration-lib.js
@@ -1111,7 +1111,7 @@ export async function callRegistryTool(name, args = {}, options = {}) {
   return withPublicPolicy(result);
 }
 
-async function dispatchReadOnlyTool(name, parsedArgs, options) {
+export async function dispatchReadOnlyTool(name, parsedArgs, options) {
   let result;
   switch (name) {
     case "registry.search":
@@ -1197,6 +1197,12 @@ async function dispatchReadOnlyTool(name, parsedArgs, options) {
       break;
     case "entry.coverage":
       result = await compareEntryTrust(parsedArgs, options);
+      break;
+    default:
+      // Allowlisted in READ_ONLY_TOOL_NAMES but missing a switch case — fail
+      // closed with the same domain error as truly unknown tools instead of
+      // returning undefined and crashing the CallTool handler on result.ok.
+      result = invalid(`Unknown read-only HeyClaude MCP tool: ${name}`);
       break;
   }
 

--- a/tests/mcp-dispatch-readonly-default.test.ts
+++ b/tests/mcp-dispatch-readonly-default.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { dispatchReadOnlyTool } from "../packages/mcp/src/registry-tool-orchestration-lib.js";
+
+describe("dispatchReadOnlyTool default branch", () => {
+  it("returns a domain invalid error for allowlisted names missing a switch case", async () => {
+    const result = await dispatchReadOnlyTool(
+      "registry.synthetic-missing-case",
+      {},
+      {},
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: "invalid_request",
+        message:
+          "Unknown read-only HeyClaude MCP tool: registry.synthetic-missing-case",
+      },
+    });
+    // CallTool handlers check `result.ok === false`; undefined would throw.
+    expect(result.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Root cause: `dispatchReadOnlyTool` had no `default` switch branch. An allowlisted tool name without a matching case left `result` as `undefined`, and `CallTool` handlers then threw on `result.ok`.
- Fix: add a `default` branch that returns the same `invalid(...)` domain error used for unknown tools.
- Impact: future `READ_ONLY_TOOL_NAMES`/switch drift fails closed with a clean error instead of crashing the request handler.

Closes #5715

## Test plan
- [x] `pnpm exec vitest run tests/mcp-dispatch-readonly-default.test.ts`
- [x] `pnpm test:mcp`

## Notes
- Linked issue: #5715
- No visual impact (MCP orchestration only)
