### PR TITLE
fix(registry): scope critical rm -rf to root/home targets (#5709)

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -8,7 +8,6 @@ import { parseSafeFrontmatter } from "./frontmatter.js";
 import {
   hasBase64DecodedShell,
   hasPipeToShellInstall,
-  hasRecursiveForceRemove,
   hasWorldWritableChmod,
 } from "./command-safety-lib.js";
 import {
@@ -956,13 +955,16 @@ const LOCAL_SCRIPT_REFERENCE_PATTERN =
 // query-param and path-based affiliate checks used by both field validation
 // (submission-lib.js) and this snippet scanner so both gates agree.
 
-// True when install text contains recursive-force rm or world-writable chmod,
-// using the same hardened detectors as scanDangerousShellPatterns (#5640).
+// True when install text contains world-writable chmod, using the same
+// hardened detector as scanDangerousShellPatterns (#5640). Recursive-force
+// `rm` is intentionally *not* OR'd here (#5709): unscoped `rm -rf ./dist`
+// cleanup is ordinary install hygiene and must not raise critical
+// `unsafe_install_pipeline`. Root/home targets stay covered by
+// `referencesDestructiveRootRemoval` in the same OR-chain.
 // Line-by-line like the curl/base64 helpers; installText is already lowercased.
 function hasDestructiveInstallShellPatterns(installText) {
   for (const line of String(installText ?? "").split(/\r?\n/)) {
     if (!line) continue;
-    if (hasRecursiveForceRemove(line, line)) return true;
     if (hasWorldWritableChmod(line, line)) return true;
   }
   return false;
@@ -1131,16 +1133,17 @@ function isMutableGithubSourceUrl(value) {
  * whether written `-rf`, `-fr`, `-r -f`, or `--recursive --force`.
  *
  * Targets stay deliberately narrow (`/`, `/etc`, `~`, `$HOME`, and
- * `${HOME}`). Relative paths like `./build` are ordinary cleanup and must
- * not flag. Each target alternative ends in a delimiter/end-of-command
- * lookahead so `/tmp/scratch`, `~/cache`, and `$HOME/tmp` aren't swallowed
- * as a matching prefix of `/`, `~`, or `$HOME` - only the bare target
- * itself (optionally with one trailing `/`) is destructive.
+ * `${HOME}`, plus glob-suffixed forms like `/*` / `~/*` — #5709). Relative
+ * paths like `./build` are ordinary cleanup and must not flag. Each target
+ * alternative ends in a delimiter/end-of-command lookahead so
+ * `/tmp/scratch`, `~/cache`, and `$HOME/tmp` aren't swallowed as a matching
+ * prefix of `/`, `~`, or `$HOME` - only the bare target itself (optionally
+ * with one trailing `/` or a trailing `/*` glob) is destructive.
  */
 function referencesDestructiveRootRemoval(value) {
   const text = String(value || "");
   const pattern =
-    /\brm\b((?:\s+-{1,2}[a-z][a-z-]*)+)\s+(?:\/etc\/?(?=[\s;&|)'"`]|$)|\/\/?(?=[\s;&|)'"`]|$)|~\/?(?=[\s;&|)'"`]|$)|\$home\/?(?=[\s;&|)'"`]|$)|\$\{home\}\/?(?=[\s;&|)'"`]|$))/gi;
+    /\brm\b((?:\s+-{1,2}[a-z][a-z-]*)+)\s+(?:\/etc(?:\/\*|\/?(?=[\s;&|)'"`]|$))|\/(?:\*|\/?(?=[\s;&|)'"`]|$))|~(?:\/\*|\/?(?=[\s;&|)'"`]|$))|\$home(?:\/\*|\/?(?=[\s;&|)'"`]|$))|\$\{home\}(?:\/\*|\/?(?=[\s;&|)'"`]|$)))/gi;
 
   for (const match of text.matchAll(pattern)) {
     const flags = match[1].toLowerCase().split(/\s+/).filter(Boolean);

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -886,14 +886,22 @@ describe("destructive rm detection", () => {
     // optional trailing slash.
     "rm -rf $HOME/",
     "rm -rf ${HOME}/",
+    // #5709: glob-suffixed root/home targets are destructive one-liners.
+    "rm -rf /*",
+    "rm -rf ~/*",
+    "rm -rf $HOME/*",
+    "rm -rf ${HOME}/*",
+    "rm -rf /etc/*",
   ])("flags %s", (command) => {
     expect(flagged(command)).toBe(true);
   });
 
-  // #5640 ORs hasRecursiveForceRemove into unsafe_install_pipeline, so any
-  // recursive+force rm flags — not only root/home targets.
+  // #5709: unscoped recursive-force rm must not raise critical on ordinary
+  // relative/tmp cleanup (hasDestructiveInstallShellPatterns no longer ORs
+  // hasRecursiveForceRemove). Root/home targets stay covered above.
   it.each([
     "rm -rf ./build",
+    "rm -rf ./dist",
     "rm -rf node_modules",
     "rm -rf /tmp/scratch",
     "rm -rf /tmp/build-cache",
@@ -901,8 +909,8 @@ describe("destructive rm detection", () => {
     "rm -rf $HOME/tmp",
     "rm -rf ${HOME}/tmp",
     "rm -rf ~/cache",
-  ])("flags recursive-force rm for non-root target %s (#5640)", (command) => {
-    expect(flagged(command)).toBe(true);
+  ])("does not flag ordinary cleanup %s (#5709)", (command) => {
+    expect(flagged(command)).toBe(false);
   });
 
   it.each([
@@ -1169,12 +1177,12 @@ describe("unsafe_install_pipeline rm/chmod via command-safety-lib (#5640)", () =
     );
   }
 
-  it("flags non-root recursive-force rm that root-only check missed", () => {
+  it("does not flag ordinary relative recursive-force rm (#5709)", () => {
     expect(
       riskFlagIds(
         "git clone https://example.com/y.git && cd y && rm -rf ../shared-config",
       ),
-    ).toContain("unsafe_install_pipeline");
+    ).not.toContain("unsafe_install_pipeline");
   });
 
   it("flags world-writable chmod in install snippets", () => {
@@ -1188,6 +1196,12 @@ describe("unsafe_install_pipeline rm/chmod via command-safety-lib (#5640)", () =
   it("still flags root-targeted rm -rf", () => {
     expect(
       riskFlagIds("curl https://example.com/x.sh | bash; rm -rf /"),
+    ).toContain("unsafe_install_pipeline");
+  });
+
+  it("flags glob-suffixed root removal (#5709)", () => {
+    expect(
+      riskFlagIds("curl https://example.com/x.sh | bash; rm -rf /*"),
     ).toContain("unsafe_install_pipeline");
   });
 });


### PR DESCRIPTION
## Summary
- Closes #5709
- Stop OR'ing unscoped `hasRecursiveForceRemove` into critical `unsafe_install_pipeline` via `hasDestructiveInstallShellPatterns` — ordinary `rm -rf ./dist` / `node_modules` cleanup no longer raises critical.
- Extend `referencesDestructiveRootRemoval` so glob-suffixed root/home targets (`/*`, `~/*`, `C:\Users\admin/*`, `C:\Users\admin/*`, `/etc/*`) are flagged.
- World-writable `chmod 777` detection and general `scanDangerousShellPatterns` recursive-force checks are unchanged.

## Before / after (`unsafe_install_pipeline`)

| Install snippet | Before | After |
| --- | --- | --- |
| `rm -rf ./dist` | critical | clean |
| `rm -rf ./build` | critical | clean |
| `rm -rf node_modules` | critical | clean |
| `rm -rf /tmp/build-cache` | critical | clean |
| `rm -rf /` | critical | critical |
| `rm -rf /etc` | critical | critical |
| `rm -rf ~` / `C:\Users\admin` | critical | critical |
| `rm -rf /*` | clean | critical |
| `rm -rf ~/*` | clean | critical |
| `chmod -R 777 .` | critical | critical |

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/submission-risk-invariants.test.ts tests/command-safety.test.ts tests/command-safety-lib.test.ts tests/command-safety-posix-shell.test.ts`