### PR TITLE
fix(ci): enforce tools-listing classification in content-policy gate (#5681)

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -54,6 +54,18 @@ const PRIVACY_NOTE_REQUIRED_FLAGS = new Set([
   "embedded_secret",
 ]);
 
+// Keep in sync with packages/registry/src/submission-classification-lib.js (#5681).
+const TOOLS_CATEGORY = "tools";
+const TOOLS_LISTING_FLOW_URL = "https://heyclau.de/tools/submit";
+const TOOL_LISTING_REVIEW_FIELDS = [
+  ["websiteUrl", ["website_url", "websiteUrl"]],
+  ["documentationUrl", ["docs_url", "documentationUrl"]],
+  ["pricingModel", ["pricing_model", "pricingModel"]],
+  ["disclosure", ["disclosure"]],
+  ["applicationCategory", ["application_category", "applicationCategory"]],
+  ["operatingSystem", ["operating_system", "operatingSystem"]],
+];
+
 const UNSAFE_FRONTMATTER_LANGUAGE_ERROR =
   "Executable JavaScript frontmatter is not allowed in content policy validation";
 const FINANCIAL_OR_IDENTITY_PATTERN =
@@ -260,6 +272,160 @@ function looksLikeCommercialApiRelay(fields, text) {
       body,
     );
   return relaySignal && commercialSignal;
+}
+
+function toolListingFieldValue(fields = {}, aliases = []) {
+  for (const alias of aliases) {
+    const value = normalizeText(fields[alias]);
+    if (value) return value;
+  }
+  return "";
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+// Port of packages/registry/src/submission-classification-lib.js (#5681).
+function toolListingSignals(fields = {}, text = "") {
+  const body = lower(
+    [
+      text,
+      fields.name,
+      fields.title,
+      fields.description,
+      fields.card_description,
+      fields.cardDescription,
+      fields.tags,
+      fields.pricing_model,
+      fields.pricingModel,
+      fields.disclosure,
+      fields.website_url,
+      fields.websiteUrl,
+      fields.docs_url,
+      fields.documentationUrl,
+    ].join("\n"),
+  );
+  const signals = [];
+
+  if (toolListingFieldValue(fields, ["website_url", "websiteUrl"])) {
+    signals.push("website_url");
+  }
+  if (toolListingFieldValue(fields, ["pricing_model", "pricingModel"])) {
+    signals.push("pricing_model");
+  }
+  if (toolListingFieldValue(fields, ["disclosure"])) {
+    signals.push("disclosure");
+  }
+
+  const patterns = [
+    ["hosted_app", /\bhosted\s+(app|application|product|service|platform)\b/i],
+    ["desktop_app", /\b(desktop app|desktop application|native app)\b/i],
+    ["web_app", /\b(web app|web application)\b/i],
+    ["mobile_app", /\b(mobile app|mobile application)\b/i],
+    [
+      "runtime_app",
+      /\b(local ai agent runtime|agentic ai runtime|ai runtime|runs on your machine)\b/i,
+    ],
+    ["product", /\b(product|commercial product|software product)\b/i],
+    ["software", /\b(software|application)\b/i],
+    ["saas", /\b(saas|software as a service)\b/i],
+    ["service", /\b(service|platform|workspace|dashboard|interface)\b/i],
+    [
+      "subscription",
+      /\b(subscription|pricing|paid plan|pro plan|free trial|free to try|no credit card)\b/i,
+    ],
+    ["features_page", /\b(features page|demo url|product url|website url)\b/i],
+    ["placement", /\b(featured|sponsored|affiliate|preferred placement)\b/i],
+  ];
+
+  for (const [signal, pattern] of patterns) {
+    if (pattern.test(body)) signals.push(signal);
+  }
+
+  return uniqueStrings(signals);
+}
+
+function looksLikeMcpServerSubmission(fields = {}, text = "") {
+  const body = lower(
+    [
+      text,
+      fields.name,
+      fields.title,
+      fields.description,
+      fields.card_description,
+      fields.cardDescription,
+      fields.install_command,
+      fields.installCommand,
+      fields.usage_snippet,
+      fields.usageSnippet,
+    ].join("\n"),
+  );
+
+  return (
+    /\bmcp\s+(server|endpoint|tool|transport|config|configuration)\b/i.test(
+      body,
+    ) || /\bclaude\s+mcp\s+add\b/i.test(body)
+  );
+}
+
+function looksLikeToolAppListing(fields = {}, text = "") {
+  const category = lower(fields.category);
+  if (category === "mcp" && looksLikeMcpServerSubmission(fields, text)) {
+    return false;
+  }
+  const signals = toolListingSignals(fields, text);
+  const hardSignals = new Set([
+    "hosted_app",
+    "desktop_app",
+    "web_app",
+    "mobile_app",
+    "runtime_app",
+    "product",
+    "software",
+    "saas",
+    "subscription",
+    "features_page",
+    "placement",
+  ]);
+  return (
+    signals.length >= 2 || signals.some((signal) => hardSignals.has(signal))
+  );
+}
+
+function missingToolListingReviewFields(fields = {}) {
+  const missing = [];
+  for (const [label, aliases] of TOOL_LISTING_REVIEW_FIELDS) {
+    if (!toolListingFieldValue(fields, aliases)) missing.push(label);
+  }
+  return missing;
+}
+
+function addToolListingClassificationSignals(report, fields, text) {
+  const category = normalizeText(fields.category);
+  if (category && category !== TOOLS_CATEGORY) {
+    if (looksLikeToolAppListing(fields, text)) {
+      addClassificationWarning(
+        report,
+        "tools_category_routing",
+        "This looks like a hosted tool/app/service/product and should route to tools listing review",
+        `Use content/tools or ${TOOLS_LISTING_FLOW_URL}`,
+      );
+    }
+    return;
+  }
+
+  if (category === TOOLS_CATEGORY) {
+    const missing = missingToolListingReviewFields(fields);
+    if (missing.length) {
+      addClassificationWarning(
+        report,
+        "tools_listing_metadata_missing",
+        "Tools listings should include website, docs/demo, pricing, disclosure, application category, and operating system fields",
+        missing.join(", "),
+      );
+    }
+  }
 }
 
 function annotationText(value) {
@@ -704,6 +870,8 @@ function frontmatterFields(data = {}, category = "") {
   return {
     category: normalizeText(data.category || category),
     slug: normalizeText(data.slug),
+    title: normalizeText(data.title),
+    description: normalizeText(data.description),
     github_url: normalizeText(data.repoUrl),
     source_url: normalizeText(data.sourceUrl),
     source_urls: stringList(data.sourceUrls).join("\n"),
@@ -714,6 +882,10 @@ function frontmatterFields(data = {}, category = "") {
     install_command: normalizeText(data.installCommand),
     usage_snippet: normalizeText(data.usageSnippet),
     full_copyable_content: normalizeText(data.copySnippet),
+    pricing_model: normalizeText(data.pricingModel),
+    disclosure: normalizeText(data.disclosure),
+    application_category: normalizeText(data.applicationCategory),
+    operating_system: normalizeText(data.operatingSystem),
     safety_notes: stringList(data.safetyNotes).join("\n"),
     privacy_notes: stringList(data.privacyNotes).join("\n"),
   };
@@ -1329,6 +1501,10 @@ function directContentRequestChangesReasons(report = {}) {
       "Sensitive execution, install, package, background, or write behavior needs safetyNotes disclosure.",
     missing_privacy_notes:
       "Credential, local data, telemetry, or third-party data behavior needs privacyNotes disclosure.",
+    tools_category_routing:
+      "Hosted tool/app/service/product submissions should route to the tools listing review flow.",
+    tools_listing_metadata_missing:
+      "Tools listings need website, docs/demo, pricing, disclosure, application category, and operating system fields.",
   };
   for (const [id, reason] of Object.entries(warningReasons)) {
     if (!isExternalDirect && externalOnlyWarnings.has(id)) continue;
@@ -1441,6 +1617,7 @@ function buildReport({ args, files, headRepo, baseRepo, headRef, sourceType }) {
     });
     addContentRiskSignals(report, fields, content);
     addDisclosureNoteSignals(report, fields);
+    addToolListingClassificationSignals(report, fields, content);
   }
 
   validatePrProvenance(report, entries, prAuthor, sourceType);

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -68,6 +68,12 @@ title: Example Tool
 category: tools
 description: Example policy validation fixture.
 sourceUrl: https://github.com/example/example-tool
+websiteUrl: https://example.com
+documentationUrl: https://example.com/docs
+pricingModel: free
+disclosure: independent
+applicationCategory: DeveloperApplication
+operatingSystem: Any
 submittedBy: tester
 submittedByUrl: https://github.com/tester
 ---
@@ -345,6 +351,12 @@ title: Example Tool
 category: tools
 description: Example maintainer-owned package fixture.
 downloadUrl: /downloads/skills/example-skill.zip
+websiteUrl: https://example.com
+documentationUrl: https://example.com/docs
+pricingModel: free
+disclosure: independent
+applicationCategory: DeveloperApplication
+operatingSystem: Any
 submittedBy: JSONbored
 submittedByUrl: https://github.com/JSONbored
 safetyNotes:
@@ -467,6 +479,12 @@ Example body.
 title: Example Tool
 category: tools
 description: Example tool entry.
+websiteUrl: https://example.com
+documentationUrl: https://example.com/docs
+pricingModel: free
+disclosure: independent
+applicationCategory: DeveloperApplication
+operatingSystem: Any
 safetyNotes:
   - Original safety note.
 privacyNotes:
@@ -479,6 +497,12 @@ Example body.
 title: Example Tool
 category: tools
 description: Example tool entry.
+websiteUrl: https://example.com
+documentationUrl: https://example.com/docs
+pricingModel: free
+disclosure: independent
+applicationCategory: DeveloperApplication
+operatingSystem: Any
 safetyNotes:
   - Updated safety note.
 privacyNotes:
@@ -1546,6 +1570,70 @@ Body.
       expect.arrayContaining([
         expect.objectContaining({ id: "affiliate_referral_url" }),
       ]),
+    );
+  });
+
+  it("fails misrouted hosted SaaS submitted under a non-tools category (#5681)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Acme Hosted SaaS
+category: agents
+description: A hosted SaaS web app product with subscription pricing and a features page.
+websiteUrl: https://acme.example.com
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+This commercial SaaS product is a hosted app with a subscription plan.
+`;
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/agents/acme-hosted-saas.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.ok).toBe(false);
+    expect(
+      output.classificationWarnings.map((w: { id: string }) => w.id),
+    ).toContain("tools_category_routing");
+    expect(output.failures.join("\n")).toContain("tools_category_routing");
+  });
+
+  it("fails incomplete tools listings missing review metadata (#5681)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Incomplete Tool
+category: tools
+description: Tools entry missing required listing metadata.
+sourceUrl: https://github.com/example/incomplete-tool
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Body.
+`;
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/tools/incomplete-tool.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.ok).toBe(false);
+    expect(
+      output.classificationWarnings.map((w: { id: string }) => w.id),
+    ).toContain("tools_listing_metadata_missing");
+    expect(output.failures.join("\n")).toContain(
+      "tools_listing_metadata_missing",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Closes #5681
- Port `looksLikeToolAppListing` / `missingToolListingReviewFields` into `validate-content-policy.mjs` and call `addToolListingClassificationSignals` for each content file.
- Add `tools_category_routing` and `tools_listing_metadata_missing` to `warningReasons` so misrouted or incomplete tool listings fail the CI gate.

## New failure reasons
| id | When |
| --- | --- |
| `tools_category_routing` | Hosted tool/app/SaaS signals under a non-`tools` category |
| `tools_listing_metadata_missing` | `tools` entry missing website/docs/pricing/disclosure/applicationCategory/operatingSystem |

## Local proof
- Incomplete `content/tools/...` fixture → fails with `tools_listing_metadata_missing`
- Hosted SaaS under `content/agents/...` → fails with `tools_category_routing`
- Existing passing fixtures updated with complete tools metadata where needed

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/content-policy-validation.test.ts`