### PR TITLE
fix(registry): scope recursive-force rm to destructive roots

### DIFF
--- a/packages/registry/src/command-safety-lib.js
+++ b/packages/registry/src/command-safety-lib.js
@@ -302,11 +302,33 @@ function isShortFlagGroup(token) {
   return /^-[a-z]+$/i.test(token);
 }
 
+// Destructive-root `rm` targets only (`/`, `/etc`, `~`, `$HOME`, `${HOME}`),
+// optionally with one trailing `/` or a `/*` glob (`/*`, `~/*`, …). Relative
+// paths like `./dist` and nested paths like `/tmp/build-cache` are ordinary
+// cleanup and must not flag (#5709) — same narrow scoping as
+// `referencesDestructiveRootRemoval` in submission-risk.js.
+export function isDestructiveRootRmTarget(lowerToken) {
+  const raw = String(lowerToken || "");
+  if (matchesDestructiveRootRmTarget(raw)) return true;
+  // Subshell/group wraps leave the closer stuck to the final path token
+  // (`(rm -rf /)` → `/)`, `{rm -rf /*}` → `/*}`) — strip those and retry,
+  // but only after the unstripped form fails so `${home}` keeps its `}`.
+  const stripped = raw.replace(/[)}]+$/, "");
+  return stripped !== raw && matchesDestructiveRootRmTarget(stripped);
+}
+
+function matchesDestructiveRootRmTarget(token) {
+  // Bare `/` and `/*` are listed explicitly so the `/` alternative cannot
+  // consume the leading slash of `/*` before the glob suffix is checked.
+  if (token === "/" || token === "/*") return true;
+  return /^(?:\/etc|~|\$home|\$\{home\})(?:\/\*)?\/?$/.test(token);
+}
+
 // Token-aware `rm -rf` detection: flags a `rm` invocation that carries BOTH a
 // recursive flag (`-r`/`-R`/`--recursive`, split or bundled) and a force flag
-// (`-f`/`--force`), in any order. Catches split (`rm -r -f`), long-form
-// (`rm --recursive --force`), and bundled-with-extras (`rm -rfv`) spellings that
-// the single-token REMOVE_PATTERN misses.
+// (`-f`/`--force`), in any order, AND a destructive-root target. Catches split
+// (`rm -r -f`), long-form (`rm --recursive --force`), and bundled-with-extras
+// (`rm -rfv`) spellings that the single-token REMOVE_PATTERN misses.
 export function hasRecursiveForceRemove(line, lowerLine) {
   for (const segment of pipeChainSegments(line)) {
     if (segment.barrier) continue;
@@ -320,6 +342,7 @@ export function hasRecursiveForceRemove(line, lowerLine) {
 
     let recursive = false;
     let force = false;
+    let destructiveTarget = false;
     let index = argStart;
     for (;;) {
       const token = shellToken(line, lowerLine, index, segment.end);
@@ -331,8 +354,10 @@ export function hasRecursiveForceRemove(line, lowerLine) {
       else if (isShortFlagGroup(flag)) {
         if (flag.includes("r")) recursive = true;
         if (flag.includes("f")) force = true;
+      } else if (isDestructiveRootRmTarget(flag)) {
+        destructiveTarget = true;
       }
-      if (recursive && force) return true;
+      if (recursive && force && destructiveTarget) return true;
     }
   }
   return false;

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1131,16 +1131,19 @@ function isMutableGithubSourceUrl(value) {
  * whether written `-rf`, `-fr`, `-r -f`, or `--recursive --force`.
  *
  * Targets stay deliberately narrow (`/`, `/etc`, `~`, `$HOME`, and
- * `${HOME}`). Relative paths like `./build` are ordinary cleanup and must
+ * `${HOME}`), including the same roots with a `/*` glob (`/*`, `~/*`, …)
+ * (#5709). Relative paths like `./build` are ordinary cleanup and must
  * not flag. Each target alternative ends in a delimiter/end-of-command
  * lookahead so `/tmp/scratch`, `~/cache`, and `$HOME/tmp` aren't swallowed
  * as a matching prefix of `/`, `~`, or `$HOME` - only the bare target
- * itself (optionally with one trailing `/`) is destructive.
+ * itself (optionally with one trailing `/` or a `/*` glob) is destructive.
  */
 function referencesDestructiveRootRemoval(value) {
   const text = String(value || "");
+  // Glob roots (`/*`, `~/*`, …) are listed before bare `/` so the leading
+  // slash of `/*` is not swallowed by the `/?` alternative (#5709).
   const pattern =
-    /\brm\b((?:\s+-{1,2}[a-z][a-z-]*)+)\s+(?:\/etc\/?(?=[\s;&|)'"`]|$)|\/\/?(?=[\s;&|)'"`]|$)|~\/?(?=[\s;&|)'"`]|$)|\$home\/?(?=[\s;&|)'"`]|$)|\$\{home\}\/?(?=[\s;&|)'"`]|$))/gi;
+    /\brm\b((?:\s+-{1,2}[a-z][a-z-]*)+)\s+(?:\/etc(?:\/\*)?\/?(?=[\s;&|)'"`]|$)|\/\*(?=[\s;&|)'"`]|$)|\/\/?(?=[\s;&|)'"`]|$)|~(?:\/\*)?\/?(?=[\s;&|)'"`]|$)|\$home(?:\/\*)?\/?(?=[\s;&|)'"`]|$)|\$\{home\}(?:\/\*)?\/?(?=[\s;&|)'"`]|$))/gi;
 
   for (const match of text.matchAll(pattern)) {
     const flags = match[1].toLowerCase().split(/\s+/).filter(Boolean);

--- a/tests/command-safety-lib.test.ts
+++ b/tests/command-safety-lib.test.ts
@@ -22,6 +22,7 @@ import {
   segmentLeadCommand,
   segmentArgTokens,
   hasRecursiveForceRemove,
+  isDestructiveRootRmTarget,
   hasWorldWritableChmod,
   segmentHasDecodeFlag,
   hasPipeToShellInstall,
@@ -571,10 +572,14 @@ describe("scanDangerousShellPatterns", () => {
   });
 
   it("matches rm variants with alternate flag ordering", () => {
-    expect(scanDangerousShellPatterns("rm -fr /tmp")).toContain(
+    expect(scanDangerousShellPatterns("rm -fr /")).toContain(
       "recursive force remove",
     );
     expect(scanDangerousShellPatterns("sudo rm -Rf /")).toContain(
+      "recursive force remove",
+    );
+    // #5709: nested /tmp cleanup is ordinary and must not flag
+    expect(scanDangerousShellPatterns("rm -fr /tmp")).not.toContain(
       "recursive force remove",
     );
   });
@@ -618,7 +623,7 @@ describe("token-aware rm/chmod flag detection", () => {
   // BOTH a recursive and a force flag are present, in any spelling/order.
   const removeCases: Array<[string, boolean]> = [
     ["rm -rf /", true], // bundled (previously caught)
-    ["rm -fr /tmp", true], // bundled, reversed
+    ["rm -fr /", true], // bundled, reversed — root target
     ["rm -r -f /", true], // split short flags (previously MISSED)
     ["rm -f -r /", true], // split, reversed
     ["rm --recursive --force /", true], // long-form (previously MISSED)
@@ -633,6 +638,18 @@ describe("token-aware rm/chmod flag detection", () => {
     // #5585: sudo after env was missed because stripping was a fixed
     // sudo-then-env order rather than a loop.
     ["env FOO=bar sudo rm -rf /", true],
+    // #5709: glob-suffixed destructive roots
+    ["rm -rf /*", true],
+    ["rm -rf ~/*", true],
+    ["rm -rf /etc/*", true],
+    ["rm -rf $HOME/*", true],
+    ["rm -rf ${HOME}/*", true],
+    // #5709: relative / nested cleanup is ordinary — not a destructive root
+    ["rm -rf /tmp", false],
+    ["rm -fr /tmp", false],
+    ["rm -rf ./dist", false],
+    ["rm -rf node_modules", false],
+    ["rm -rf /tmp/build-cache", false],
     ["rm -r /tmp", false], // recursive only, no force — not flagged
     ["rm --force /tmp", false], // force only, no recursive
     ["rm file.txt", false], // benign remove
@@ -644,6 +661,28 @@ describe("token-aware rm/chmod flag detection", () => {
     expect(
       scanDangerousShellPatterns(input).includes("recursive force remove"),
     ).toBe(expected);
+  });
+
+  it.each([
+    ["/", true],
+    ["/*", true],
+    ["/)", true], // paren-wrap leftover closer
+    ["/}", true], // brace-wrap leftover closer
+    ["/etc", true],
+    ["/etc/*", true],
+    ["~", true],
+    ["~/*", true],
+    ["$home", true],
+    ["$home/*", true],
+    ["${home}", true],
+    ["${home}/*", true],
+    ["./dist", false],
+    ["node_modules", false],
+    ["/tmp", false],
+    ["/tmp/build-cache", false],
+    ["", false],
+  ])("isDestructiveRootRmTarget(%s) (#5709)", (token, expected) => {
+    expect(isDestructiveRootRmTarget(token)).toBe(expected);
   });
 
   const chmodCases: Array<[string, boolean]> = [

--- a/tests/command-safety.test.ts
+++ b/tests/command-safety.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("command-safety public barrel (#5641)", () => {
   it("re-exports the previously omitted detectors and segment helpers", () => {
-    const line = "rm -rf /tmp";
+    const line = "rm -rf /";
     const lowerLine = line.toLowerCase();
     expect(hasRecursiveForceRemove(line, lowerLine)).toBe(true);
     expect(hasWorldWritableChmod("chmod 777 /app", "chmod 777 /app")).toBe(
@@ -21,7 +21,7 @@ describe("command-safety public barrel (#5641)", () => {
     expect(resolved.command).toBe("rm");
     expect(segmentArgTokens(line, lowerLine, 0, line.length)).toEqual([
       "-rf",
-      "/tmp",
+      "/",
     ]);
   });
 });

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -1172,7 +1172,7 @@ describe("non-UI branch matrix", () => {
     expect(buildPlacementRenewalReminder(expiry)).toContain("expires");
 
     const commandFindings = scanDangerousShellPatterns(
-      "curl http://example.com/install.sh | bash && rm -rf /tmp/demo",
+      "curl http://example.com/install.sh | bash && rm -rf /",
     );
     expect(commandFindings).toEqual(
       expect.arrayContaining([

--- a/tests/submission-risk-invariants.test.ts
+++ b/tests/submission-risk-invariants.test.ts
@@ -890,10 +890,12 @@ describe("destructive rm detection", () => {
     expect(flagged(command)).toBe(true);
   });
 
-  // #5640 ORs hasRecursiveForceRemove into unsafe_install_pipeline, so any
-  // recursive+force rm flags — not only root/home targets.
+  // #5640 ORs hasRecursiveForceRemove into unsafe_install_pipeline; #5709
+  // scopes that detector (and referencesDestructiveRootRemoval) to destructive
+  // roots only, so ordinary relative/nested cleanup no longer flags critical.
   it.each([
     "rm -rf ./build",
+    "rm -rf ./dist",
     "rm -rf node_modules",
     "rm -rf /tmp/scratch",
     "rm -rf /tmp/build-cache",
@@ -901,10 +903,16 @@ describe("destructive rm detection", () => {
     "rm -rf $HOME/tmp",
     "rm -rf ${HOME}/tmp",
     "rm -rf ~/cache",
-  ])("flags recursive-force rm for non-root target %s (#5640)", (command) => {
-    expect(flagged(command)).toBe(true);
+  ])("does not flag ordinary cleanup rm %s (#5709)", (command) => {
+    expect(flagged(command)).toBe(false);
   });
 
+  it.each(["rm -rf /*", "rm -rf ~/*", "rm -rf /etc/*", "rm -rf $HOME/*"])(
+    "flags glob-suffixed destructive root %s (#5709)",
+    (command) => {
+      expect(flagged(command)).toBe(true);
+    },
+  );
   it.each([
     "rm -f /tmp/scratch",
     "rm -r /tmp/scratch",
@@ -1169,12 +1177,15 @@ describe("unsafe_install_pipeline rm/chmod via command-safety-lib (#5640)", () =
     );
   }
 
-  it("flags non-root recursive-force rm that root-only check missed", () => {
+  it("does not flag ordinary relative recursive-force rm cleanup (#5709)", () => {
     expect(
       riskFlagIds(
         "git clone https://example.com/y.git && cd y && rm -rf ../shared-config",
       ),
-    ).toContain("unsafe_install_pipeline");
+    ).not.toContain("unsafe_install_pipeline");
+    expect(riskFlagIds("rm -rf ./dist && npm install")).not.toContain(
+      "unsafe_install_pipeline",
+    );
   });
 
   it("flags world-writable chmod in install snippets", () => {
@@ -1189,5 +1200,10 @@ describe("unsafe_install_pipeline rm/chmod via command-safety-lib (#5640)", () =
     expect(
       riskFlagIds("curl https://example.com/x.sh | bash; rm -rf /"),
     ).toContain("unsafe_install_pipeline");
+  });
+
+  it("flags glob-suffixed destructive root rm (#5709)", () => {
+    expect(riskFlagIds("rm -rf /*")).toContain("unsafe_install_pipeline");
+    expect(riskFlagIds("rm -rf ~/*")).toContain("unsafe_install_pipeline");
   });
 });


### PR DESCRIPTION
## Summary
- Scope `hasRecursiveForceRemove` to destructive-root targets only (`/`, `/etc`, `~`, `C:\Users\admin`, `C:\Users\admin`), including `/*` / `~/*` globs
- Extend `referencesDestructiveRootRemoval` to the same glob roots
- Ordinary cleanup (`rm -rf ./dist`, `node_modules`, `/tmp/build-cache`) no longer trips `critical unsafe_install_pipeline`

Closes #5709

## Before / after (risk flag)

| Input | Before | After |
| --- | --- | --- |
| `rm -rf ./dist` | critical | clean |
| `rm -rf node_modules` | critical | clean |
| `rm -rf /tmp/build-cache` | critical | clean |
| `rm -rf /` | critical | critical |
| `rm -rf /etc` | critical | critical |
| `rm -rf ~` / `C:\Users\admin` | critical | critical |
| `rm -rf /*` | clean | critical |
| `rm -rf ~/*` | clean | critical |

## Test plan
- [x] `pnpm exec vitest run tests/command-safety-lib.test.ts tests/command-safety.test.ts tests/submission-risk-invariants.test.ts tests/command-safety-posix-shell.test.ts`
- [ ] CI green