### PR TITLE
fix(web): show result counts on browse mobile category chips (#5717)

### DIFF
--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -1148,6 +1148,7 @@ function Browse() {
                     role="radio"
                     active={(sp.category || "") === c.id}
                     onClick={() => onCategoryFilter(c.id)}
+                    count={c.id ? axisCount("category", c.id) : undefined}
                   >
                     {c.label}
                   </FilterChip>

--- a/tests/browse-mobile-category-counts.test.ts
+++ b/tests/browse-mobile-category-counts.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+const browseSource = () =>
+  fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/browse.tsx"),
+    "utf8",
+  );
+
+describe("browse mobile category chips show counts (#5717)", () => {
+  // Desktop category chips and mobile signal chips already pass axisCount;
+  // the mobile category row omitted count — pin parity at the source.
+  it("passes axisCount category counts on the mobile category FilterChip row", () => {
+    const source = browseSource();
+    expect(source).toContain('aria-label="Filter by category"');
+    expect(source).toContain(
+      'count={c.id ? axisCount("category", c.id) : undefined}',
+    );
+  });
+
+  it("keeps desktop category counts and mobile signal counts as references", () => {
+    const source = browseSource();
+    expect(source).toContain('count={axisCount("category", c.id)}');
+    expect(source).toContain('count={axisCount("signal", option.id)}');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5717
- Mobile category chips on `/browse` omitted the `count` prop that desktop category chips and mobile trust-signal chips already pass.
- Pass `axisCount("category", c.id)` for real categories; omit count on the synthetic All chip (matches desktop).

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/browse-mobile-category-counts.test.ts`
- [ ] Confirm mobile category row shows muted counts and dims zero-match chips