### PR TITLE
fix(ci): enforce tools-listing checks in content-policy gate

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -262,6 +262,173 @@ function looksLikeCommercialApiRelay(fields, text) {
   return relaySignal && commercialSignal;
 }
 
+// Ported from packages/registry/src/submission-classification-lib.js so the
+// standalone CI content-policy gate can enforce tools-listing routing without
+// importing the registry package (#5681).
+const TOOLS_CATEGORY = "tools";
+const TOOLS_LISTING_FLOW_URL = "https://heyclau.de/tools/submit";
+const TOOL_LISTING_REVIEW_FIELDS = [
+  ["websiteUrl", ["website_url", "websiteUrl"]],
+  ["documentationUrl", ["docs_url", "documentationUrl"]],
+  ["pricingModel", ["pricing_model", "pricingModel"]],
+  ["disclosure", ["disclosure"]],
+  ["applicationCategory", ["application_category", "applicationCategory"]],
+  ["operatingSystem", ["operating_system", "operatingSystem"]],
+];
+
+function fieldValue(fields = {}, aliases = []) {
+  for (const alias of aliases) {
+    const value = normalizeText(fields[alias]);
+    if (value) return value;
+  }
+  return "";
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function toolListingSignals(fields = {}, text = "") {
+  const body = lower(
+    [
+      text,
+      fields.name,
+      fields.title,
+      fields.description,
+      fields.card_description,
+      fields.cardDescription,
+      fields.tags,
+      fields.pricing_model,
+      fields.pricingModel,
+      fields.disclosure,
+      fields.website_url,
+      fields.websiteUrl,
+      fields.docs_url,
+      fields.documentationUrl,
+    ].join("\n"),
+  );
+  const signals = [];
+
+  if (fieldValue(fields, ["website_url", "websiteUrl"])) {
+    signals.push("website_url");
+  }
+  if (fieldValue(fields, ["pricing_model", "pricingModel"])) {
+    signals.push("pricing_model");
+  }
+  if (fieldValue(fields, ["disclosure"])) {
+    signals.push("disclosure");
+  }
+
+  const patterns = [
+    ["hosted_app", /\bhosted\s+(app|application|product|service|platform)\b/i],
+    ["desktop_app", /\b(desktop app|desktop application|native app)\b/i],
+    ["web_app", /\b(web app|web application)\b/i],
+    ["mobile_app", /\b(mobile app|mobile application)\b/i],
+    [
+      "runtime_app",
+      /\b(local ai agent runtime|agentic ai runtime|ai runtime|runs on your machine)\b/i,
+    ],
+    ["product", /\b(product|commercial product|software product)\b/i],
+    ["software", /\b(software|application)\b/i],
+    ["saas", /\b(saas|software as a service)\b/i],
+    ["service", /\b(service|platform|workspace|dashboard|interface)\b/i],
+    [
+      "subscription",
+      /\b(subscription|pricing|paid plan|pro plan|free trial|free to try|no credit card)\b/i,
+    ],
+    ["features_page", /\b(features page|demo url|product url|website url)\b/i],
+    ["placement", /\b(featured|sponsored|affiliate|preferred placement)\b/i],
+  ];
+
+  for (const [signal, pattern] of patterns) {
+    if (pattern.test(body)) signals.push(signal);
+  }
+
+  return unique(signals);
+}
+
+function looksLikeMcpServerSubmission(fields = {}, text = "") {
+  const body = lower(
+    [
+      text,
+      fields.name,
+      fields.title,
+      fields.description,
+      fields.card_description,
+      fields.cardDescription,
+      fields.install_command,
+      fields.installCommand,
+      fields.usage_snippet,
+      fields.usageSnippet,
+    ].join("\n"),
+  );
+
+  return (
+    /\bmcp\s+(server|endpoint|tool|transport|config|configuration)\b/i.test(
+      body,
+    ) || /\bclaude\s+mcp\s+add\b/i.test(body)
+  );
+}
+
+function looksLikeToolAppListing(fields = {}, text = "") {
+  const category = lower(fields.category);
+  if (category === "mcp" && looksLikeMcpServerSubmission(fields, text)) {
+    return false;
+  }
+  const signals = toolListingSignals(fields, text);
+  const hardSignals = new Set([
+    "hosted_app",
+    "desktop_app",
+    "web_app",
+    "mobile_app",
+    "runtime_app",
+    "product",
+    "software",
+    "saas",
+    "subscription",
+    "features_page",
+    "placement",
+  ]);
+  return (
+    signals.length >= 2 || signals.some((signal) => hardSignals.has(signal))
+  );
+}
+
+function missingToolListingReviewFields(fields = {}) {
+  const missing = [];
+  for (const [label, aliases] of TOOL_LISTING_REVIEW_FIELDS) {
+    if (!fieldValue(fields, aliases)) missing.push(label);
+  }
+  return missing;
+}
+
+function addToolListingClassificationSignals(report, fields, text) {
+  const category = normalizeText(fields.category);
+  if (category && category !== TOOLS_CATEGORY) {
+    if (looksLikeToolAppListing(fields, text)) {
+      addClassificationWarning(
+        report,
+        "tools_category_routing",
+        "This looks like a hosted tool/app/service/product and should route to tools listing review",
+        `Use content/tools or ${TOOLS_LISTING_FLOW_URL}`,
+      );
+    }
+    return;
+  }
+
+  if (category === TOOLS_CATEGORY) {
+    const missing = missingToolListingReviewFields(fields);
+    if (missing.length) {
+      addClassificationWarning(
+        report,
+        "tools_listing_metadata_missing",
+        "Tools listings should include website, docs/demo, pricing, disclosure, application category, and operating system fields",
+        missing.join(", "),
+      );
+    }
+  }
+}
+
 function annotationText(value) {
   return normalizeText(value)
     .replace(/%/g, "%25")
@@ -704,6 +871,9 @@ function frontmatterFields(data = {}, category = "") {
   return {
     category: normalizeText(data.category || category),
     slug: normalizeText(data.slug),
+    name: normalizeText(data.title || data.name),
+    description: normalizeText(data.description),
+    card_description: normalizeText(data.cardDescription),
     github_url: normalizeText(data.repoUrl),
     source_url: normalizeText(data.sourceUrl),
     source_urls: stringList(data.sourceUrls).join("\n"),
@@ -711,6 +881,10 @@ function frontmatterFields(data = {}, category = "") {
     docs_url: normalizeText(data.documentationUrl || data.projectUrl),
     download_url: normalizeText(data.downloadUrl),
     affiliate_url: normalizeText(data.affiliateUrl),
+    pricing_model: normalizeText(data.pricingModel),
+    disclosure: normalizeText(data.disclosure),
+    application_category: normalizeText(data.applicationCategory),
+    operating_system: normalizeText(data.operatingSystem),
     install_command: normalizeText(data.installCommand),
     usage_snippet: normalizeText(data.usageSnippet),
     full_copyable_content: normalizeText(data.copySnippet),
@@ -1329,6 +1503,10 @@ function directContentRequestChangesReasons(report = {}) {
       "Sensitive execution, install, package, background, or write behavior needs safetyNotes disclosure.",
     missing_privacy_notes:
       "Credential, local data, telemetry, or third-party data behavior needs privacyNotes disclosure.",
+    tools_category_routing:
+      "Hosted tools/apps/services/products must use the tools listing path or /tools/submit flow.",
+    tools_listing_metadata_missing:
+      "Tools listings need website, docs/demo, pricing, disclosure, application category, and operating system fields.",
   };
   for (const [id, reason] of Object.entries(warningReasons)) {
     if (!isExternalDirect && externalOnlyWarnings.has(id)) continue;
@@ -1440,6 +1618,7 @@ function buildReport({ args, files, headRepo, baseRepo, headRef, sourceType }) {
       baseContentBody: baseParsed.content || "",
     });
     addContentRiskSignals(report, fields, content);
+    addToolListingClassificationSignals(report, fields, content);
     addDisclosureNoteSignals(report, fields);
   }
 

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -711,6 +711,109 @@ Example body.
     );
   });
 
+  it("fails misrouted tool/app listings outside content/tools (#5681)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Acme SaaS Product
+category: guides
+description: A hosted SaaS product with a subscription pricing plan.
+sourceUrl: https://github.com/example/acme-saas
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+This commercial software product is a hosted SaaS web application.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/guides/acme-saas.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("tools_category_routing"),
+      ]),
+    );
+  });
+
+  it("fails tools listings missing required review metadata (#5681)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Sparse Tools Listing
+category: tools
+description: A tools-category entry without review metadata.
+sourceUrl: https://github.com/example/sparse-tool
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Sparse tools listing body.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/tools/sparse-tool.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("tools_listing_metadata_missing"),
+      ]),
+    );
+  });
+
+  it("does not route MCP server submissions as tools listings (#5681)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Example MCP Server
+category: mcp
+description: An MCP server endpoint for local tools.
+sourceUrl: https://github.com/example/example-mcp
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+installCommand: claude mcp add example
+safetyNotes:
+  - Runs locally with user-selected tools.
+privacyNotes:
+  - Only handles context selected by the user.
+---
+
+Configure this MCP server with claude mcp add.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/mcp/example-mcp.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures ?? []).not.toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("tools_category_routing"),
+      ]),
+    );
+  });
+
   it("fails external content PRs that set maintainer review provenance", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),


### PR DESCRIPTION
## Summary
- Port `looksLikeToolAppListing` / `missingToolListingReviewFields` into `scripts/ci/validate-content-policy.mjs`
- Emit and fail on `tools_category_routing` and `tools_listing_metadata_missing` (added to `warningReasons`)
- Extend CI `frontmatterFields` so tools review metadata is visible to the missing-fields check

Closes #5681

## New failure reasons
| Reason ID | When |
| --- | --- |
| `tools_category_routing` | Non-`tools` path/category looks like a hosted tool/app/SaaS product |
| `tools_listing_metadata_missing` | `content/tools` entry missing website/docs/pricing/disclosure/applicationCategory/operatingSystem |

## Before / after (local)
Misrouted SaaS-under-guides: previously green → now fails with `tools_category_routing`.
Sparse `content/tools` entry: previously green → now fails with `tools_listing_metadata_missing`.
MCP server under `content/mcp`: still not routed as a tools listing.

## Test plan
- [x] `pnpm exec vitest run tests/content-policy-validation.test.ts -t "5681|category/path mismatch"`
- [ ] CI green