### PR TITLE
chore(mcp): refresh GoodMemory to 0.7.0

### DIFF
--- a/content/mcp/goodmemory-mcp-server.mdx
+++ b/content/mcp/goodmemory-mcp-server.mdx
@@ -20,7 +20,7 @@ repoUrl: "https://github.com/hjqcan/GoodMemory"
 documentationUrl: "https://github.com/hjqcan/GoodMemory/blob/main/docs/GoodMemory-Standalone-MCP-Setup-Guide.md"
 packageUrl: "https://www.npmjs.com/package/goodmemory"
 installable: true
-installCommand: "npm install -g goodmemory@0.5.1"
+installCommand: "npm install -g goodmemory@0.7.0"
 usageSnippet: >-
   Ask Claude to recall relevant project decisions before a task, inspect the
   returned trace, and enable governed writes only after reviewing the memory
@@ -110,7 +110,7 @@ remember pipeline used by the library API.
 Install the published package globally:
 
 ```sh
-npm install -g goodmemory@0.5.1
+npm install -g goodmemory@0.7.0
 ```
 
 Add the standalone server to an MCP client:
@@ -165,6 +165,6 @@ context: it will be visible to the model provider used by the host.
 - https://www.npmjs.com/package/goodmemory
 - https://registry.modelcontextprotocol.io/v0.1/servers/io.github.hjqcan%2Fgoodmemory/versions/latest
 
-These sources were reviewed on **2026-07-13**. Prefer the live repository,
+These sources were reviewed on **2026-07-30**. Prefer the live repository,
 published package metadata, capability descriptor, and official MCP registry
 entry for current versions, commands, storage behavior, and tool exposure.


### PR DESCRIPTION
## Summary

- update the GoodMemory install command from `0.5.1` to the current npm `latest`, `0.7.0`
- refresh the source-review date after rechecking the published package metadata
- keep the change scoped to the existing GoodMemory content entry; no generated artifacts

## Validation

- `npm view goodmemory@0.7.0 version engines bin dist-tags --json`
- `pnpm validate:content:strict` (passed; 24 unrelated existing warnings)
- `git diff --check`

No visual impact.