### PR TITLE
fix(web): align entry WebPage dateModified with sitemap freshness

### DIFF
--- a/apps/web/src/lib/entry-webpage-jsonld-lib.ts
+++ b/apps/web/src/lib/entry-webpage-jsonld-lib.ts
@@ -3,9 +3,30 @@
 // isBasedOn) can be unit-tested without rendering the route.
 
 import type { Entry } from "@/types/registry";
+import { safeSitemapDate } from "@/lib/sitemap-policy";
+
+/** Freshness fields that live on the raw registry snapshot (not client Entry). */
+export type EntryWebPageFreshness = {
+  contentUpdatedAt?: string | null;
+  repoUpdatedAt?: string | null;
+  verifiedAt?: string | null;
+};
+
+/**
+ * dateModified for entry WebPage JSON-LD: prefer the same content/repo/verified
+ * priority the sitemap uses for lastmod (#5472 / #5675), then fall back to the
+ * historical reviewedAt ?? dateAdded mapping when those signals are absent.
+ */
+export function entryWebPageDateModified(
+  entry: Pick<Entry, "dateAdded"> & { reviewedAt?: string } & EntryWebPageFreshness,
+): string {
+  const fresh = entry.contentUpdatedAt || entry.repoUpdatedAt || entry.verifiedAt || null;
+  if (fresh && safeSitemapDate(fresh)) return fresh;
+  return entry.reviewedAt ?? entry.dateAdded;
+}
 
 /** schema.org WebPage JSON-LD for an entry at the given absolute url. */
-export function entryWebPageJsonLd(entry: Entry, url: string) {
+export function entryWebPageJsonLd(entry: Entry & EntryWebPageFreshness, url: string) {
   return {
     "@context": "https://schema.org",
     "@type": "WebPage",
@@ -13,7 +34,7 @@ export function entryWebPageJsonLd(entry: Entry, url: string) {
     description: entry.description,
     url,
     datePublished: entry.dateAdded,
-    dateModified: entry.reviewedAt ?? entry.dateAdded,
+    dateModified: entryWebPageDateModified(entry),
     about: entry.category,
     author: { "@type": "Person", name: entry.author },
     ...(entry.sourceUrl ? { isBasedOn: entry.sourceUrl } : {}),

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -19,7 +19,7 @@ import {
 } from "lucide-react";
 import { getEntry, related, relatedGroups, relatedGuides } from "@/data/search";
 import { getEntryRedirectTarget } from "@/lib/entry-redirects";
-import { BEST_LISTS, ENTRIES } from "@/data/entries";
+import { BEST_LISTS, ENTRIES, REGISTRY_ENTRIES } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
 import { EntryAuthorAttribution } from "@/components/contributor-attribution";
 import { findContributorForIdentity } from "@/data/contributors";
@@ -39,7 +39,7 @@ import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { entryBreadcrumbJsonLd } from "@/lib/entry-breadcrumb-jsonld-lib";
-import { entryWebPageJsonLd } from "@/lib/entry-webpage-jsonld-lib";
+import { entryWebPageDateModified, entryWebPageJsonLd } from "@/lib/entry-webpage-jsonld-lib";
 import { hasSchemaDetails } from "@/lib/entry-schema-details-lib";
 import { booleanLabel } from "@/lib/boolean-label-lib";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -234,7 +234,20 @@ export const Route = createFileRoute("/entry/$category/$slug")({
     const e = loaderData.entry;
     const path = `/entry/${params.category}/${params.slug}`;
     const url = absoluteUrl(path);
-    const ld = entryWebPageJsonLd(e, url);
+    // contentUpdatedAt/repoUpdatedAt live on the raw registry snapshot only
+    // (buildEntry drops them); look up the sibling the way sitemap.xml does
+    // so WebPage dateModified matches sitemap lastmod (#5675).
+    const raw = REGISTRY_ENTRIES.find(
+      (entry) => entry.category === e.category && entry.slug === e.slug,
+    );
+    const freshEntry = {
+      ...e,
+      contentUpdatedAt: raw?.contentUpdatedAt,
+      repoUpdatedAt: raw?.repoUpdatedAt,
+      verifiedAt: raw?.verifiedAt,
+    };
+    const ld = entryWebPageJsonLd(freshEntry, url);
+    const modifiedTime = entryWebPageDateModified(freshEntry);
     const breadcrumbs = entryBreadcrumbJsonLd(e, url, absoluteUrl);
     const ogUrl = absoluteUrl(`/og/${params.category}/${params.slug}`);
     const ogTitle = `${e.title} — HeyClaude`;
@@ -258,7 +271,7 @@ export const Route = createFileRoute("/entry/$category/$slug")({
         { property: "og:image:width", content: "1200" },
         { property: "og:image:height", content: "630" },
         { property: "article:published_time", content: e.dateAdded },
-        { property: "article:modified_time", content: e.reviewedAt ?? e.dateAdded },
+        { property: "article:modified_time", content: modifiedTime },
         ...(e.author ? [{ property: "article:author", content: e.author }] : []),
         { property: "article:section", content: e.category },
         ...(e.tags ?? []).map((tag) => ({ property: "article:tag", content: tag })),

--- a/tests/entry-webpage-jsonld-lib.test.ts
+++ b/tests/entry-webpage-jsonld-lib.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { Entry } from "../apps/web/src/types/registry";
-import { entryWebPageJsonLd } from "../apps/web/src/lib/entry-webpage-jsonld-lib";
+import {
+  entryWebPageDateModified,
+  entryWebPageJsonLd,
+} from "../apps/web/src/lib/entry-webpage-jsonld-lib";
 
 const entry = (over: Record<string, unknown> = {}): Entry =>
   ({
@@ -37,5 +40,74 @@ describe("entryWebPageJsonLd", () => {
     expect(
       entryWebPageJsonLd(entry({ sourceUrl: "https://github.com/o/r" }), URL),
     ).toMatchObject({ isBasedOn: "https://github.com/o/r" });
+  });
+});
+
+describe("entryWebPageDateModified (#5675)", () => {
+  it("prefers contentUpdatedAt over repoUpdatedAt/verifiedAt/reviewedAt", () => {
+    expect(
+      entryWebPageDateModified(
+        entry({
+          reviewedAt: "2026-02-02",
+          verifiedAt: "2026-02-10",
+          repoUpdatedAt: "2026-03-15T12:00:00.000Z",
+          contentUpdatedAt: "2026-04-01T00:00:00.000Z",
+        }),
+      ),
+    ).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  it("prefers repoUpdatedAt over verifiedAt/reviewedAt when contentUpdatedAt is absent", () => {
+    expect(
+      entryWebPageDateModified(
+        entry({
+          reviewedAt: "2026-02-02",
+          verifiedAt: "2026-02-10",
+          repoUpdatedAt: "2026-03-15T12:00:00.000Z",
+        }),
+      ),
+    ).toBe("2026-03-15T12:00:00.000Z");
+  });
+
+  it("prefers verifiedAt over reviewedAt when content/repo signals are absent", () => {
+    expect(
+      entryWebPageDateModified(
+        entry({
+          reviewedAt: "2026-02-02",
+          verifiedAt: "2026-02-10T08:00:00.000Z",
+        }),
+      ),
+    ).toBe("2026-02-10T08:00:00.000Z");
+  });
+
+  it("ignores invalid freshness strings and keeps the reviewedAt/dateAdded fallback", () => {
+    expect(
+      entryWebPageDateModified(
+        entry({
+          reviewedAt: "2026-02-02",
+          repoUpdatedAt: "not-a-date",
+        }),
+      ),
+    ).toBe("2026-02-02");
+    expect(
+      entryWebPageDateModified(
+        entry({
+          contentUpdatedAt: "also-invalid",
+        }),
+      ),
+    ).toBe("2026-01-01");
+  });
+
+  it("treats empty/null freshness fields as absent", () => {
+    expect(
+      entryWebPageDateModified(
+        entry({
+          reviewedAt: "2026-02-02",
+          contentUpdatedAt: null,
+          repoUpdatedAt: "",
+          verifiedAt: null,
+        }),
+      ),
+    ).toBe("2026-02-02");
   });
 });


### PR DESCRIPTION
## Summary
- Entry detail WebPage JSON-LD `dateModified` prefers `contentUpdatedAt` / `repoUpdatedAt` / `verifiedAt` (same priority as sitemap `lastmod`)
- Looks up raw `REGISTRY_ENTRIES` in the entry route head (same pattern as `sitemap.xml`)
- `article:modified_time` uses the same helper so OG/JSON-LD stay aligned
- Falls back to `reviewedAt ?? dateAdded` when freshness fields are absent or invalid

Closes #5675

## Before / after (synthetic)

| Signals | Before `dateModified` | After |
| --- | --- | --- |
| `repoUpdatedAt=2026-03-15`, `reviewedAt=2026-02-02` | `2026-02-02` | `2026-03-15T…` |
| no freshness fields, `reviewedAt` set | `reviewedAt` | unchanged |
| no freshness / reviewed | `dateAdded` | unchanged |

Structured-data only — no visual change.

## Test plan
- [x] `pnpm exec prettier --check apps/web/src/lib/entry-webpage-jsonld-lib.ts`
- [x] `pnpm exec vitest run tests/entry-webpage-jsonld-lib.test.ts`
- [ ] CI green (`validate-ci` / Trunk Check)