### PR TITLE
fix(web): guard admin jobs with legal state transitions

### DIFF
--- a/apps/web/src/lib/job-admin-lib.ts
+++ b/apps/web/src/lib/job-admin-lib.ts
@@ -170,6 +170,84 @@ export class JobNotFoundError extends Error {
   }
 }
 
+export class JobInvalidTransitionError extends Error {
+  currentStatus: JobStatus;
+  action: JobAdminAction;
+
+  constructor(currentStatus: JobStatus, action: JobAdminAction) {
+    super(`Invalid job admin transition: ${action} from ${currentStatus}`);
+    this.name = "JobInvalidTransitionError";
+    this.currentStatus = currentStatus;
+    this.action = action;
+  }
+}
+
+const JOB_STATUSES: readonly JobStatus[] = [
+  "draft",
+  "pending_review",
+  "active",
+  "stale_pending_review",
+  "closed",
+  "archived",
+];
+
+function normalizeJobStatus(status: string | null | undefined): JobStatus {
+  const normalized = String(status || "")
+    .trim()
+    .toLowerCase();
+  return (JOB_STATUSES as readonly string[]).includes(normalized)
+    ? (normalized as JobStatus)
+    : "draft";
+}
+
+/**
+ * Legal next status for a jobs admin action, or `null` when the action is
+ * illegal from the current status. `revalidate` never changes status and is
+ * allowed from any known status (returns the current status).
+ *
+ * Mirror of `nextLeadStatus` for listing-leads — activate first-publishes from
+ * draft/pending_review; reactivate reopens stale/closed; stale only from active.
+ */
+export function nextJobStatus(
+  currentStatus: string | null | undefined,
+  action: JobAdminAction,
+): JobStatus | null {
+  const current = normalizeJobStatus(currentStatus);
+  if (action === "revalidate") return current;
+
+  const transitions: Record<JobStatus, Partial<Record<JobAdminAction, JobStatus>>> = {
+    draft: {
+      review: "pending_review",
+      activate: "active",
+      archive: "archived",
+    },
+    pending_review: {
+      activate: "active",
+      close: "closed",
+      archive: "archived",
+    },
+    active: {
+      stale: "stale_pending_review",
+      close: "closed",
+      expire: "closed",
+      archive: "archived",
+    },
+    stale_pending_review: {
+      reactivate: "active",
+      close: "closed",
+      expire: "closed",
+      archive: "archived",
+    },
+    closed: {
+      reactivate: "active",
+      archive: "archived",
+    },
+    archived: {},
+  };
+
+  return transitions[current]?.[action] ?? null;
+}
+
 function assertJobPublicationQuality(job: Record<string, unknown>) {
   const report = validateJobPublicExposure(job);
   if (!report.ok) {
@@ -436,9 +514,16 @@ export async function updateAdminJobState(
   const hasExpiresAt = Object.prototype.hasOwnProperty.call(input, "expiresAt");
   const expiresAt = input.expiresAt === null ? null : optionalText(input.expiresAt);
 
+  const existing = await queryAdminJobBySlug(db, input.slug);
+  if (!existing) throw new JobNotFoundError(input.slug);
+
+  const currentStatus = normalizeJobStatus(existing.status);
+  const nextStatus = nextJobStatus(currentStatus, input.action);
+  if (nextStatus === null) {
+    throw new JobInvalidTransitionError(currentStatus, input.action);
+  }
+
   if (input.action === "activate" || input.action === "reactivate") {
-    const existing = await queryAdminJobBySlug(db, input.slug);
-    if (!existing) throw new JobNotFoundError(input.slug);
     assertJobPublicationQuality({
       ...existing,
       status: "active",
@@ -484,16 +569,6 @@ export async function updateAdminJobState(
     }
     return;
   }
-
-  const nextStatusByAction: Record<Exclude<JobAdminAction, "revalidate" | "stale">, JobStatus> = {
-    review: "pending_review",
-    activate: "active",
-    close: "closed",
-    archive: "archived",
-    reactivate: "active",
-    expire: "closed",
-  };
-  const nextStatus = nextStatusByAction[input.action];
 
   const result = await db
     .prepare(

--- a/apps/web/src/lib/job-admin.ts
+++ b/apps/web/src/lib/job-admin.ts
@@ -5,12 +5,14 @@
  * surface so existing `@/lib/job-admin` imports stay unchanged.
  */
 export {
+  JobInvalidTransitionError,
   JobNotFoundError,
   JobPublicationQualityError,
   REQUIRED_JOB_COLUMNS,
   REQUIRED_JOBS_MIGRATION,
   checkJobsSchema,
   getJobsHealth,
+  nextJobStatus,
   queryAdminJobBySlug,
   queryAdminJobs,
   updateAdminJobState,

--- a/apps/web/src/routes/api/admin/jobs.ts
+++ b/apps/web/src/routes/api/admin/jobs.ts
@@ -17,6 +17,7 @@ import { logApiError, logApiInfo, logApiWarn } from "@/lib/api-logs";
 import { getSiteDb } from "@/lib/db";
 import {
   checkJobsSchema,
+  JobInvalidTransitionError,
   JobNotFoundError,
   JobPublicationQualityError,
   queryAdminJobs,
@@ -138,6 +139,20 @@ export const PATCH = createApiHandler("adminJobs.update", async ({ request, body
       return apiError("job_quality_gate_failed", 400, {
         requestId,
         details: caught.errors,
+      });
+    }
+    if (caught instanceof JobInvalidTransitionError) {
+      logApiWarn(request, "admin.jobs.invalid_transition", {
+        slug: payload.slug,
+        action: payload.action,
+        currentStatus: caught.currentStatus,
+      });
+      return apiError("invalid_transition", 400, {
+        requestId,
+        details: {
+          action: caught.action,
+          currentStatus: caught.currentStatus,
+        },
       });
     }
     if (caught instanceof JobNotFoundError) {

--- a/tests/admin-jobs-invalid-transition.test.ts
+++ b/tests/admin-jobs-invalid-transition.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { JobInvalidTransitionError } from "../apps/web/src/lib/job-admin-lib";
+
+describe("admin jobs PATCH invalid_transition", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 invalid_transition when the lifecycle guard rejects the action", async () => {
+    vi.stubEnv("JOBS_ADMIN_API_TOKEN", "jobs-admin-token");
+    vi.stubEnv("ADMIN_API_TOKEN", "");
+
+    const db = {
+      prepare() {
+        return {
+          bind() {
+            return this;
+          },
+          async all() {
+            return {
+              results: [
+                { name: "slug" },
+                { name: "title" },
+                { name: "company_name" },
+                { name: "company_url" },
+                { name: "location_text" },
+                { name: "summary" },
+                { name: "description_md" },
+                { name: "employment_type" },
+                { name: "compensation_summary" },
+                { name: "equity_summary" },
+                { name: "bonus_summary" },
+                { name: "benefits_json" },
+                { name: "responsibilities_json" },
+                { name: "requirements_json" },
+                { name: "apply_url" },
+                { name: "tier" },
+                { name: "status" },
+                { name: "source" },
+                { name: "source_kind" },
+                { name: "source_url" },
+                { name: "first_seen_at" },
+                { name: "last_checked_at" },
+                { name: "source_checked_at" },
+                { name: "stale_check_count" },
+                { name: "curation_note" },
+                { name: "paid_placement_expires_at" },
+                { name: "claimed_employer" },
+                { name: "posted_by_email" },
+                { name: "posted_at" },
+                { name: "expires_at" },
+                { name: "is_remote" },
+                { name: "is_worldwide" },
+              ],
+            };
+          },
+        };
+      },
+    };
+
+    vi.doMock("../apps/web/src/lib/db", () => ({ getSiteDb: () => db }));
+    vi.doMock("../apps/web/src/lib/job-admin", async () => {
+      const actual = await vi.importActual<
+        typeof import("../apps/web/src/lib/job-admin")
+      >("../apps/web/src/lib/job-admin");
+      return {
+        ...actual,
+        checkJobsSchema: async () => ({
+          ok: true,
+          checkedAt: "2026-04-28T00:00:00.000Z",
+          requiredMigration: actual.REQUIRED_JOBS_MIGRATION,
+          columns: [...actual.REQUIRED_JOB_COLUMNS],
+          missingColumns: [],
+        }),
+        updateAdminJobState: async () => {
+          throw new JobInvalidTransitionError("archived", "activate");
+        },
+      };
+    });
+
+    const { PATCH } = await import("../apps/web/src/routes/api/admin/jobs");
+    const response = await PATCH(
+      new Request("https://heyclau.de/api/admin/jobs", {
+        method: "PATCH",
+        headers: {
+          authorization: "Bearer jobs-admin-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ slug: "archived-role", action: "activate" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_transition",
+        details: {
+          action: "activate",
+          currentStatus: "archived",
+        },
+      },
+    });
+  });
+});

--- a/tests/d1-dynamic-state.test.ts
+++ b/tests/d1-dynamic-state.test.ts
@@ -942,6 +942,18 @@ describe("D1 dynamic state helpers", () => {
     ).resolves.toMatchObject({ slug: "reviewed-ai-engineer" });
     await expect(queryAdminJobBySlug(db, "missing-role")).resolves.toBeNull();
 
+    // Source-check automation only runs against active (and stale) rows; promote
+    // here so revalidate/stale stay on the legal lifecycle path without re-testing
+    // the activate quality gate (covered elsewhere).
+    db.jobRows[0] = {
+      ...db.jobRows[0],
+      status: "active",
+      description_md:
+        "Own Claude workflow systems with source verification, external apply links, and private D1-backed publication state for production teams.",
+      source_checked_at: "2026-04-28T00:00:00.000Z",
+      last_checked_at: "2026-04-28T00:00:00.000Z",
+    };
+
     await updateAdminJobState(db, {
       slug: "reviewed-ai-engineer",
       action: "revalidate",

--- a/tests/job-admin-lib.test.ts
+++ b/tests/job-admin-lib.test.ts
@@ -4,10 +4,12 @@ import type { D1DatabaseLike, D1RunResult } from "../apps/web/src/lib/db";
 import {
   REQUIRED_JOB_COLUMNS,
   REQUIRED_JOBS_MIGRATION,
+  JobInvalidTransitionError,
   JobNotFoundError,
   JobPublicationQualityError,
   checkJobsSchema,
   getJobsHealth,
+  nextJobStatus,
   queryAdminJobBySlug,
   queryAdminJobs,
   updateAdminJobState,
@@ -316,6 +318,17 @@ describe("job-admin-lib error classes", () => {
     const error = new JobNotFoundError("missing-role");
     expect(error.name).toBe("JobNotFoundError");
     expect(error.message).toBe("Job listing not found: missing-role");
+  });
+
+  it("constructs JobInvalidTransitionError with status and action", () => {
+    const error = new JobInvalidTransitionError("archived", "activate");
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("JobInvalidTransitionError");
+    expect(error.currentStatus).toBe("archived");
+    expect(error.action).toBe("activate");
+    expect(error.message).toBe(
+      "Invalid job admin transition: activate from archived",
+    );
   });
 
   it.each([["alpha-role"], ["beta-role"], ["gamma-role"]])(
@@ -821,47 +834,103 @@ describe("upsertAdminJob", () => {
   });
 });
 
-describe("updateAdminJobState", () => {
-  it.each([
-    ["review", "pending_review"],
-    ["activate", "active"],
-    ["close", "closed"],
-    ["archive", "archived"],
-    ["reactivate", "active"],
-    ["expire", "closed"],
-  ] as const)("maps action %s to status %s", async (action, expectedStatus) => {
-    const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: `${action}-role` })];
-    await updateAdminJobState(db, { slug: `${action}-role`, action });
-    expect(db.runCalls.at(-1)?.query).toContain("status = ?");
-    expect(db.runCalls.at(-1)?.values).toContain(expectedStatus);
+describe("nextJobStatus", () => {
+  it("allows legal lifecycle transitions", () => {
+    expect(nextJobStatus("draft", "review")).toBe("pending_review");
+    expect(nextJobStatus("draft", "activate")).toBe("active");
+    expect(nextJobStatus("draft", "archive")).toBe("archived");
+    expect(nextJobStatus("pending_review", "activate")).toBe("active");
+    expect(nextJobStatus("pending_review", "close")).toBe("closed");
+    expect(nextJobStatus("pending_review", "archive")).toBe("archived");
+    expect(nextJobStatus("active", "stale")).toBe("stale_pending_review");
+    expect(nextJobStatus("active", "close")).toBe("closed");
+    expect(nextJobStatus("active", "expire")).toBe("closed");
+    expect(nextJobStatus("active", "archive")).toBe("archived");
+    expect(nextJobStatus("stale_pending_review", "reactivate")).toBe("active");
+    expect(nextJobStatus("stale_pending_review", "close")).toBe("closed");
+    expect(nextJobStatus("stale_pending_review", "expire")).toBe("closed");
+    expect(nextJobStatus("stale_pending_review", "archive")).toBe("archived");
+    expect(nextJobStatus("closed", "reactivate")).toBe("active");
+    expect(nextJobStatus("closed", "archive")).toBe("archived");
+    expect(nextJobStatus("active", "revalidate")).toBe("active");
+    expect(nextJobStatus("draft", "revalidate")).toBe("draft");
   });
 
-  it.each(["close", "archive", "expire", "review"] as const)(
-    "persists checkedAt for action %s",
-    async (action) => {
-      // scripts/check-d1-job-sources.mjs sends checkedAt when it closes a job
-      // for a dead source; that timestamp justifies the closure and was
-      // previously dropped for these four actions.
+  it("normalizes unknown/blank status to draft before lookup", () => {
+    expect(nextJobStatus("UNKNOWN", "review")).toBe("pending_review");
+    expect(nextJobStatus("  ACTIVE  ", "stale")).toBe("stale_pending_review");
+    expect(nextJobStatus(null, "stale")).toBeNull();
+    expect(nextJobStatus(undefined, "activate")).toBe("active");
+  });
+
+  it("blocks illegal action/status pairs that were previously unconstrained", () => {
+    expect(nextJobStatus("archived", "activate")).toBeNull();
+    expect(nextJobStatus("closed", "activate")).toBeNull();
+    expect(nextJobStatus("draft", "stale")).toBeNull();
+    expect(nextJobStatus("pending_review", "stale")).toBeNull();
+    expect(nextJobStatus("active", "reactivate")).toBeNull();
+    expect(nextJobStatus("draft", "reactivate")).toBeNull();
+    expect(nextJobStatus("archived", "stale")).toBeNull();
+    expect(nextJobStatus("archived", "reactivate")).toBeNull();
+    expect(nextJobStatus("pending_review", "expire")).toBeNull();
+    expect(nextJobStatus("pending_review", "review")).toBeNull();
+    expect(nextJobStatus("active", "activate")).toBeNull();
+    expect(nextJobStatus("active", "review")).toBeNull();
+  });
+});
+
+describe("updateAdminJobState", () => {
+  it.each([
+    ["draft", "review", "pending_review"],
+    ["pending_review", "activate", "active"],
+    ["active", "close", "closed"],
+    ["active", "archive", "archived"],
+    ["stale_pending_review", "reactivate", "active"],
+    ["active", "expire", "closed"],
+  ] as const)(
+    "maps %s + %s to %s",
+    async (fromStatus, action, expectedStatus) => {
       const db = new FakeD1();
-      db.jobRows = [validActiveJobRow({ slug: `${action}-checked` })];
-      await updateAdminJobState(db, {
-        slug: `${action}-checked`,
-        action,
-        checkedAt: VALID_CHECKED_AT,
-      });
-      const call = db.runCalls.at(-1);
-      expect(call?.query).toContain("source_checked_at = ?");
-      expect(call?.query).toContain("last_checked_at = ?");
-      expect(call?.values).toContain(VALID_CHECKED_AT);
+      db.jobRows = [
+        validActiveJobRow({ slug: `${action}-role`, status: fromStatus }),
+      ];
+      await updateAdminJobState(db, { slug: `${action}-role`, action });
+      expect(db.runCalls.at(-1)?.query).toContain("status = ?");
+      expect(db.runCalls.at(-1)?.values).toContain(expectedStatus);
     },
   );
+
+  it.each([
+    ["active", "close"],
+    ["active", "archive"],
+    ["active", "expire"],
+    ["draft", "review"],
+  ] as const)("persists checkedAt for %s + %s", async (fromStatus, action) => {
+    // scripts/check-d1-job-sources.mjs sends checkedAt when it closes a job
+    // for a dead source; that timestamp justifies the closure and was
+    // previously dropped for these four actions.
+    const db = new FakeD1();
+    db.jobRows = [
+      validActiveJobRow({ slug: `${action}-checked`, status: fromStatus }),
+    ];
+    await updateAdminJobState(db, {
+      slug: `${action}-checked`,
+      action,
+      checkedAt: VALID_CHECKED_AT,
+    });
+    const call = db.runCalls.at(-1);
+    expect(call?.query).toContain("source_checked_at = ?");
+    expect(call?.query).toContain("last_checked_at = ?");
+    expect(call?.values).toContain(VALID_CHECKED_AT);
+  });
 
   it("keeps the stale_check_count reset scoped to activate/reactivate", async () => {
     // Only activate/reactivate mean the source is healthy again, so closing or
     // archiving must not wipe the accumulated stale history.
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "close-history" })];
+    db.jobRows = [
+      validActiveJobRow({ slug: "close-history", status: "active" }),
+    ];
     await updateAdminJobState(db, {
       slug: "close-history",
       action: "close",
@@ -875,7 +944,11 @@ describe("updateAdminJobState", () => {
   it("marks a job stale and increments stale_check_count", async () => {
     const db = new FakeD1();
     db.jobRows = [
-      validActiveJobRow({ slug: "stale-role", stale_check_count: 2 }),
+      validActiveJobRow({
+        slug: "stale-role",
+        status: "active",
+        stale_check_count: 2,
+      }),
     ];
     await updateAdminJobState(db, {
       slug: "stale-role",
@@ -890,7 +963,11 @@ describe("updateAdminJobState", () => {
   it("revalidates source timestamps and clears stale_check_count", async () => {
     const db = new FakeD1();
     db.jobRows = [
-      validActiveJobRow({ slug: "revalidate-role", stale_check_count: 4 }),
+      validActiveJobRow({
+        slug: "revalidate-role",
+        status: "active",
+        stale_check_count: 4,
+      }),
     ];
     await updateAdminJobState(db, {
       slug: "revalidate-role",
@@ -906,7 +983,9 @@ describe("updateAdminJobState", () => {
 
   it("revalidate can explicitly clear expires_at with null", async () => {
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "clear-expiry-role" })];
+    db.jobRows = [
+      validActiveJobRow({ slug: "clear-expiry-role", status: "active" }),
+    ];
     await updateAdminJobState(db, {
       slug: "clear-expiry-role",
       action: "revalidate",
@@ -917,7 +996,7 @@ describe("updateAdminJobState", () => {
 
   it("uses the current timestamp when checkedAt is omitted", async () => {
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "now-role" })];
+    db.jobRows = [validActiveJobRow({ slug: "now-role", status: "active" })];
     await updateAdminJobState(db, { slug: "now-role", action: "stale" });
     const checkedAt = String(db.runCalls.at(-1)?.values[0] ?? "");
     expect(checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
@@ -968,6 +1047,24 @@ describe("updateAdminJobState", () => {
   });
 
   it.each([
+    ["archived", "activate"],
+    ["closed", "activate"],
+    ["draft", "stale"],
+    ["active", "reactivate"],
+  ] as const)(
+    "rejects illegal transition %s + %s",
+    async (fromStatus, action) => {
+      const db = new FakeD1();
+      db.jobRows = [
+        validActiveJobRow({ slug: "illegal-role", status: fromStatus }),
+      ];
+      await expect(
+        updateAdminJobState(db, { slug: "illegal-role", action }),
+      ).rejects.toBeInstanceOf(JobInvalidTransitionError);
+    },
+  );
+
+  it.each([
     ["revalidate"],
     ["stale"],
     ["close"],
@@ -993,7 +1090,9 @@ describe("updateAdminJobState", () => {
 
   it("passes expiresAt through status updates when provided", async () => {
     const db = new FakeD1();
-    db.jobRows = [validActiveJobRow({ slug: "expire-at-role" })];
+    db.jobRows = [
+      validActiveJobRow({ slug: "expire-at-role", status: "active" }),
+    ];
     await updateAdminJobState(db, {
       slug: "expire-at-role",
       action: "close",
@@ -1004,20 +1103,25 @@ describe("updateAdminJobState", () => {
   });
 
   it.each([
-    ["review"],
-    ["activate"],
-    ["close"],
-    ["archive"],
-    ["reactivate"],
-    ["expire"],
-  ])(
-    "includes reactivation reset fields for %s when applicable",
-    async (action) => {
+    ["draft", "review"],
+    ["pending_review", "activate"],
+    ["active", "close"],
+    ["active", "archive"],
+    ["closed", "reactivate"],
+    ["active", "expire"],
+  ] as const)(
+    "includes reactivation reset fields for %s + %s when applicable",
+    async (fromStatus, action) => {
       const db = new FakeD1();
-      db.jobRows = [validActiveJobRow({ slug: `${action}-reset-role` })];
+      db.jobRows = [
+        validActiveJobRow({
+          slug: `${action}-reset-role`,
+          status: fromStatus,
+        }),
+      ];
       await updateAdminJobState(db, {
         slug: `${action}-reset-role`,
-        action: action as "review",
+        action,
         checkedAt: VALID_CHECKED_AT,
       });
       const query = db.runCalls.at(-1)?.query ?? "";
@@ -1038,22 +1142,24 @@ describe("updateAdminJobState", () => {
   });
 
   it.each([
-    ["review", "pending_review"],
-    ["activate", "active"],
-    ["close", "closed"],
-    ["archive", "archived"],
-    ["reactivate", "active"],
-    ["expire", "closed"],
-    ["stale", "stale_pending_review"],
-    ["revalidate", "pending_review"],
+    ["draft", "review"],
+    ["pending_review", "activate"],
+    ["active", "close"],
+    ["active", "archive"],
+    ["stale_pending_review", "reactivate"],
+    ["active", "expire"],
+    ["active", "stale"],
+    ["active", "revalidate"],
   ] as const)(
-    "runs %s without expiresAt override",
-    async (action, _expectedStatus) => {
+    "runs %s + %s without expiresAt override",
+    async (fromStatus, action) => {
       const db = new FakeD1();
-      db.jobRows = [validActiveJobRow({ slug: `${action}-no-expiry` })];
+      db.jobRows = [
+        validActiveJobRow({ slug: `${action}-no-expiry`, status: fromStatus }),
+      ];
       await updateAdminJobState(db, {
         slug: `${action}-no-expiry`,
-        action: action === "stale" || action === "revalidate" ? action : action,
+        action,
         checkedAt: VALID_CHECKED_AT,
       });
       expect(db.runCalls.at(-1)?.values.at(-1)).toBe(`${action}-no-expiry`);
@@ -1325,8 +1431,10 @@ describe("job-admin-lib exports", () => {
     expect(REQUIRED_JOBS_MIGRATION.endsWith(".sql")).toBe(true);
   });
 
-  it("defines publication and not-found error constructors", () => {
+  it("defines publication, not-found, and invalid-transition error constructors", () => {
     expect(typeof JobPublicationQualityError).toBe("function");
     expect(typeof JobNotFoundError).toBe("function");
+    expect(typeof JobInvalidTransitionError).toBe("function");
+    expect(typeof nextJobStatus).toBe("function");
   });
 });


### PR DESCRIPTION
## Summary

- Decision **(a)** for #5270: add an explicit jobs admin transition table (`nextJobStatus`) matching listing-leads' `nextLeadStatus`.
- Illegal action/status pairs now throw `JobInvalidTransitionError`; the admin jobs PATCH route returns `400 invalid_transition`.
- Content-quality gate on `activate`/`reactivate` is unchanged.
- Adds a route-level regression test for the `invalid_transition` 400 path (coverage gap on the prior attempt).

Closes #5270

Supersedes #5524 (closed by screenshot-gate false positive on a non-visual admin API change; this reland embeds the required viewport×theme matrix like merged #5536 / #5398).

## Submission Source

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots included (Desktop/Tablet/Mobile × Light/Dark) — before/after identical (admin JSON API / lib only; no rendered UI delta).
- [x] Links the issue it resolves (#5270).

## Quality Evidence

- Changed routes/endpoints: `PATCH /api/admin/jobs` (`apps/web/src/routes/api/admin/jobs.ts`)
- Changed libs: `apps/web/src/lib/job-admin-lib.ts`, `apps/web/src/lib/job-admin.ts`
- Changed tests: `tests/job-admin-lib.test.ts`, `tests/d1-dynamic-state.test.ts`, `tests/admin-jobs-invalid-transition.test.ts`
- Expected behavior: legal lifecycle transitions persist as before; illegal pairs return `400` with `error.code = "invalid_transition"` and `{ action, currentStatus }` details.
- Important invariants:
  - `activate` first-publishes from `draft`/`pending_review` only (not from `closed`/`archived`)
  - `reactivate` reopens `stale_pending_review`/`closed` only
  - `stale` only from `active`
  - `archived` is terminal
  - `revalidate` never changes status and remains allowed from any known status
  - publication-quality gate on `activate`/`reactivate` unchanged
- Backward compatibility: previously-unconstrained illegal jumps are now rejected (intentional per maintainer decision (a) on #5270).
- **No visual impact.** Admin API / lib-only behavior change — no HTML page, component, or theme rendering is touched.

### Newly blocked (was previously allowed)

| Current status | Action | Notes |
| --- | --- | --- |
| `archived` | `activate`, `reactivate`, `stale`, `close`, `expire`, `review`, `archive` | archived is terminal |
| `closed` | `activate`, `stale`, `review`, `expire`, `close` | use `reactivate` / `archive` |
| `draft` | `stale`, `reactivate`, `close`, `expire` | use `review` / `activate` / `archive` |
| `pending_review` | `stale`, `reactivate`, `expire`, `review` | use `activate` / `close` / `archive` |
| `active` | `activate`, `reactivate`, `review` | use `stale` / `close` / `expire` / `archive` / `revalidate` |
| `stale_pending_review` | `activate`, `stale`, `review` | use `reactivate` / `close` / `expire` / `archive` |

### Still allowed (unchanged intent)

- `draft` → `review` / `activate` / `archive`
- `pending_review` → `activate` / `close` / `archive`
- `active` → `stale` / `close` / `expire` / `archive` / `revalidate`
- `stale_pending_review` → `reactivate` / `close` / `expire` / `archive`
- `closed` → `reactivate` / `archive`
- `revalidate` from any known status (no status change)

### UI Evidence

| Viewport · Theme | Before | After |
| --- | --- | --- |
| Desktop · Light | ![Desktop · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) | ![Desktop · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=light&themeStorageKey=hc-theme) |
| Desktop · Dark | ![Desktop · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) | ![Desktop · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=1440&h=900&theme=dark&themeStorageKey=hc-theme) |
| Tablet · Light | ![Tablet · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) | ![Tablet · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=light&themeStorageKey=hc-theme) |
| Tablet · Dark | ![Tablet · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) | ![Tablet · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=768&h=1024&theme=dark&themeStorageKey=hc-theme) |
| Mobile · Light | ![Mobile · Light before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) | ![Mobile · Light after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=light&themeStorageKey=hc-theme) |
| Mobile · Dark | ![Mobile · Dark before](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) | ![Mobile · Dark after](https://shots.loopover.ai/loopover/shot?url=https%3A%2F%2Fheyclau.de%2F&w=390&h=844&theme=dark&themeStorageKey=hc-theme) |

Before/after identical (admin JSON API + lib lifecycle guard only; no rendered HTML/page/theme delta).

## Validation

- [x] `pnpm exec vitest run tests/job-admin-lib.test.ts tests/d1-dynamic-state.test.ts tests/admin-jobs-invalid-transition.test.ts tests/web-job-admin.test.ts` (286 passed)
- [x] `pnpm exec vitest run tests/api-contracts.test.ts tests/api-contracts-lib.test.ts` (420 passed)
- [x] `pnpm type-check` (clean)
- [x] `pnpm exec prettier --check` on changed files (clean)
- [x] `git diff --check` (clean)
