### PR TITLE
fix(web): wire trending window chips into row filtering (#5477)

### DIFF
--- a/apps/web/src/lib/trending-window-lib.ts
+++ b/apps/web/src/lib/trending-window-lib.ts
@@ -1,0 +1,32 @@
+export type TrendingWindowId = "7d" | "30d" | "all";
+
+export const TRENDING_WINDOW_OPTIONS: Array<{ id: TrendingWindowId; label: string }> = [
+  { id: "all", label: "All time" },
+  { id: "30d", label: "30 days" },
+  { id: "7d", label: "7 days" },
+];
+
+/** ISO date (YYYY-MM-DD) cutoff for a window, or null when unfiltered. */
+export function trendingWindowCutoffIso(
+  window: TrendingWindowId,
+  nowMs: number = Date.now(),
+): string | null {
+  if (window === "all") return null;
+  const days = window === "7d" ? 7 : 30;
+  const d = new Date(nowMs);
+  d.setUTCDate(d.getUTCDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+/** True when entry.dateAdded is on/after the window cutoff (string YYYY-MM-DD compare). */
+export function entryMatchesTrendingWindow(
+  entry: { dateAdded?: string | null },
+  window: TrendingWindowId,
+  nowMs: number = Date.now(),
+): boolean {
+  const cutoff = trendingWindowCutoffIso(window, nowMs);
+  if (!cutoff) return true;
+  const added = String(entry.dateAdded ?? "").slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(added)) return false;
+  return added >= cutoff;
+}

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -49,10 +49,11 @@ import {
   type TrendingListWindow,
   type TrendingShareAction,
 } from "@/lib/trending-entry-cta-events";
+import { entryMatchesTrendingWindow, TRENDING_WINDOW_OPTIONS } from "@/lib/trending-window-lib";
 import { cn } from "@/lib/utils";
 
 const defaultSearch = {
-  window: "7d" as const,
+  window: "all" as const,
   category: "",
 };
 
@@ -250,16 +251,23 @@ function TrendingPage() {
   const latestBrief = BRIEF_ISSUES[0];
   const { rows: allRows, mode, signals, loading } = useTrendingRows();
 
-  const rows = sp.category ? allRows.filter((entry) => entry.category === sp.category) : allRows;
+  const rows = React.useMemo(() => {
+    return allRows.filter((entry) => {
+      if (!entryMatchesTrendingWindow(entry, sp.window)) return false;
+      if (sp.category && entry.category !== sp.category) return false;
+      return true;
+    });
+  }, [allRows, sp.category, sp.window]);
   const podium = rows.slice(0, 3);
   const list = rows.slice(3);
   const liveSignals = hasLiveSignals(signals);
 
   const countsByCategory = React.useMemo(() => {
     const counts: Record<string, number> = {};
-    for (const entry of allRows) counts[entry.category] = (counts[entry.category] ?? 0) + 1;
+    const windowed = allRows.filter((entry) => entryMatchesTrendingWindow(entry, sp.window));
+    for (const entry of windowed) counts[entry.category] = (counts[entry.category] ?? 0) + 1;
     return counts;
-  }, [allRows]);
+  }, [allRows, sp.window]);
 
   const set = (patch: Partial<typeof sp>) =>
     navigate({ search: (prev: typeof sp) => ({ ...prev, ...patch }) });
@@ -282,7 +290,11 @@ function TrendingPage() {
     [list.length, mode, sp.category, sp.window],
   );
 
-  const shareUrl = `/trending${sp.category ? `?category=${sp.category}` : ""}`;
+  const shareParams = new URLSearchParams();
+  if (sp.window !== defaultSearch.window) shareParams.set("window", sp.window);
+  if (sp.category) shareParams.set("category", sp.category);
+  const shareQuery = shareParams.toString();
+  const shareUrl = `/trending${shareQuery ? `?${shareQuery}` : ""}`;
 
   const trackCategoryFilter = (categoryFilter: string, active: boolean, matchCount: number) => {
     trackEvent(
@@ -402,17 +414,46 @@ function TrendingPage() {
           </div>
         </div>
 
-        <div className="relative mt-3 -mx-1">
+        <div className="relative mt-3 -mx-1 space-y-2">
+          <div className="overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[role=radiogroup]]:w-max [&_[role=radiogroup]]:flex-nowrap [&_[role=radiogroup]]:gap-1.5">
+            <FilterChipGroup label="Filter by time window" multi={false}>
+              {TRENDING_WINDOW_OPTIONS.map((option) => {
+                const active = sp.window === option.id;
+                const count = allRows.filter((entry) =>
+                  entryMatchesTrendingWindow(entry, option.id),
+                ).length;
+                return (
+                  <FilterChip
+                    key={option.id}
+                    role="radio"
+                    active={active}
+                    count={count}
+                    onClick={() => {
+                      if (active) return;
+                      set({ window: option.id });
+                    }}
+                  >
+                    {option.label}
+                  </FilterChip>
+                );
+              })}
+            </FilterChipGroup>
+          </div>
           <div className="overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_[role=radiogroup]]:w-max [&_[role=radiogroup]]:flex-nowrap [&_[role=radiogroup]]:gap-1.5">
             <FilterChipGroup label="Filter by category" multi={false}>
               <FilterChip
                 role="radio"
                 active={!sp.category}
                 onClick={() => {
-                  trackCategoryFilter("", true, allRows.length);
+                  const windowedCount = allRows.filter((entry) =>
+                    entryMatchesTrendingWindow(entry, sp.window),
+                  ).length;
+                  trackCategoryFilter("", true, windowedCount);
                   set({ category: "" });
                 }}
-                count={allRows.length}
+                count={
+                  allRows.filter((entry) => entryMatchesTrendingWindow(entry, sp.window)).length
+                }
               >
                 All
               </FilterChip>
@@ -455,7 +496,7 @@ function TrendingPage() {
             type="button"
             onClick={() => {
               trackFilterReset();
-              set({ window: "7d", category: "" });
+              set({ window: "all", category: "" });
             }}
             className="mt-2 inline-flex h-8 items-center gap-1.5 rounded-md bg-ink px-3 text-xs font-medium text-background transition-transform hover:bg-ink/90 active:translate-y-px"
           >

--- a/tests/trending-window-lib.test.ts
+++ b/tests/trending-window-lib.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  entryMatchesTrendingWindow,
+  trendingWindowCutoffIso,
+} from "../apps/web/src/lib/trending-window-lib";
+
+describe("trending window filter (#5477)", () => {
+  const now = Date.parse("2026-07-30T12:00:00.000Z");
+
+  it("uses all as unfiltered and computes 7d/30d cutoffs", () => {
+    expect(trendingWindowCutoffIso("all", now)).toBeNull();
+    expect(trendingWindowCutoffIso("7d", now)).toBe("2026-07-23");
+    expect(trendingWindowCutoffIso("30d", now)).toBe("2026-06-30");
+  });
+
+  it("matches entries by dateAdded against the cutoff", () => {
+    expect(
+      entryMatchesTrendingWindow({ dateAdded: "2026-07-29" }, "7d", now),
+    ).toBe(true);
+    expect(
+      entryMatchesTrendingWindow({ dateAdded: "2026-07-01" }, "7d", now),
+    ).toBe(false);
+    expect(
+      entryMatchesTrendingWindow({ dateAdded: "2026-07-01" }, "30d", now),
+    ).toBe(true);
+    expect(
+      entryMatchesTrendingWindow({ dateAdded: "2026-01-01" }, "all", now),
+    ).toBe(true);
+    expect(entryMatchesTrendingWindow({ dateAdded: "" }, "7d", now)).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #5477 (decision **a**: wire `window` into UI + filtering)
- Add All time / 30 days / 7 days `FilterChip` controls on `/trending`
- Filter rows by `dateAdded` for `7d`/`30d`; `all` keeps the full ranking
- Default search param is `all` (per maintainer note) so the landing view stays populated; `7d`/`30d` are opt-in shrinks

## Test plan
- [x] `pnpm exec prettier --check` on touched files
- [x] `pnpm exec vitest run tests/trending-window-lib.test.ts`
- [ ] Toggle window chips and confirm the list shrinks for 7d/30d