### PR TITLE
fix(web): give advertise/tools submit errors role=alert (#5713)

### DIFF
--- a/apps/web/src/routes/advertise.tsx
+++ b/apps/web/src/routes/advertise.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState, type FormEvent } from "react";
 import { Check } from "lucide-react";
 import { absoluteUrl } from "@/lib/seo";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { CommercialDisclosure, CommercialLeadSuccess } from "@/components/commercial-disclosure";
 import { submitListingLead } from "@/lib/listing-lead-client";
 import { trackEvent } from "@/lib/analytics";
@@ -238,7 +239,11 @@ function AdvertisePage() {
             >
               {submitting ? "Sending…" : "Join waitlist"}
             </button>
-            {error && <p className="text-sm text-trust-blocked">{error}</p>}
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
           </div>
         </form>
 

--- a/apps/web/src/routes/tools.submit.tsx
+++ b/apps/web/src/routes/tools.submit.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState, type FormEvent } from "react";
 import { ArrowRight } from "lucide-react";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { CommercialDisclosure } from "@/components/commercial-disclosure";
 import { trackEvent } from "@/lib/analytics";
 import { absoluteUrl } from "@/lib/seo";
@@ -220,7 +221,11 @@ function CommercialToolListingForm() {
           >
             {submitting ? "Sending…" : "Submit listing interest"}
           </button>
-          {error && <p className="text-sm text-trust-blocked">{error}</p>}
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
         </form>
       )}
     </section>
@@ -314,7 +319,11 @@ function PaidReviewInterestForm() {
           >
             {submitting ? "Sending…" : "Submit review interest"}
           </button>
-          {error && <p className="text-sm text-trust-blocked">{error}</p>}
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
         </form>
       )}
     </section>

--- a/tests/form-error-role-alert.test.ts
+++ b/tests/form-error-role-alert.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+function routeSource(file: string) {
+  return fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes", file),
+    "utf8",
+  );
+}
+
+describe("form submission errors use Alert live regions (#5713)", () => {
+  // jobs.post / submit already wrap errors in <Alert variant="destructive">
+  // (role="alert" via alert.tsx). advertise + tools.submit used bare <p>
+  // with no live-region semantics — pin the shared Alert wrapper at source.
+  it("advertise waitlist form renders errors via Alert/AlertDescription", () => {
+    const source = routeSource("advertise.tsx");
+    expect(source).toContain(
+      'import { Alert, AlertDescription } from "@/components/ui/alert"',
+    );
+    expect(source).toContain('<Alert variant="destructive">');
+    expect(source).toContain("<AlertDescription>{error}</AlertDescription>");
+    expect(source).not.toMatch(
+      /\{error && <p className="text-sm text-trust-blocked">\{error\}<\/p>\}/,
+    );
+  });
+
+  it("tools.submit listing and review forms render errors via Alert/AlertDescription", () => {
+    const source = routeSource("tools.submit.tsx");
+    expect(source).toContain(
+      'import { Alert, AlertDescription } from "@/components/ui/alert"',
+    );
+    const alertBlocks = source.match(/<Alert variant="destructive">/g) ?? [];
+    expect(alertBlocks.length).toBe(2);
+    expect(source).not.toMatch(
+      /\{error && <p className="text-sm text-trust-blocked">\{error\}<\/p>\}/,
+    );
+  });
+
+  it("jobs.post remains the reference Alert pattern", () => {
+    const source = routeSource("jobs.post.tsx");
+    expect(source).toContain('<Alert variant="destructive">');
+    expect(source).toContain("<AlertDescription>{error}</AlertDescription>");
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5713
- `/advertise` and both forms on `/tools/submit` rendered submission errors as bare `<p>` tags with no live-region semantics.
- Wrap those three error states in the same `Alert` / `AlertDescription` pattern already used by `jobs.post.tsx` / `submit.tsx` (`role="alert"` via `alert.tsx`).

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/form-error-role-alert.test.ts`
- [ ] Confirm screen readers announce submit errors on `/advertise` and `/tools/submit`