### PR TITLE
fix(web): URL-sync /tags topic-filter search box (#5712)

### DIFF
--- a/apps/web/src/routes/tags.index.tsx
+++ b/apps/web/src/routes/tags.index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, stripSearchParams } from "@tanstack/react-router";
+import { z } from "zod";
 import { Search } from "lucide-react";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
@@ -22,7 +23,17 @@ import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { cn } from "@/lib/utils";
 
+const defaultSearch = { q: "" };
+
+const tagsSearchSchema = z.object({
+  q: z.string().catch(defaultSearch.q).default(defaultSearch.q),
+});
+
 export const Route = createFileRoute("/tags/")({
+  validateSearch: tagsSearchSchema,
+  search: {
+    middlewares: [stripSearchParams(defaultSearch)],
+  },
   head: () => {
     const url = absoluteUrl("/tags");
     const title = "Browse Claude resources by tag — HeyClaude";
@@ -117,8 +128,22 @@ function TagPill({
 }
 
 function TagsIndex() {
+  const sp = Route.useSearch();
+  const navigate = Route.useNavigate();
   const all = React.useMemo(() => getIndexableTagGroups().map(toTagView), []);
-  const [query, setQuery] = React.useState("");
+  // Debounce free-text query: local state drives the input; URL updates 250ms after idle (#5712).
+  const [query, setQuery] = React.useState(sp.q);
+  React.useEffect(() => {
+    setQuery(sp.q);
+  }, [sp.q]);
+  React.useEffect(() => {
+    if (query === sp.q) return;
+    const t = window.setTimeout(() => {
+      navigate({ search: (prev: typeof sp) => ({ ...prev, q: query }), replace: true });
+    }, 250);
+    return () => window.clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
   const q = query.trim().toLowerCase();
 
   const filtered = React.useMemo(

--- a/tests/tags-topic-filter-url-sync.test.ts
+++ b/tests/tags-topic-filter-url-sync.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+const tagsSource = () =>
+  fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/tags.index.tsx"),
+    "utf8",
+  );
+
+describe("tags topic-filter URL sync (#5712)", () => {
+  it("defines validateSearch with q and strips empty defaults", () => {
+    const source = tagsSource();
+    expect(source).toContain("validateSearch: tagsSearchSchema");
+    expect(source).toContain("stripSearchParams(defaultSearch)");
+    expect(source).toContain("q: z.string()");
+    expect(source).toContain('q: ""');
+  });
+
+  it("debounces local input into navigate({ search }) like browse", () => {
+    const source = tagsSource();
+    expect(source).toContain("Route.useSearch()");
+    expect(source).toContain("Route.useNavigate()");
+    expect(source).toContain("React.useState(sp.q)");
+    expect(source).toContain(
+      "navigate({ search: (prev: typeof sp) => ({ ...prev, q: query }), replace: true })",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5712
- `/tags` topic filter lived only in `useState`, so filtered views could not be bookmarked or shared.
- Add zod `validateSearch` for `q`, debounce local input into `navigate({ search })`, and `stripSearchParams` so empty `q` stays off the URL (same pattern as `/browse`).

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/tags-topic-filter-url-sync.test.ts`
- [ ] Type a filter on `/tags` → URL updates; reload preserves text; clear filter strips `?q=`