### PR TITLE
fix(mcp): treat empty limit/offset query params as absent

### DIFF
--- a/packages/mcp/src/registry-normalize-lib.js
+++ b/packages/mcp/src/registry-normalize-lib.js
@@ -38,12 +38,16 @@ export function normalizeText(value) {
 }
 
 export function normalizeLimit(value, fallback = 10) {
+  // Present-but-empty query params (e.g. `?limit=`) coerce to Number("") === 0
+  // and would otherwise clamp to 1. Treat blank strings as "absent".
+  if (typeof value === "string" && value.trim() === "") return fallback;
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return fallback;
   return Math.max(1, Math.min(25, Math.trunc(numeric)));
 }
 
 export function normalizeOffset(value) {
+  if (typeof value === "string" && value.trim() === "") return 0;
   const numeric = Number(value);
   if (!Number.isFinite(numeric)) return 0;
   return Math.max(0, Math.min(5000, Math.trunc(numeric)));

--- a/tests/mcp-registry-normalize-lib.test.ts
+++ b/tests/mcp-registry-normalize-lib.test.ts
@@ -17,9 +17,14 @@ describe("registry-normalize-lib text and pagination", () => {
     expect(normalizeLimit(3)).toBe(3);
     expect(normalizeLimit(100)).toBe(25);
     expect(normalizeLimit("not-a-number")).toBe(10);
+    expect(normalizeLimit("", 25)).toBe(25);
+    expect(normalizeLimit("  ", 25)).toBe(25);
+    expect(normalizeLimit("5", 25)).toBe(5);
     expect(normalizeOffset(10)).toBe(10);
     expect(normalizeOffset(9000)).toBe(5000);
     expect(normalizeOffset(-5)).toBe(0);
+    expect(normalizeOffset("")).toBe(0);
+    expect(normalizeOffset("  ")).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Root cause: `normalizeLimit("")` treated empty query params as `Number("") === 0`, then clamped to `1`, so `heyclaude://category/skills?limit=` silently returned a 1-entry page instead of `DISCOVERY_RESOURCE_LIMIT`.
- Fix: treat blank/whitespace strings as absent in `normalizeLimit`/`normalizeOffset` so they use the documented fallbacks.
- Impact: empty `limit=`/`offset=` match absent params; real numeric values like `limit=5` still work.

Closes #5714

## Test plan
- [x] `pnpm exec vitest run tests/mcp-registry-normalize-lib.test.ts`

## Notes
- Linked issue: #5714
- No visual impact (MCP pagination helpers only)
- Before: `normalizeLimit("", 25) === 1`
- After: `normalizeLimit("", 25) === 25`
