### PR TITLE
fix(web): implement browse Escape-to-clear search shortcut (#5716)

### DIFF
--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -688,7 +688,7 @@ function Browse() {
     value: string,
   ) => facetCounts[axis]?.[value] ?? 0;
 
-  // Focus search on "/" key.
+  // Focus search on "/" key; cycle view density on "[" / "]".
   const searchRef = React.useRef<HTMLInputElement>(null);
   useKeyboardShortcuts({
     "/": () => searchRef.current?.focus(),
@@ -696,6 +696,23 @@ function Browse() {
       set({ view: sp.view === "compact" ? "row" : sp.view === "row" ? "grid" : "compact" }),
     "[": () => set({ view: sp.view === "grid" ? "row" : sp.view === "row" ? "compact" : "grid" }),
   });
+  // Escape clears search while the input has focus (#5716). Needs whenTyping so
+  // the shared hook does not skip bindings inside INPUT; keep it on a separate
+  // registration so "/" / "[" / "]" stay suppressed while typing.
+  useKeyboardShortcuts(
+    {
+      Escape: () => {
+        if (document.activeElement !== searchRef.current) return;
+        if (!qInput) return;
+        trackEvent(
+          browseSearchClearAnalyticsEvent(),
+          browseSearchClearAnalyticsData(Boolean(qInput.trim()), results.length),
+        );
+        setQInput("");
+      },
+    },
+    { whenTyping: true },
+  );
 
   const recentEntries = recents.entries
     .map((r) => entryByRef(r.category, r.slug))

--- a/tests/browse-esc-clear-search.test.ts
+++ b/tests/browse-esc-clear-search.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+const browseSource = () =>
+  fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/browse.tsx"),
+    "utf8",
+  );
+
+describe("browse Escape clears search input (#5716)", () => {
+  // Hint strip advertises esc → clear input, but shortcuts only bound "/" and
+  // "["/"]". Escape must register with whenTyping so it works inside the
+  // search INPUT; keep it on a separate call so density shortcuts stay quiet.
+  it("registers Escape with whenTyping and clears qInput when search is focused", () => {
+    const source = browseSource();
+    expect(source).toMatch(/Escape:\s*\(\)\s*=>/);
+    expect(source).toContain("{ whenTyping: true }");
+    expect(source).toContain("document.activeElement !== searchRef.current");
+    expect(source).toContain('setQInput("")');
+    expect(source).toContain(">esc</kbd>");
+    expect(source).toContain("clear input");
+  });
+
+  it("keeps / and density shortcuts on a registration without whenTyping", () => {
+    const source = browseSource();
+    // First registration: focus + density only.
+    expect(source).toMatch(
+      /useKeyboardShortcuts\(\{\s*"\/":[\s\S]*?"\]":[\s\S]*?"\[":[\s\S]*?\}\);/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5716
- `/browse` advertised `esc` clear input but never bound Escape.
- Register Escape with `{ whenTyping: true }` on a separate `useKeyboardShortcuts` call so it clears the focused search input without enabling `/` / `[` / `]` while typing.
- Reuses the existing clear-search analytics event used by the X button.

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/browse-esc-clear-search.test.ts`
- [ ] Press Escape in the browse search box with text → input clears