### PR TITLE
docs(mcp): refresh GoodMemory to 0.7.2

### DIFF
--- a/content/mcp/goodmemory-mcp-server.mdx
+++ b/content/mcp/goodmemory-mcp-server.mdx
@@ -17,10 +17,10 @@ submittedBy: hjqcan
 submittedByUrl: "https://github.com/hjqcan"
 dateAdded: "2026-07-13"
 repoUrl: "https://github.com/hjqcan/GoodMemory"
-documentationUrl: "https://github.com/hjqcan/GoodMemory/blob/main/docs/GoodMemory-Standalone-MCP-Setup-Guide.md"
+documentationUrl: "https://github.com/hjqcan/GoodMemory/blob/v0.7.2/docs/GoodMemory-Standalone-MCP-Setup-Guide.md"
 packageUrl: "https://www.npmjs.com/package/goodmemory"
 installable: true
-installCommand: "npm install -g goodmemory@0.5.1"
+installCommand: "npm install -g goodmemory@0.7.2"
 usageSnippet: >-
   Ask Claude to recall relevant project decisions before a task, inspect the
   returned trace, and enable governed writes only after reviewing the memory
@@ -46,12 +46,13 @@ configSnippet: |-
 estimatedSetupTime: 5 minutes
 difficulty: intermediate
 retrievalSources:
-  - "https://github.com/hjqcan/GoodMemory/blob/main/README.md"
-  - "https://github.com/hjqcan/GoodMemory/blob/main/docs/GoodMemory-Standalone-MCP-Setup-Guide.md"
-  - "https://github.com/hjqcan/GoodMemory/blob/main/.well-known/goodmemory.json"
-  - "https://registry.modelcontextprotocol.io/v0.1/servers/io.github.hjqcan%2Fgoodmemory/versions/latest"
+  - "https://github.com/hjqcan/GoodMemory/blob/v0.7.2/README.md"
+  - "https://github.com/hjqcan/GoodMemory/blob/v0.7.2/docs/GoodMemory-Standalone-MCP-Setup-Guide.md"
+  - "https://github.com/hjqcan/GoodMemory/blob/v0.7.2/.well-known/goodmemory.json"
+  - "https://github.com/hjqcan/GoodMemory/releases/tag/v0.7.2"
+  - "https://www.npmjs.com/package/goodmemory/v/0.7.2"
 prerequisites:
-  - Bun 1.3 or newer on PATH for the packaged MCP command.
+  - Bun 1.3.14 or newer on PATH for the packaged MCP command.
   - Node.js 20 or newer and npm for the global package install.
   - A stable user id to scope recalled and stored memory.
   - A writable local GoodMemory directory, or an explicitly configured PostgreSQL store.
@@ -110,7 +111,7 @@ remember pipeline used by the library API.
 Install the published package globally:
 
 ```sh
-npm install -g goodmemory@0.5.1
+npm install -g goodmemory@0.7.2
 ```
 
 Add the standalone server to an MCP client:
@@ -159,12 +160,12 @@ context: it will be visible to the model provider used by the host.
 
 ## Source Review
 
-- https://github.com/hjqcan/GoodMemory
-- https://github.com/hjqcan/GoodMemory/blob/main/docs/GoodMemory-Standalone-MCP-Setup-Guide.md
-- https://github.com/hjqcan/GoodMemory/blob/main/.well-known/goodmemory.json
-- https://www.npmjs.com/package/goodmemory
-- https://registry.modelcontextprotocol.io/v0.1/servers/io.github.hjqcan%2Fgoodmemory/versions/latest
+- https://github.com/hjqcan/GoodMemory/tree/v0.7.2
+- https://github.com/hjqcan/GoodMemory/blob/v0.7.2/docs/GoodMemory-Standalone-MCP-Setup-Guide.md
+- https://github.com/hjqcan/GoodMemory/blob/v0.7.2/.well-known/goodmemory.json
+- https://github.com/hjqcan/GoodMemory/releases/tag/v0.7.2
+- https://www.npmjs.com/package/goodmemory/v/0.7.2
 
-These sources were reviewed on **2026-07-13**. Prefer the live repository,
-published package metadata, capability descriptor, and official MCP registry
-entry for current versions, commands, storage behavior, and tool exposure.
+These sources were reviewed on **2026-08-03**. Prefer the tagged repository,
+published package metadata, capability descriptor, and release for current
+versions, commands, storage behavior, and tool exposure.


### PR DESCRIPTION
## Summary

- pin the global install and source review to GoodMemory v0.7.2
- require the exact Bun 1.3.14 runtime baseline
- replace moving or stale sources with tagged release and package evidence

## Validation

- `pnpm validate:content:strict`
- `git diff --check`

No visual impact. This changes only the GoodMemory content source entry; generated artifacts were not edited.